### PR TITLE
fix(cli-and-auth, obs): fix --cli-profile syntax and OBS Content-Disposition/docs

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-obs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-obs/SKILL.md
@@ -37,7 +37,7 @@ Domain expertise for Huawei Cloud Object Storage Service (OBS). Covers bucket/ob
 | OBS uses AK/SK directly | NOT IAM tokens. Auth errors mean check AK/SK validity |
 | Static website via CLI missing | KooCLI OBS lacks website config. Use REST API or console |
 | **OBS needs separate cred config** | `hcloud configure` is NOT enough for OBS. Before any OBS operation, call `huaweicloud_setup_obs_config` to sync credentials from hcloud profile. |
-| **obsutil interactive prompts** | `cp`/`rm` without `-f` causes "Please input (y/n)" → Agent hangs (TIMEOUT). Always use `-f` for non-interactive. |
+| **obsutil interactive prompts** | `cp`/`rm`/`chattri` without `-f` causes "Please input (y/n)" → Agent hangs (TIMEOUT). `chattri -r` prompts per-file without `-f`. Always use `-f` for non-interactive. |
 | **Directory upload adds prefix** | `cp <dir>/ obs://<bucket>/ -r` puts files under `bucket/<dir>/...`. Use `-flat` for root-level files (static sites). Preview with `-dryRun` first. |
 
 ## OBS Credential Setup (Required Before First Use)

--- a/plugins/huaweicloud-core/skills/huawei-obs/references/common-pitfalls.md
+++ b/plugins/huaweicloud-core/skills/huawei-obs/references/common-pitfalls.md
@@ -77,6 +77,22 @@ hcloud OBS chattri obs://<bucket> -acl=public-read
 hcloud OBS chattri obs://<bucket>/index.html -acl=public-read
 ```
 
+## Content-Disposition 陷阱
+
+obsutil `cp`/`sync` 默认对无已知 MIME 类型的文件附加 `Content-Disposition: attachment`，导致浏览器触发下载而非渲染（对静态网站影响严重）。
+
+```bash
+# 现象：浏览器下载 .js/.css 文件，而非渲染
+# 根因：obsutil 默认附加 attachment
+
+# 规避方法：上传后设置对象元数据
+hcloud OBS chattri obs://<bucket>/<key> -meta=Content-Disposition:inline -f
+# 批量设置（所有对象）
+hcloud OBS chattri obs://<bucket>/ -r -meta=Content-Disposition:inline -f
+```
+
+> **已知限制**: `obs-website` 端点不读取对象的 Content-Disposition 元数据，即使已设为 `inline` 仍返回 `attachment`。这是 OBS 服务端行为，需联系华为云支持。
+
 ## 桶命名约束
 
 - 全局唯一，所有用户共享命名空间

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -365,7 +365,7 @@ export async function runVersionCheck(options = {}) {
 async function showProfileRedacted(profile) {
   const args = ['configure', 'show'];
   if (profile) {
-    args.push('--cli-profile', String(profile));
+    args.push(`--cli-profile=${String(profile)}`);
   }
   const result = await runHcloud(args, { allowWrites: false, allowCredentialRead: true }).catch((error) => ({
     ok: false,
@@ -396,7 +396,7 @@ async function setupObsConfig(profile) {
   }
 
   const args = ['configure', 'show'];
-  if (profile) args.push('--cli-profile', String(profile));
+  if (profile) args.push(`--cli-profile=${String(profile)}`);
   const result = await runHcloud(args, { allowWrites: false, allowCredentialRead: true });
 
   if (!result.ok) {


### PR DESCRIPTION
## Summary

Fixes 3 actionable bugs from the deployment test report (#19).

### Changes

1. **Bug 9: Fix `--cli-profile` syntax** — Changed space-separated `--cli-profile <value>` to `--cli-profile=<value>` in both `showProfileRedacted` and `setupObsConfig` tools (`tools.mjs`). KooCLI 7.x rejects space-separated parameter forms, causing `[USE_ERROR]参数default的格式错误`.

2. **Bug 10: Add `chattri` to obsutil interactive prompt warning** — The OBS critical warnings table now mentions `chattri` alongside `cp`/`rm` for the `-f` flag requirement. `chattri -r` prompts per-file without `-f`.

3. **Bug 3: Document Content-Disposition pitfall** — Added a new section to OBS common-pitfalls describing that obsutil defaults to `Content-Disposition: attachment` for unknown MIME types, and that `obs-website` endpoint ignores object metadata (OBS service limitation).

### Not addressed (outside devkit repo)

The following bugs are in the deployed application (hc-devkit-portal), not in this repo:
- `characterEncoding=utf8mb4` in `application-mysql.yml`
- `DATEADD` H2 syntax in `V1__init_schema.sql`
- K8s Secret key mismatch in `deployment.yaml`

### Not addressed (feature requests / external)

- **Bug 1 (`setup_obs_config` credential sync)**: The tool correctly syncs plaintext AK/SK from hcloud profile. When hcloud stores encrypted/masked credentials, this is a hcloud CLI limitation.
- **Bug 2 (CCE LoadBalancer errors)**: CCE API behavior — incremental error reporting is upstream.
- **Bug 4 (OBS website endpoint)**: OBS service bug, documented in common-pitfalls.
- **Bug 5 (Missing env detection)**: Feature request — out of scope for this fix.
- **Bug 6 (Flyway SQL incompatibility)**: In hc-devkit-portal, not in devkit.
- **Bug 7 (SWR login expiration)**: Already documented in CCE skill: 'SWR Auth token valid 12h'.
- **Bug 8 (K8s Secret key mismatch)**: In hc-devkit-portal, not in devkit.

### Testing

- `npm test`: 78/79 pass (1 pre-existing failure: missing `docs/hook-rule-model.md`)
- `npm run validate`: Passes

Closes #19