### PR TITLE
feat: unify Huawei Cloud auth across agents

### DIFF
--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -1,0 +1,87 @@
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+import { spawnSync } from 'node:child_process';
+
+export const SUPPORTED_AGENT_TARGETS = ['opencode', 'codex', 'codex-desktop', 'codearts', 'workbuddy'];
+
+function baseHome() {
+  return process.env.HUAWEICLOUD_HOME || homedir();
+}
+
+function opencodeConfigFile() {
+  const jsonc = join(baseHome(), '.config', 'opencode', 'opencode.jsonc');
+  if (existsSync(jsonc)) return jsonc;
+  return join(baseHome(), '.config', 'opencode', 'opencode.json');
+}
+
+function readJsonSafe(path) {
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+function opencodeRegistered() {
+  const path = opencodeConfigFile();
+  const cfg = readJsonSafe(path);
+  return Boolean(cfg?.mcp?.['huaweicloud-devkit']);
+}
+
+function codexDesktopRegistered() {
+  const path = join(baseHome(), '.codex', 'config.toml');
+  if (!existsSync(path)) return false;
+  try {
+    return readFileSync(path, 'utf8').includes('[mcp_servers.huaweicloud-devkit]');
+  } catch {
+    return false;
+  }
+}
+
+function codexCliRegistered() {
+  try {
+    const r = spawnSync('codex', ['plugin', 'list'], {
+      shell: false,
+      windowsHide: true,
+      stdio: 'pipe',
+      timeout: 10000,
+    });
+    const out = `${r.stdout || ''}${r.stderr || ''}`;
+    return out.includes('huaweicloud-core');
+  } catch {
+    return false;
+  }
+}
+
+function codeartsRegistered() {
+  const paths = [
+    join(baseHome(), '.codeartsdoer', 'mcp', 'mcp_settings.json'),
+    join(process.cwd(), '.codeartsdoer', 'mcp', 'mcp_settings.json'),
+  ];
+  return paths.some((path) => {
+    const cfg = readJsonSafe(path);
+    return Boolean(cfg?.mcpServers?.['huaweicloud-devkit']);
+  });
+}
+
+function workbuddyRegistered() {
+  const cfg = readJsonSafe(join(baseHome(), '.workbuddy', 'mcp.json'));
+  return Boolean(cfg?.mcpServers?.['huaweicloud-devkit']);
+}
+
+export function getAgentRegistrationStatuses(target = 'all') {
+  const requested = target === 'all' ? SUPPORTED_AGENT_TARGETS : [target];
+  const result = { target, agents: {} };
+  for (const agent of requested) {
+    let configured = false;
+    if (agent === 'opencode') configured = opencodeRegistered();
+    if (agent === 'codex-desktop') configured = codexDesktopRegistered();
+    if (agent === 'codex') configured = codexCliRegistered();
+    if (agent === 'codearts') configured = codeartsRegistered();
+    if (agent === 'workbuddy') configured = workbuddyRegistered();
+    result.agents[agent] = { configured };
+  }
+  return result;
+}

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -1,0 +1,74 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { homedir } from 'node:os';
+
+function baseHome() {
+  return process.env.HUAWEICLOUD_HOME || homedir();
+}
+
+export function globalCredentialsPath() {
+  return join(baseHome(), '.config', 'huaweicloud', 'credentials.json');
+}
+
+export function obsConfigPath() {
+  return join(baseHome(), '.obsutilconfig');
+}
+
+export function readGlobalCredentials() {
+  const path = globalCredentialsPath();
+  if (!existsSync(path)) return null;
+  try {
+    return JSON.parse(readFileSync(path, 'utf8'));
+  } catch {
+    return null;
+  }
+}
+
+export function writeGlobalCredentials(credentials = {}) {
+  const path = globalCredentialsPath();
+  mkdirSync(dirname(path), { recursive: true });
+  const payload = {
+    ak: String(credentials.ak || ''),
+    sk: String(credentials.sk || ''),
+    securityToken: String(credentials.securityToken || ''),
+    region: String(credentials.region || ''),
+  };
+  writeFileSync(path, JSON.stringify(payload, null, 2), { encoding: 'utf8', mode: 0o600 });
+  return path;
+}
+
+export function writeObsConfig(credentials = {}) {
+  const region = String(credentials.region || '');
+  const ak = String(credentials.ak || '');
+  const sk = String(credentials.sk || '');
+  if (!region || !ak || !sk) {
+    throw new Error('region, ak, and sk are required to write OBS config');
+  }
+  const path = obsConfigPath();
+  const endpoint = credentials.endpoint || `https://obs.${region}.myhuaweicloud.com`;
+  const content = `[default]\r\nendpoint=${endpoint}\r\nak=${ak}\r\nsk=${sk}\r\n`;
+  writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
+  return { path, endpoint };
+}
+
+export function resolveCredentials(options = {}) {
+  let ak = process.env.HW_ACCESS_KEY;
+  let sk = process.env.HW_SECRET_KEY;
+  let securityToken = process.env.HW_SECURITY_TOKEN;
+  let region = process.env.HW_REGION || process.env.HUAWEICLOUD_REGION || '';
+
+  const stored = readGlobalCredentials();
+  if (stored) {
+    if (!ak && stored.ak) ak = stored.ak;
+    if (!sk && stored.sk) sk = stored.sk;
+    if (!securityToken && stored.securityToken) securityToken = stored.securityToken;
+    if (!region && stored.region) region = stored.region;
+  }
+
+  if (!ak || !sk) {
+    if (options.allowMissing) return null;
+    throw new Error('Huawei Cloud credentials are not configured. Run "npx huaweicloud-devkit auth init" or set HW_ACCESS_KEY/HW_SECRET_KEY.');
+  }
+
+  return { ak, sk, securityToken, region };
+}

--- a/plugins/huaweicloud-core/src/auth/service.mjs
+++ b/plugins/huaweicloud-core/src/auth/service.mjs
@@ -1,0 +1,63 @@
+import { existsSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { getAgentRegistrationStatuses } from './agent-registration.mjs';
+import { globalCredentialsPath, obsConfigPath, readGlobalCredentials, writeObsConfig } from './credentials.mjs';
+
+function hcloudInstalled() {
+  const bin = process.env.HCLOUD_BIN || 'hcloud';
+  try {
+    const r = spawnSync(`"${bin}" version`, [], {
+      shell: true,
+      windowsHide: true,
+      stdio: 'pipe',
+      timeout: 5000,
+    });
+    const out = `${r.stdout || ''}${r.stderr || ''}`;
+    return r.status === 0 && /KooCLI|Current.*version|当前KooCLI/i.test(out);
+  } catch {
+    return false;
+  }
+}
+
+export function getAuthStatus(target = 'all') {
+  const credentials = readGlobalCredentials();
+  return {
+    target,
+    credentialsConfigured: Boolean(credentials?.ak && credentials?.sk),
+    credentialsPath: globalCredentialsPath(),
+    obsConfigured: existsSync(obsConfigPath()),
+    obsConfigPath: obsConfigPath(),
+    kooCliInstalled: hcloudInstalled(),
+    agents: getAgentRegistrationStatuses(target).agents,
+  };
+}
+
+export function syncAuth(target = 'all') {
+  const credentials = readGlobalCredentials();
+  if (!credentials?.ak || !credentials?.sk) {
+    return {
+      ok: false,
+      error: 'Global credentials are not configured.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" first.',
+    };
+  }
+
+  let obs = null;
+  try {
+    obs = writeObsConfig(credentials);
+  } catch (error) {
+    return {
+      ok: false,
+      error: error.message,
+      nextStep: 'Run "npx huaweicloud-devkit auth init" to refresh credentials and region.',
+    };
+  }
+
+  return {
+    ok: true,
+    obs: { configured: true, path: obs.path, endpoint: obs.endpoint },
+    credentialsConfigured: true,
+    agents: getAgentRegistrationStatuses(target).agents,
+    note: 'OBS credentials were synced from the global credential vault. Agent MCP registration is managed by "npx huaweicloud-devkit install --target <agent>".',
+  };
+}

--- a/plugins/huaweicloud-core/src/sandbox/hwlink-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hwlink-api.mjs
@@ -1,7 +1,5 @@
 import crypto from 'node:crypto';
-import { readFileSync, existsSync } from 'node:fs';
-import { join } from 'node:path';
-import { homedir } from 'node:os';
+import { resolveCredentials } from '../auth/credentials.mjs';
 
 const BASE_URL = process.env.HWLINK_ENDPOINT || 'https://devstation.myhuaweicloud.com';
 
@@ -89,27 +87,8 @@ function signRequest(method, path, query, body, ak, sk, securitytoken) {
 }
 
 export function getCredentials() {
-  let ak = process.env.HW_ACCESS_KEY;
-  let sk = process.env.HW_SECRET_KEY;
-  let securitytoken = process.env.HW_SECURITY_TOKEN;
-
-  if (!ak || !sk) {
-    try {
-      const cfgPath = join(homedir(), '.config', 'opencode', 'opencode.json');
-      if (existsSync(cfgPath)) {
-        const cfg = JSON.parse(readFileSync(cfgPath, 'utf8'));
-        const mcpEnv = cfg?.mcp?.['huaweicloud-devkit']?.env || {};
-        if (!ak && mcpEnv.HW_ACCESS_KEY) ak = mcpEnv.HW_ACCESS_KEY;
-        if (!sk && mcpEnv.HW_SECRET_KEY) sk = mcpEnv.HW_SECRET_KEY;
-        if (!securitytoken && mcpEnv.HW_SECURITY_TOKEN) securitytoken = mcpEnv.HW_SECURITY_TOKEN;
-      }
-    } catch {}
-  }
-
-  if (!ak || !sk) {
-    throw new Error('HW_ACCESS_KEY and HW_SECRET_KEY environment variables are required');
-  }
-  return { ak, sk, securitytoken };
+  const credentials = resolveCredentials();
+  return { ak: credentials.ak, sk: credentials.sk, securitytoken: credentials.securityToken };
 }
 
 async function apiGet(path, query, ak, sk, securitytoken) {

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -6,6 +6,8 @@ import { fileURLToPath } from 'node:url';
 import { homedir, platform } from 'node:os';
 import { createInterface } from 'node:readline';
 import { spawnSync } from 'node:child_process';
+import { getAuthStatus, syncAuth } from './auth/service.mjs';
+import { globalCredentialsPath, readGlobalCredentials, writeGlobalCredentials, writeObsConfig } from './auth/credentials.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const PLUGIN_ROOT = resolve(__dirname, '..');
@@ -1042,6 +1044,175 @@ async function cmdInstallHcloud() {
   console.log('\nThen run: npx huaweicloud-devkit doctor');
 }
 
+function readLineQuestion(prompt) {
+  return new Promise((resolve) => {
+    const rl = createInterface({ input: process.stdin, output: process.stdout });
+    rl.question(prompt, (answer) => {
+      rl.close();
+      resolve(answer.trim());
+    });
+  });
+}
+
+async function readSecret(prompt) {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    return readLineQuestion(prompt);
+  }
+
+  process.stdout.write(prompt);
+  const wasRaw = process.stdin.isRaw;
+  process.stdin.setRawMode(true);
+  process.stdin.resume();
+
+  return new Promise((resolve) => {
+    let value = '';
+    const onData = (chunk) => {
+      for (const ch of chunk.toString('utf8')) {
+        if (ch === '\r' || ch === '\n') {
+          cleanup();
+          resolve(value.trim());
+          return;
+        }
+        if (ch === '\u0003') {
+          cleanup();
+          process.exit(130);
+        }
+        if (ch === '\b' || ch === '\u007f') {
+          value = value.slice(0, -1);
+          continue;
+        }
+        value += ch;
+      }
+    };
+    const cleanup = () => {
+      process.stdin.setRawMode(wasRaw);
+      process.stdin.pause();
+      process.stdin.off('data', onData);
+      process.stdout.write('\n');
+    };
+    process.stdin.on('data', onData);
+  });
+}
+
+function configureHcloud(credentials) {
+  const hcloudBin = findHcloudBin() || (process.env.HCLOUD_BIN || 'hcloud');
+  const args = [
+    'configure',
+    'set',
+    `--cli-access-key=${credentials.ak}`,
+    `--cli-secret-key=${credentials.sk}`,
+    `--cli-region=${credentials.region || ''}`,
+  ];
+  const r = spawnSync(hcloudBin, args, {
+    shell: false,
+    windowsHide: true,
+    stdio: 'pipe',
+    timeout: 30000,
+  });
+  return {
+    ok: r.status === 0,
+    code: r.status,
+    error: String(r.stderr || '').trim().slice(0, 240),
+  };
+}
+
+function printAuthAgents(agents = {}) {
+  for (const [agent, info] of Object.entries(agents)) {
+    console.log(`  ${agent}: ${info.configured ? '[OK]' : '[MISSING]'}`);
+  }
+}
+
+function printAuthStatus(status) {
+  console.log(`Credentials vault: ${status.credentialsConfigured ? 'configured' : 'missing'} (${status.credentialsPath})`);
+  console.log(`OBS config: ${status.obsConfigured ? 'configured' : 'missing'} (${status.obsConfigPath})`);
+  console.log(`KooCLI: ${status.kooCliInstalled ? 'installed' : 'missing'}`);
+  console.log('Agent MCP registration:');
+  printAuthAgents(status.agents);
+}
+
+async function cmdAuthInit() {
+  console.log(BANNER);
+  console.log('HuaweiCloud DevKit Unified Authentication Setup\n');
+
+  let ak = process.env.HW_ACCESS_KEY || '';
+  let sk = process.env.HW_SECRET_KEY || '';
+  let securityToken = process.env.HW_SECURITY_TOKEN || '';
+  let region = process.env.HW_REGION || process.env.HUAWEICLOUD_REGION || '';
+
+  if (!ak) ak = await readSecret('Access Key ID (AK): ');
+  if (!sk) sk = await readSecret('Secret Access Key (SK): ');
+  if (!securityToken) securityToken = await readLineQuestion('Security Token (optional, press Enter to skip): ');
+  if (!region) region = await readLineQuestion('Region (e.g. cn-north-4): ');
+
+  if (!ak || !sk) {
+    console.error('\nAK and SK are required.');
+    process.exitCode = 1;
+    return;
+  }
+  if (!region) {
+    console.error('\nRegion is required to generate the OBS endpoint.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const vaultPath = writeGlobalCredentials({ ak, sk, securityToken, region });
+  console.log(`\nCredentials stored: ${vaultPath}`);
+
+  try {
+    const obs = writeObsConfig({ ak, sk, securityToken, region });
+    console.log(`OBS config synced: ${obs.path} (${obs.endpoint})`);
+  } catch (error) {
+    console.log(`OBS config sync failed: ${error.message}`);
+  }
+
+  if (findHcloudBin()) {
+    const result = configureHcloud({ ak, sk, region });
+    console.log(result.ok ? 'KooCLI profile updated.' : `KooCLI update failed: ${result.error || result.code}`);
+  } else {
+    console.log('KooCLI not found. Run "npx huaweicloud-devkit install-hcloud" and then "auth sync".');
+  }
+
+  console.log('\nNext steps:');
+  console.log('  npx huaweicloud-devkit install --target all');
+  console.log('  Restart your agent sessions.');
+}
+
+async function cmdAuthSync() {
+  const target = parseTarget();
+  console.log(BANNER);
+  console.log('Synchronizing Huawei Cloud authentication...\n');
+
+  const credentials = readGlobalCredentials();
+  if (!credentials?.ak || !credentials?.sk) {
+    console.error('No global credentials found. Run "npx huaweicloud-devkit auth init" first.');
+    process.exitCode = 1;
+    return;
+  }
+
+  const result = syncAuth(target);
+  if (result.ok) {
+    console.log(`OBS config synced: ${result.obs.path} (${result.obs.endpoint})`);
+  } else {
+    console.error(result.error);
+  }
+  console.log('Agent MCP registration:');
+  printAuthAgents(result.agents);
+}
+
+async function cmdAuthStatus() {
+  const target = parseTarget();
+  console.log(BANNER);
+  console.log('HuaweiCloud DevKit Authentication Status\n');
+  printAuthStatus(getAuthStatus(target));
+}
+
+async function cmdAuth() {
+  const sub = (process.argv[3] || 'status').toLowerCase();
+  if (sub === 'init' || sub === 'setup') return cmdAuthInit();
+  if (sub === 'sync' || sub === 'refresh') return cmdAuthSync();
+  return cmdAuthStatus();
+}
+
 async function main() {
   const cmd = process.argv[2] || 'help';
 
@@ -1072,6 +1243,9 @@ async function main() {
     case 'install-hcloud':
       await cmdInstallHcloud();
       break;
+    case 'auth':
+      await cmdAuth();
+      break;
     case 'help':
     case '--help':
     case '-h':
@@ -1086,6 +1260,7 @@ async function main() {
       console.log('  status       Show installation status');
       console.log('  doctor       Self-check: hcloud, MCP, skills, auth');
       console.log('  install-hcloud  Show KooCLI install commands for your OS');
+      console.log('  auth         Manage unified auth: init | sync | status');
       console.log('  help         Show this help');
       console.log('\nOptions:');
       console.log('  --target     Target agent: opencode (default), codex, codearts, workbuddy, all');
@@ -1095,6 +1270,9 @@ async function main() {
       console.log('  npx huaweicloud-devkit install --target codearts');
       console.log('  npx huaweicloud-devkit install --target workbuddy');
       console.log('  npx huaweicloud-devkit install --target all');
+      console.log('  npx huaweicloud-devkit auth init');
+      console.log('  npx huaweicloud-devkit auth sync --target all');
+      console.log('  npx huaweicloud-devkit auth status --target all');
       break;
   }
 }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -8,6 +8,8 @@ import { homedir } from 'node:os';
 import { searchMarketplace } from './search-market.mjs';
 import { execOneShot, execWithSession, closeSession, DEFAULT_WORKSPACE_ID } from './sandbox/session-manager.mjs';
 import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials, hdkitRelease } from './sandbox/hdkitservice-api.mjs';
+import { getAuthStatus, syncAuth } from './auth/service.mjs';
+import { readGlobalCredentials, writeObsConfig as writeObsConfigFile } from './auth/credentials.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILLS_ROOT_DEV = join(__dirname, '..', 'skills');
@@ -288,6 +290,26 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'huaweicloud_auth_status',
+    description: 'Check unified Huawei Cloud authentication status across the global credential vault, OBS, KooCLI, and all supported agent MCP registrations. Returns only redacted/status information, never credentials.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        target: { type: 'string', description: 'Agent target to check: opencode, codex, codex-desktop, codearts, workbuddy, or all (default).' },
+      },
+    },
+  },
+  {
+    name: 'huaweicloud_auth_sync',
+    description: 'Synchronize credentials from the global Huawei Cloud credential vault to OBS and report agent registration status. Does not write secrets into any agent config.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        target: { type: 'string', description: 'Agent target to report after sync: opencode, codex, codex-desktop, codearts, workbuddy, or all (default).' },
+      },
+    },
+  },
+  {
     name: 'huaweicloud_sandbox_exec',
     description: 'Execute a command on a Huawei Cloud workspace terminal via hwlink (one-shot, no session reuse). Each call creates a new connection. Shell state does NOT persist across calls.',
     inputSchema: {
@@ -432,6 +454,10 @@ export async function callTool(name, args = {}) {
       return searchMarketplace(args.query || '', args.category || '');
     case 'huaweicloud_setup_obs_config':
       return setupObsConfig(args.profile);
+    case 'huaweicloud_auth_status':
+      return getAuthStatus(args.target || 'all');
+    case 'huaweicloud_auth_sync':
+      return syncAuth(args.target || 'all');
     case 'huaweicloud_sandbox_exec': {
       const sandboxWsId1 = args.workspace_id || DEFAULT_WORKSPACE_ID;
       const sandboxUser1 = args.username || 'root';
@@ -529,6 +555,33 @@ async function showProfileRedacted(profile) {
 }
 
 async function setupObsConfig(profile) {
+  const stored = readGlobalCredentials();
+  if (stored?.ak && stored?.sk) {
+    try {
+      const obs = writeObsConfigFile(stored);
+      return {
+        ok: true,
+        existed: false,
+        created: true,
+        path: obs.path,
+        region: stored.region,
+        endpoint: obs.endpoint,
+        source: 'global-credentials',
+        note: 'OBS credentials synced from the global credential vault. OBS commands (hcloud OBS ls, mb, cp, etc.) should now work.',
+      };
+    } catch (error) {
+      return {
+        ok: false,
+        error: error.message,
+        nextStep: 'Run "npx huaweicloud-devkit auth init" to refresh credentials and region.',
+      };
+    }
+  }
+
+  return setupObsConfigFromHcloud(profile);
+}
+
+async function setupObsConfigFromHcloud(profile) {
   const obsConfigPath = join(homedir(), '.obsutilconfig');
   if (existsSync(obsConfigPath)) {
     return { ok: true, existed: true, path: obsConfigPath, note: 'OBS config already exists. Delete ~/.obsutilconfig first if you need to re-sync.' };

--- a/test/auth-credentials.test.mjs
+++ b/test/auth-credentials.test.mjs
@@ -1,0 +1,126 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+import {
+  globalCredentialsPath,
+  obsConfigPath,
+  readGlobalCredentials,
+  resolveCredentials,
+  writeGlobalCredentials,
+  writeObsConfig,
+} from '../plugins/huaweicloud-core/src/auth/credentials.mjs';
+import { getAgentRegistrationStatuses } from '../plugins/huaweicloud-core/src/auth/agent-registration.mjs';
+import { getAuthStatus, syncAuth } from '../plugins/huaweicloud-core/src/auth/service.mjs';
+
+function withTempHome(fn) {
+  const dir = mkdtempSync(join(tmpdir(), 'huaweicloud-auth-'));
+  const previous = {
+    HUAWEICLOUD_HOME: process.env.HUAWEICLOUD_HOME,
+    HW_ACCESS_KEY: process.env.HW_ACCESS_KEY,
+    HW_SECRET_KEY: process.env.HW_SECRET_KEY,
+    HW_SECURITY_TOKEN: process.env.HW_SECURITY_TOKEN,
+    HW_REGION: process.env.HW_REGION,
+    HUAWEICLOUD_REGION: process.env.HUAWEICLOUD_REGION,
+  };
+  process.env.HUAWEICLOUD_HOME = dir;
+  delete process.env.HW_ACCESS_KEY;
+  delete process.env.HW_SECRET_KEY;
+  delete process.env.HW_SECURITY_TOKEN;
+  delete process.env.HW_REGION;
+  delete process.env.HUAWEICLOUD_REGION;
+  try {
+    return fn(dir);
+  } finally {
+    for (const [key, value] of Object.entries(previous)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test('global credentials round-trip with secure file path', () => {
+  withTempHome((home) => {
+    const path = writeGlobalCredentials({ ak: 'AK123', sk: 'SK456', region: 'cn-north-4' });
+    assert.equal(path, globalCredentialsPath());
+    assert.equal(readGlobalCredentials().ak, 'AK123');
+    assert.equal(readGlobalCredentials().sk, 'SK456');
+    assert.equal(readGlobalCredentials().region, 'cn-north-4');
+    assert.ok(globalCredentialsPath().startsWith(home));
+  });
+});
+
+test('resolveCredentials prefers environment and falls back to vault', () => {
+  withTempHome((home) => {
+    writeGlobalCredentials({ ak: 'VAULT_AK', sk: 'VAULT_SK', region: 'cn-north-4' });
+    const fromVault = resolveCredentials();
+    assert.equal(fromVault.ak, 'VAULT_AK');
+    assert.equal(fromVault.sk, 'VAULT_SK');
+    assert.equal(fromVault.region, 'cn-north-4');
+
+    process.env.HW_ACCESS_KEY = 'ENV_AK';
+    process.env.HW_SECRET_KEY = 'ENV_SK';
+    const fromEnv = resolveCredentials();
+    assert.equal(fromEnv.ak, 'ENV_AK');
+    assert.equal(fromEnv.sk, 'ENV_SK');
+    delete process.env.HW_ACCESS_KEY;
+    delete process.env.HW_SECRET_KEY;
+
+    rmSync(globalCredentialsPath(), { force: true });
+    assert.throws(() => resolveCredentials({}), /auth init/);
+    assert.ok(!home.includes('\0'));
+  });
+});
+
+test('writeObsConfig creates obsutilconfig content from vault', () => {
+  withTempHome(() => {
+    const result = writeObsConfig({ ak: 'OBS_AK', sk: 'OBS_SK', region: 'cn-north-4' });
+    assert.equal(result.endpoint, 'https://obs.cn-north-4.myhuaweicloud.com');
+    const content = readFileSync(obsConfigPath(), 'utf8');
+    assert.match(content, /ak=OBS_AK/);
+    assert.match(content, /sk=OBS_SK/);
+    assert.match(content, /endpoint=https:\/\/obs\.cn-north-4\.myhuaweicloud\.com/);
+  });
+});
+
+test('auth sync writes OBS and reports all agent registration targets', () => {
+  withTempHome(() => {
+    writeGlobalCredentials({ ak: 'SYNC_AK', sk: 'SYNC_SK', region: 'cn-north-4' });
+    const sync = syncAuth('all');
+    assert.equal(sync.ok, true);
+    assert.equal(sync.obs.configured, true);
+    assert.ok(sync.agents.opencode !== undefined);
+    assert.ok(sync.agents.codex !== undefined);
+    assert.ok(sync.agents['codex-desktop'] !== undefined);
+    assert.ok(sync.agents.codearts !== undefined);
+    assert.ok(sync.agents.workbuddy !== undefined);
+  });
+});
+
+test('agent registration detects OpenCode MCP config', () => {
+  withTempHome((home) => {
+    const cfgDir = join(home, '.config', 'opencode');
+    mkdirSync(cfgDir, { recursive: true });
+    writeFileSync(
+      join(cfgDir, 'opencode.jsonc'),
+      JSON.stringify({ mcp: { 'huaweicloud-devkit': { enabled: true } } }),
+      'utf8',
+    );
+    const status = getAgentRegistrationStatuses('opencode');
+    assert.equal(status.agents.opencode.configured, true);
+  });
+});
+
+test('auth status is redacted and reflects vault/OBS state', () => {
+  withTempHome(() => {
+    writeGlobalCredentials({ ak: 'STATUS_AK', sk: 'STATUS_SK', region: 'cn-north-4' });
+    writeObsConfig({ ak: 'STATUS_AK', sk: 'STATUS_SK', region: 'cn-north-4' });
+    const status = getAuthStatus('all');
+    assert.equal(status.credentialsConfigured, true);
+    assert.equal(status.obsConfigured, true);
+    assert.ok(status.agents.opencode !== undefined);
+    assert.doesNotMatch(JSON.stringify(status), /STATUS_AK|STATUS_SK/);
+  });
+});

--- a/test/huaweicloud-cleanup/SKILL.md
+++ b/test/huaweicloud-cleanup/SKILL.md
@@ -34,7 +34,7 @@ Remove-Item -Force $env:USERPROFILE\.config\opencode\commands\huaweicloud* -Erro
 
 ## Step 4: Remove MCP Config
 
-Remove `mcp.huaweicloud` entry from both:
+Remove `mcp.huaweicloud-devkit` entry from both:
 - `~\.config\opencode\opencode.json`
 - `~\.config\opencode\opencode.jsonc` (if exists)
 
@@ -43,8 +43,8 @@ $files = @("$env:USERPROFILE\.config\opencode\opencode.json", "$env:USERPROFILE\
 foreach ($f in $files) {
   if (Test-Path $f) {
     $c = Get-Content $f -Raw | ConvertFrom-Json
-    if ($c.mcp.PSObject.Properties.Name -contains 'huaweicloud') {
-      $c.mcp.PSObject.Properties.Remove('huaweicloud')
+    if ($c.mcp.PSObject.Properties.Name -contains 'huaweicloud-devkit') {
+      $c.mcp.PSObject.Properties.Remove('huaweicloud-devkit')
       if ($c.mcp.PSObject.Properties.Count -eq 0) { $c.PSObject.Properties.Remove('mcp') }
       $c | ConvertTo-Json -Depth 5 | Set-Content $f -Encoding UTF8
     }

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -91,6 +91,8 @@ test('MCP server initializes, lists tools, and plans CLI commands', async () => 
     assert.ok(toolNames.includes('huaweicloud_list_operations'));
     assert.ok(toolNames.includes('huaweicloud_run_approved_command'));
     assert.ok(toolNames.includes('huaweicloud_show_profile_redacted'));
+    assert.ok(toolNames.includes('huaweicloud_auth_status'));
+    assert.ok(toolNames.includes('huaweicloud_auth_sync'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_exec'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_check_user'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_connect'));

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -55,6 +55,8 @@ test('TOOL_DEFINITIONS includes all required tools including sandbox', () => {
     'huaweicloud_get_regional_availability',
     'huaweicloud_search_marketplace',
     'huaweicloud_setup_obs_config',
+    'huaweicloud_auth_status',
+    'huaweicloud_auth_sync',
     'huaweicloud_sandbox_exec',
     'huaweicloud_sandbox_exec_with_session',
     'huaweicloud_sandbox_close_session',
@@ -67,7 +69,7 @@ test('TOOL_DEFINITIONS includes all required tools including sandbox', () => {
   for (const name of required) {
     assert.ok(names.includes(name), `Missing tool: ${name}`);
   }
-  assert.ok(names.length >= 22);
+  assert.ok(names.length >= 24);
   assert.ok(names.includes('huaweicloud_search_marketplace'), 'Should have marketplace search tool');
 });
 


### PR DESCRIPTION
## Summary
- Add a global Huawei Cloud credential vault instead of writing credentials into OpenCode config.
- Add \huaweicloud_auth_status\ and \huaweicloud_auth_sync\ MCP tools.
- Add \huaweicloud-devkit auth init|sync|status\ CLI commands covering OpenCode, Codex, Codex Desktop, CodeArts, and WorkBuddy.
- Refactor sandbox credential resolution to use the global vault.
- Sync OBS config from the global vault.
- Add tests for credential storage, OBS sync, agent registration, and MCP tools.

## Tests
- \
pm test\ passes (85 tests)
- \
pm run validate\ passes (28 skills)