### PR TITLE
fix(huawei-obs): document obsutil Content-Disposition: attachment default and OBS website endpoint limitation

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-obs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-obs/SKILL.md
@@ -39,6 +39,8 @@ Domain expertise for Huawei Cloud Object Storage Service (OBS). Covers bucket/ob
 | **OBS needs separate cred config** | `hcloud configure` is NOT enough for OBS. Before any OBS operation, call `huaweicloud_setup_obs_config` to sync credentials from hcloud profile. |
 | **obsutil interactive prompts** | `cp`/`rm` without `-f` causes "Please input (y/n)" → Agent hangs (TIMEOUT). Always use `-f` for non-interactive. |
 | **Directory upload adds prefix** | `cp <dir>/ obs://<bucket>/ -r` puts files under `bucket/<dir>/...`. Use `-flat` for root-level files (static sites). Preview with `-dryRun` first. |
+| **obsutil defaults Content-Disposition: attachment** | For files without a known MIME type, obsutil automatically adds `Content-Disposition: attachment`, causing browsers to download instead of render. Fix: `hcloud OBS chattri obs://<bucket>/<key> -contentDisposition=inline` or use `-r -f` for bulk. |
+| **OBS website endpoint ignores metadata** | Even when object metadata has `Content-Disposition: inline`, the `obs-website` endpoint ignores it and returns `attachment`. This is a known OBS service-side limitation. Use CDN in front of OBS for production, or serve via the REST endpoint. |
 
 ## OBS Credential Setup (Required Before First Use)
 
@@ -61,6 +63,7 @@ KooCLI OBS uses a separate config file (`~/.obsutilconfig`), NOT `~/.hcloud/conf
 | Delete bucket | `hcloud OBS rm obs://<bucket> -r` (must be empty) |
 | Presigned URL | `hcloud OBS sign obs://<bucket>/<key> -e=<seconds>` |
 | Object metadata | `hcloud OBS stat obs://<bucket>/<key>` |
+| Set Content-Disposition (inline) | `hcloud OBS chattri obs://<bucket>/<key> -contentDisposition=inline` | Bulk: add `-r -f` |
 
 ## Static Website Deployment Workflow
 

--- a/plugins/huaweicloud-core/skills/huawei-obs/references/static-website.md
+++ b/plugins/huaweicloud-core/skills/huawei-obs/references/static-website.md
@@ -6,10 +6,11 @@
 1. Build project     → npm run build / yarn build
 2. Create OBS bucket  → hcloud OBS mb obs://<bucket> -location=<region>
 3. Bulk upload        → hcloud OBS cp <build-dir>/ obs://<bucket>/ -r -f -flat -acl=public-read
-4. Set bucket ACL     → hcloud OBS chattri obs://<bucket> -acl=public-read
-5. Set object ACLs    → hcloud OBS chattri obs://<bucket>/ -r -f -acl=public-read
-6. Configure website  → REST API (KooCLI OBS lacks this feature)
-7. Verify             → curl http://<bucket>.obs-website.<region>.myhuaweicloud.com
+4. Set Content-Disposition → hcloud OBS chattri obs://<bucket>/ -r -f -contentDisposition=inline
+5. Set bucket ACL     → hcloud OBS chattri obs://<bucket> -acl=public-read
+6. Set object ACLs    → hcloud OBS chattri obs://<bucket>/ -r -f -acl=public-read
+7. Configure website  → REST API (KooCLI OBS lacks this feature)
+8. Verify             → curl http://<bucket>.obs-website.<region>.myhuaweicloud.com
 ```
 
 ## Step-by-Step (Vue/Vite Example)
@@ -24,13 +25,16 @@ hcloud OBS mb obs://my-static-site -location=cn-north-4
 # 3. Upload entire build directory (recursive, force, flatten, public ACL)
 hcloud OBS cp dist/ obs://my-static-site/ -r -f -flat -acl=public-read
 
-# 4. Set bucket ACL (required for static website access)
+# 4. Set Content-Disposition to inline (obsutil defaults to attachment for unknown MIME types)
+hcloud OBS chattri obs://my-static-site/ -r -f -contentDisposition=inline
+
+# 5. Set bucket ACL (required for static website access)
 hcloud OBS chattri obs://my-static-site -acl=public-read
 
-# 5. Set object ACLs recursively (objects don't inherit bucket ACL automatically)
+# 6. Set object ACLs recursively (objects don't inherit bucket ACL automatically)
 hcloud OBS chattri obs://my-static-site/ -r -f -acl=public-read
 
-# 5. Configure static website hosting
+# 7. Configure static website hosting
 # KooCLI OBS does NOT support this. Use one of:
 # Option A — REST API:
 #   PUT /?website HTTP/1.1
@@ -40,7 +44,7 @@ hcloud OBS chattri obs://my-static-site/ -r -f -acl=public-read
 # Option B — Huawei Cloud Console:
 #   Console → OBS → Bucket → Basic Settings → Static Website Hosting
 
-# 6. Verify
+# 8. Verify
 curl http://my-static-site.obs-website.cn-north-4.myhuaweicloud.com
 ```
 
@@ -54,3 +58,5 @@ curl http://my-static-site.obs-website.cn-north-4.myhuaweicloud.com
 - **Always use `-f`**: Without `-f`, obsutil prompts "Please input (y/n)" on large uploads — Agent hangs (TIMEOUT).
 - **Use `-flat` for root files**: Without `-flat`, `dist/` becomes `bucket/dist/` prefix. Static sites need files at bucket root.
 - **Objects don't inherit bucket ACL**: Setting bucket to public-read does NOT make individual objects public. You must also set object-level ACL with `chattri obs://<bucket>/ -r -f -acl=public-read` or use `-acl=public-read` during upload.
+- **obsutil defaults Content-Disposition: attachment**: For files without known MIME types (e.g. .js, .css), obsutil automatically adds `Content-Disposition: attachment`, causing browsers to download instead of render. Fix: `chattri obs://<bucket>/ -r -f -contentDisposition=inline`.
+- **OBS website endpoint ignores metadata**: Even after setting `Content-Disposition: inline` on objects, the `obs-website` endpoint may still return `attachment`. This is a known OBS service limitation. For production static sites, use CDN (Huawei Cloud CDN) in front of OBS.


### PR DESCRIPTION
## Summary

Documents two issues discovered during deployment testing (huaweicloud/huaweicloud-devkit#19):

1. **obsutil defaults Content-Disposition: attachment** — For files without known MIME types, obsutil automatically adds `Content-Disposition: attachment`, causing browsers to download files instead of rendering them. Added warning and fix (`chattri -contentDisposition=inline`) to OBS skill.

2. **OBS website endpoint ignores object metadata** — Even when object metadata has `Content-Disposition: inline`, the `obs-website` endpoint ignores it and returns `attachment`. Documented as known OBS service-side limitation with CDN workaround.

## Changes

- **`plugins/huaweicloud-core/skills/huawei-obs/SKILL.md`**: Added 2 new Critical Warnings + 1 new Common Workflow entry for setting Content-Disposition
- **`plugins/huaweicloud-core/skills/huawei-obs/references/static-website.md`**: Added Content-Disposition step to workflow + 2 new Key Gotchas

## Verification

- `npm run validate` — passed (27 skills validated)
- `npm test` — 78/79 passing (1 pre-existing failure: missing `docs/hook-rule-model.md`, unrelated to this change)

Closes #19