### PR TITLE
feat(huawei-obs): add single-file quick share workflow

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-obs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-obs/SKILL.md
@@ -79,6 +79,13 @@ Build → Create bucket → Upload → Set bucket ACL → Set object ACL → Con
 
 > KooCLI OBS does NOT support `SetBucketWebsite`. Configure static website hosting via REST API (`PUT /?website`) or the Huawei Cloud console.
 
+## Single-File Quick Share
+
+See `references/single-file-share.md` for the full workflow to host one file and get a shareable link in seconds:
+
+- **Private, time-limited**: `hcloud OBS sign obs://<bucket>/<key> -e=<seconds>` (max 7 days)
+- **Public, permanent**: `hcloud OBS cp <file> obs://<bucket>/<key> -f` + `hcloud OBS chattri obs://<bucket>/<key> -acl=public-read`, then share `https://<bucket>.obs.<region>.myhuaweicloud.com/<key>`
+
 ## Storage Classes
 
 | Class | Use Case | Min Storage | Retrieval Fee |
@@ -115,5 +122,6 @@ Build → Create bucket → Upload → Set bucket ACL → Set object ACL → Con
 
 - OBS Docs: https://support.huaweicloud.com/obs/
 - Static website: references/static-website.md
+- Single-file share: references/single-file-share.md
 - Lifecycle: references/bucket-lifecycle.md
 - Replication: references/replication.md

--- a/plugins/huaweicloud-core/skills/huawei-obs/references/single-file-share.md
+++ b/plugins/huaweicloud-core/skills/huawei-obs/references/single-file-share.md
@@ -1,0 +1,40 @@
+# OBS Single-File Quick Share
+
+Host one file and get a shareable link in seconds. Two options:
+
+| Option | Link type | Bucket/object visibility | Expiry |
+|--------|-----------|--------------------------|--------|
+| Presigned URL | Time-limited private link | Keep private | `-e=<seconds>`, max 7 days |
+| Public URL | Permanent public link | Set object `-acl=public-read` | None |
+
+## Option 1: Presigned URL (private, time-limited)
+
+No ACL change needed. The object stays private; the link grants temporary access.
+
+```bash
+hcloud OBS cp <file> obs://<bucket>/<key> -f
+hcloud OBS sign obs://<bucket>/<key> -e=3600   # valid 1 hour, max 604800 (7 days)
+```
+
+The `sign` command prints the full presigned URL directly — share it as-is.
+
+## Option 2: Public URL (permanent, public-read)
+
+```bash
+hcloud OBS cp <file> obs://<bucket>/<key> -f
+hcloud OBS chattri obs://<bucket>/<key> -acl=public-read
+```
+
+The shareable public URL follows the OBS endpoint format (NOT the `obs-website` static-site endpoint):
+
+```
+https://<bucket>.obs.<region>.myhuaweicloud.com/<key>
+```
+
+## Key Gotchas
+
+- **Bucket ACL does NOT cascade**: `chattri obs://<bucket> -acl=public-read` alone does not make objects public. Set the object-level ACL explicitly.
+- **`-f` is mandatory**: `cp` without `-f` prompts "Please input (y/n)" on overwrite → agent hangs (TIMEOUT).
+- **Public-read means anyone with the link can access**: use presigned URLs when the file is sensitive.
+- **Presigned URL max expiry is 7 days** (`-e=604800`). For longer-lived public access, use the public-read option.
+- **Credential setup**: OBS uses a separate config (`~/.obsutilconfig`). Call `huaweicloud_setup_obs_config` before first use.


### PR DESCRIPTION
## Summary

Adds a documented "single-file quick share" workflow to the `huawei-obs` skill, addressing the feature request to host a single file and get a shareable link in seconds.

## What changed

- New reference `plugins/huaweicloud-core/skills/huawei-obs/references/single-file-share.md` documenting two options:
  - **Private, time-limited**: presigned URL via `hcloud OBS sign` (max 7 days)
  - **Public, permanent**: upload + `-acl=public-read` then share `https://<bucket>.obs.<region>.myhuaweicloud.com/<key>`
- `SKILL.md`: added a "Single-File Quick Share" section and a References entry pointing to the new reference.

## Notes

- No new code; reuses existing KooCLI OBS primitives (`cp`, `chattri`, `sign`) already documented in the skill.
- Gotchas re-documented: `-f` to avoid interactive hangs, object ACL does not cascade from bucket ACL, presigned max 7 days, public-read exposes the object.

## Verification

- `npm test` — 79 pass
- `npm run validate` — pass
- `npm run lint:md` — 0 issues

Closes #32