### PR TITLE
docs: update prerequisites for unified auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ Help AI coding agents use Huawei Cloud safely and accurately — a single integr
 
 Supports OpenCode, Codex, CodeArts Agent, and WorkBuddy.
 
+## Prerequisites
+
+- Node.js >= 22
+
 ## Quick Start
 
 ### OpenCode
@@ -51,7 +55,7 @@ npx --yes huaweicloud-devkit uninstall --target codearts
 
 > **Sandbox mode**: CodeArts defaults to sandbox mode which blocks KooCLI. `install-hcloud` detects this and shows how to resolve it — install KooCLI outside the sandbox terminal, or disable sandbox mode in CodeArts settings (Settings → Permissions → Bash mode).
 >
-> **Authentication**: Run `hcloud configure init` to configure AK/SK and region.
+> **Authentication**: Run `npx huaweicloud-devkit auth init` to configure unified AK/SK credentials for KooCLI, OBS, and sandbox APIs.
 
 ### WorkBuddy
 
@@ -83,7 +87,7 @@ Then install:
 npx --yes huaweicloud-devkit install
 ```
 
-> **Prerequisites:** [KooCLI](https://support.huaweicloud.com/qs-hcli/hcli_02_003.html) (`hcloud`) installed and authenticated. Node.js >= 20 required.
+> **Prerequisite:** Node.js >= 22. Run `npx huaweicloud-devkit auth init` for unified credentials.
 
 ## What It Does
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,6 +9,10 @@
 
 支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy。
 
+## 前置条件
+
+- Node.js >= 22
+
 ## 快速开始
 
 ### OpenCode
@@ -51,7 +55,7 @@ npx --yes huaweicloud-devkit uninstall --target codearts
 
 > **沙箱模式**：码道默认沙箱模式会阻止 KooCLI 运行。`install-hcloud` 自动检测并给出指引——请在码道外终端安装使用 KooCLI，或在码道设置中关闭沙箱模式（设置 → 权限 → Bash 模式）。
 >
-> **认证**：执行 `hcloud configure init` 配置 AK/SK 与区域。
+> **认证**：执行 `npx huaweicloud-devkit auth init`，统一配置 KooCLI、OBS 和沙箱接口所需的 AK/SK。
 
 ### WorkBuddy
 
@@ -83,7 +87,7 @@ npx --yes huaweicloud-devkit install --target workbuddy
 npx --yes huaweicloud-devkit install
 ```
 
-> **前置条件：** 需要安装 [KooCLI](https://support.huaweicloud.com/qs-hcli/hcli_02_003.html)（`hcloud`）并完成认证。Node.js >= 20。
+> **前置条件：** Node.js >= 22。执行 `npx huaweicloud-devkit auth init` 完成统一认证。
 
 ## 功能特性
 


### PR DESCRIPTION
## Summary
- Update README prerequisites to Node.js >= 22.
- Remove KooCLI authentication from the prerequisite list.
- Point authentication steps to \
px huaweicloud-devkit auth init\ for unified credentials.