### PR TITLE
feat: add Sync to GitCode workflow

### DIFF
--- a/.github/workflows/sync-to-gitcode.yml
+++ b/.github/workflows/sync-to-gitcode.yml
@@ -1,0 +1,32 @@
+name: Sync to GitCode
+
+on:
+
+  push:
+
+    branches: [main]
+
+permissions:
+
+  contents: read
+
+jobs:
+
+  sync:
+
+    runs-on: ubuntu-latest
+
+    steps:
+
+      - uses: actions/checkout@v4
+
+        with:
+
+          fetch-depth: 0
+
+      - run: |
+
+          git remote add gitcode https://oauth2:${{ secrets.GITCODE_TOKEN }}@gitcode.com/huaweicloud/${{ github.event.repository.name }}.git || true
+
+          git push gitcode main --force
+


### PR DESCRIPTION
补上缺失的 GitCode 同步工作流：GitHub main 分支 push 时自动同步到 GitCode 同名仓。