### PR TITLE
fix(huaweicloud-core): adapt doctor restart messages to detected host platform

### DIFF
--- a/docs/hook-rule-model.md
+++ b/docs/hook-rule-model.md
@@ -1,0 +1,47 @@
+# Hook 规则模型
+
+PreToolUse hook 在 agent 工具执行前拦截高风险操作。本文件描述 hook 的规则判断模型与隐私边界。
+
+## 隐私边界
+
+Hook 将以下数据流视为穿过隐私边界的操作，直接拒绝（`permissionDecision: "deny"`）：
+
+1. **读取凭证文件**：任何访问 `.hcloud`、`.huaweicloud`、`hcloud/config`、`huaweicloud/config` 路径的命令。
+2. **导出环境变量**：`env`、`printenv` 等命令中包含 `HUAWEICLOUD`、`HWC_`、`HCLOUD`、`OS_` 前缀的变量。
+3. **直接获取密钥值**：调用 `ShowSecretVersion` 或 `GetSecretValue` 等 API 会把明文密钥泄漏到 agent 上下文。
+
+这些检查在 `hooks/huaweicloud-safety.py` 中以正则表达式实现，策略词汇定义在 `safety/policy.json`。
+
+## 规则判断流程
+
+### 1. 凭证文件拦截
+
+匹配 `CONFIG_FILE_RE` 正则，命中即 deny。
+
+### 2. 环境变量导出拦截
+
+匹配 `ENV_DUMP_RE` 正则，命令中包含环境变量导出工具且目标包含云凭证前缀时 deny。
+
+### 3. 密钥读取拦截
+
+匹配 `SECRET_READ_RE` 正则，调用获取密钥的 API 操作时 deny。
+
+### 4. 云风险规则评估
+
+`cloud-risk-rules.json` 中的 command 阶段 deny 规则按 `all`（全部满足）、`any`（任一满足）、`none`（均不满足）逻辑匹配命令文本，命中即 deny。
+
+### 5. 未授权写操作拦截
+
+当工具为 `Bash` 且命令包含 `hcloud` 及写操作前缀（Create/Delete/Update/Modify/Resize/Reboot/Stop/Start/Restart 等）且无只读操作前缀（List/Show/Get/Describe）时 deny。
+
+## huaweicloud_hook_check_command
+
+`huaweicloud_hook_check_command` 是 MCP 工具层的前置检查接口，允许 agent 在执行命令前主动评估风险。它与 Python hook 共享同一套 `safety/policy.json` 词汇和 `cloud-risk-rules.json` 风险规则，确保非 hook 平台（OpenCode、Codex）也能获得一致的安全判定。
+
+输入待执行的命令文本，返回：
+- `allowed: true` — 命令安全，可以执行
+- `allowed: false` + `reason` + `remediation` — 命令被拦截，附带原因与修复建议
+
+## 规则扩展
+
+新增风险规则只需更新 `safety/rules/cloud-risk-rules.json`，Python hook 和 MCP 工具会同时加载，无需修改代码。

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -636,17 +636,20 @@ async function cmdDoctor() {
   // Node.js
   check('Node.js >= 20', process.versions.node.split('.')[0] >= 20, 'Run: nvm install 20 && nvm use 20');
 
-    // MCP server — check OpenCode and Codex Desktop paths
+    // MCP server — check OpenCode, Codex Desktop, and CodeArts paths
   const opencodePluginDir = opencodePluginsDir();
   const codexPluginDir = codexDesktopPluginsDir();
+  const codeartsPluginDir = codeartsPluginsDir();
   const mcpOk = existsSync(join(opencodePluginDir, 'src', 'mcp-server.mjs'))
-    || existsSync(join(codexPluginDir, 'src', 'mcp-server.mjs'));
-  const mcpTarget = existsSync(join(opencodePluginDir, 'src', 'mcp-server.mjs')) ? 'OpenCode'
-    : existsSync(join(codexPluginDir, 'src', 'mcp-server.mjs')) ? 'Codex Desktop' : '';
+    || existsSync(join(codexPluginDir, 'src', 'mcp-server.mjs'))
+    || existsSync(join(codeartsPluginDir, 'src', 'mcp-server.mjs'));
+  const mcpHostName = existsSync(join(opencodePluginDir, 'src', 'mcp-server.mjs')) ? 'OpenCode'
+    : existsSync(join(codexPluginDir, 'src', 'mcp-server.mjs')) ? 'Codex Desktop'
+    : existsSync(join(codeartsPluginDir, 'src', 'mcp-server.mjs')) ? 'CodeArts' : '';
   check('MCP server installed', mcpOk, 'Run: npx huaweicloud-devkit install');
 
   if (mcpOk) {
-    check(`MCP server can start (${mcpTarget})`, true, '');
+    check(`MCP server can start (${mcpHostName})`, true, '');
   }
 
   const safetyOk = existsSync(join(opencodePluginDir, 'safety', 'policy.json'))
@@ -712,21 +715,24 @@ async function cmdDoctor() {
 
   console.log(`\nResults: ${pass} pass, ${warn} warn, ${fail} fail`);
 
+  const appName = mcpHostName || mcpCfgTarget || 'agent';
   if (mcpConfigured && !hcloudOk) {
-    console.log('\n\x1b[33mMCP is configured but hcloud is not installed. Install hcloud then restart OpenCode.\x1b[0m');
+    console.log(`\n\x1b[33mMCP is configured but hcloud is not installed. Install hcloud then restart ${appName}.\x1b[0m`);
   }
   if (fail > 0) {
-    console.log('\x1b[33mFix failures above, then restart your OpenCode / Codex session.\x1b[0m');
+    console.log(`\n\x1b[33mFix failures above, then restart your ${appName} session.\x1b[0m`);
   }
   if (fail === 0 && mcpConfigured) {
-    console.log('\n\x1b[32mAll checks passed.\x1b[0m Restart OpenCode, then describe your Huawei Cloud task');
+    console.log(`\n\x1b[32mAll checks passed.\x1b[0m Restart ${appName}, then describe your Huawei Cloud task`);
   }
 
   // Detect "installed but not restarted" scenario
   const installedMarker = join(opencodePluginsDir(), '.installed');
   if (mcpConfigured && existsSync(installedMarker)) {
+    const name = mcpHostName || mcpCfgTarget || 'agent';
+    const nameLabel = name === 'OpenCode' ? 'OpenCode' : `${name} 会话`;
     console.log(`\n\x1b[1m\x1b[31m╔══════════════════════════════════════════╗`);
-    console.log(`\x1b[1m\x1b[31m║  请重启 OpenCode！MCP 工具尚未激活       ║`);
+    console.log(`\x1b[1m\x1b[31m║  请重启 ${nameLabel}！MCP 工具尚未激活     ║`);
     console.log(`\x1b[1m\x1b[31m║  关闭当前会话 → 重新打开即可             ║`);
     console.log(`\x1b[1m\x1b[31m╚══════════════════════════════════════════╝\x1b[0m`);
   }


### PR DESCRIPTION
## Summary

The `doctor` command hardcoded "OpenCode" in all restart messages, which was confusing for users who installed for Codex Desktop or CodeArts. This PR adapts the messages to use the actually detected host platform.

## Changes

### 1. `setup-cli.mjs` — Adaptive doctor messages
- **Added CodeArts to MCP server detection** — the doctor now checks `~/.codeartsdoer/huaweicloud-plugins/src/mcp-server.mjs` in addition to OpenCode and Codex Desktop paths
- **Renamed `mcpTarget` → `mcpHostName`** for clarity
- **Adaptive restart messages** — the "restart OpenCode" hints now use the detected platform name (OpenCode / Codex Desktop / CodeArts / agent fallback)
- **Adaptive "请重启" box** — the Chinese restart prompt now says "请重启 {平台}" instead of always "请重启 OpenCode"

### Before
```
MCP is configured but hcloud is not installed. Install hcloud then restart OpenCode.
...
║  请重启 OpenCode！MCP 工具尚未激活
```

### After (CodeArts example)
```
MCP is configured but hcloud is not installed. Install hcloud then restart CodeArts.
...
║  请重启 CodeArts 会话！MCP 工具尚未激活
```

### 2. `docs/hook-rule-model.md` — New documentation
Required by `test/structure.test.mjs` but was missing. Documents the PreToolUse hook rule model, privacy boundary, and `huaweicloud_hook_check_command` interface.

## Test Results
```
79 tests pass, 0 fail
npm run validate: Validated with 27 skills
```

## Related
- Fixes #25