### PR TITLE
fix(huawei-obs, huawei-cce, huaweicloud-core): deployment test report fixes

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-cce/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-cce/SKILL.md
@@ -24,6 +24,8 @@ Domain expertise for CCE (Cloud Container Engine) and SWR (Software Repository f
 | Network model affects pod IP | VPC network gives pods VPC IPs |
 | Addon ops use UID not name | `ShowAddonInstance` returns `metadata.uid` for install/uninstall/update |
 | SWR enterprise instance costs | `postPaid` billing. One-time activation at console required |
+| **SWR auth token expires in 12h** | `CreateAuthorizationToken` returns a 12-hour token. `docker login` failures with "Authenticate Error" after expiry. Before pushing images, re-run `CreateAuthorizationToken` or check `docker login` status first. |
+| **Secret key names must match deployment.yaml** | K8s Secrets (e.g. `MYSQL_PASSWORD`) must use the exact key name referenced in deployment manifests (e.g. `secretKeyRef.name`). Mismatched names + `optional: true` cause silent failures — pods start with empty/missing values. Validate Secret keys against deployment references before `kubectl apply`. |
 
 ## Common Workflows
 
@@ -47,7 +49,12 @@ Domain expertise for CCE (Cloud Container Engine) and SWR (Software Repository f
 
 **Prerequisite**: User/agency must have `sts::createServiceBearerToken` IAM permission. Without it, `CreateAuthorizationToken` returns `SVCSTG.SWR.4030170 Insufficient permissions`. Grant via IAM console or attach SWR Admin role.
 
+Before pushing images, verify Docker login is still valid. The SWR auth token expires after 12 hours. If login fails with "Authenticate Error", re-run `CreateAuthorizationToken` and `docker login` again.
+
 ```bash
+# 0. Check if already logged in (optional skip-if-valid)
+docker login swr.<region>.myhuaweicloud.com --get-login 2>/dev/null || echo 'Login required'
+
 # 1. Docker login to SWR
 hcloud SWR CreateAuthorizationToken --help
 docker login -u <region>@<AK> -p <token> swr.<region>.myhuaweicloud.com
@@ -83,6 +90,7 @@ See `hcloud CCI --help` for full operation list.
 | SVCSTG.SWR.4030170 | Missing `sts::createServiceBearerToken` IAM permission. Grant SWR Admin role or add policy |
 | Addon install fails | Use `metadata.uid` from `ShowAddonInstance`, not name |
 | `kubectl cce` not found | Install plugin: `kubectl cce` uses AK/SK, no kubeconfig required |
+| Pod CrashLoopBackOff with empty env vars | `secretKeyRef` in deployment.yaml uses a key name that does not exist in Secret. Validate all `secretKeyRef.key` against `kubectl get secret <name> -o jsonpath='{.data}'` before `apply`. `optional: true` in secretKeyRef suppresses errors, causing silent failures. |
 
 ## Security Considerations
 

--- a/plugins/huaweicloud-core/skills/huawei-obs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-obs/SKILL.md
@@ -44,6 +44,8 @@ Domain expertise for Huawei Cloud Object Storage Service (OBS). Covers bucket/ob
 
 KooCLI OBS uses a separate config file (`~/.obsutilconfig`), NOT `~/.hcloud/config.json`. Call `huaweicloud_setup_obs_config` to automatically sync credentials from the active hcloud profile. No manual AK/SK entry needed.
 
+> **KooCLI credential masking**: If `hcloud configure show` returns masked/encrypted AK/SK (containing `****`), the automatic sync will fail because hcloud does not expose plaintext credentials. In this case, the agent will receive a `maskedCredential` error. Fallback: ask the user to run `hcloud OBS configure -i` interactively outside agent chat to set OBS credentials, or export `OBS_ACCESS_KEY_ID` and `OBS_SECRET_ACCESS_KEY` environment variables as a one-time workaround.
+
 ## Common Workflows
 
 | Task | Command |

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -365,7 +365,7 @@ export async function runVersionCheck(options = {}) {
 async function showProfileRedacted(profile) {
   const args = ['configure', 'show'];
   if (profile) {
-    args.push('--cli-profile', String(profile));
+    args.push('--cli-profile=' + String(profile));
   }
   const result = await runHcloud(args, { allowWrites: false, allowCredentialRead: true }).catch((error) => ({
     ok: false,
@@ -392,11 +392,16 @@ async function showProfileRedacted(profile) {
 async function setupObsConfig(profile) {
   const obsConfigPath = join(homedir(), '.obsutilconfig');
   if (existsSync(obsConfigPath)) {
-    return { ok: true, existed: true, path: obsConfigPath, note: 'OBS config already exists. Delete ~/.obsutilconfig first if you need to re-sync.' };
+    return {
+      ok: true,
+      existed: true,
+      path: obsConfigPath,
+      note: 'OBS config already exists. If OBS operations fail with auth errors, the existing config may contain expired or invalid credentials. Delete ~/.obsutilconfig and retry, or run "hcloud OBS configure -i" interactively outside agent chat to set fresh credentials.',
+    };
   }
 
   const args = ['configure', 'show'];
-  if (profile) args.push('--cli-profile', String(profile));
+  if (profile) args.push('--cli-profile=' + String(profile));
   const result = await runHcloud(args, { allowWrites: false, allowCredentialRead: true });
 
   if (!result.ok) {
@@ -434,6 +439,16 @@ async function setupObsConfig(profile) {
     };
   }
 
+  if (isMaskedCredential(accessKeyId) || isMaskedCredential(secretAccessKey)) {
+    return {
+      ok: false,
+      error: 'KooCLI hcloud configure show returns masked credentials and cannot extract plaintext AK/SK automatically.',
+      detail: `Detected masked AK/SK (${accessKeyId.substring(0, 8)}...). hcloud stores credentials in encrypted/masked form and hcloud configure show does not expose plaintext values.`,
+      nextStep: 'OBS needs plaintext AK/SK. Run "hcloud OBS configure -i" interactively to set OBS credentials outside agent chat, or the user must manually provide AK/SK for OBS operations.',
+      alternative: 'export OBS_ACCESS_KEY_ID=<AK> OBS_SECRET_ACCESS_KEY=<SK> before running obsutil commands from the agent.',
+    };
+  }
+
   if (!region) {
     return {
       ok: false,
@@ -465,6 +480,10 @@ async function setupObsConfig(profile) {
     endpoint,
     note: 'OBS credentials synced from hcloud profile. OBS commands (hcloud OBS ls, mb, cp, etc.) should now work.',
   };
+}
+
+function isMaskedCredential(value) {
+  return /^\w{3,4}\*{2,}\w{3,4}$/.test(value) || /^\*{3,}$/.test(value) || /\*{5,}/.test(value);
 }
 
 const SERVICE_EXAMPLES = {


### PR DESCRIPTION
## Changes

Based on the deployment test report in [#19](https://github.com/huaweicloud/huaweicloud-devkit/issues/19), this PR addresses the following actionable bugs and improvements:

### Bug Fixes

**Bug 9 (P2): `--cli-profile` parameter format error**
- Fixed `showProfileRedacted` and `setupObsConfig` to use `--cli-profile=<value>` (KooCLI 7.x requires `=`-separated args, not space-separated)
- Before: `args.push('--cli-profile', profile)` → error: `参数default的格式错误,正确格式为:--param=value`
- After: `args.push('--cli-profile=' + profile)`

**Bug 1 (P0): `setupObsConfig` credential masking detection**
- Added `isMaskedCredential()` helper to detect masked AK/SK patterns (e.g. `HPU****WYH`)
- After credential extraction from `hcloud configure show`, checks if values appear masked
- Returns clear error with fallback options: `hcloud OBS configure -i` interactively or env var export
- Improved "already exists" message with stale/expired config guidance

### Skill Guidance Improvements

**Bug 7 (P1): SWR Docker login expiry** (huawei-cce/SKILL.md)
- Added warning that SWR auth token expires in 12h
- Added pre-login check step to SWR image push workflow
- Added troubleshooting entry for "Authenticate Error"

**Bug 8 (P1): K8s Secret key validation** (huawei-cce/SKILL.md)
- Added warning about Secret key names needing to match `secretKeyRef` in deployment manifests
- Added troubleshooting entry for Pod CrashLoopBackOff from `secretKeyRef` mismatches
- Notes that `optional: true` suppresses validation errors, causing silent failures

**Bug 1 context: OBS credential masking** (huawei-obs/SKILL.md)
- Documented KooCLI credential masking limitation in OBS credential setup section
- Listed fallback options: interactive `hcloud OBS configure -i` or environment variable export

### Files Changed
- `plugins/huaweicloud-core/src/tools.mjs`
- `plugins/huaweicloud-core/skills/huawei-cce/SKILL.md`
- `plugins/huaweicloud-core/skills/huawei-obs/SKILL.md`

### Verification
- `npm test`: 78/79 pass (1 pre-existing failure: missing docs/hook-rule-model.md)
- `npm run validate`: Passed