### PR TITLE
feat: incremental per-agent update + dev publish manifest version sync + hdkit endpoint

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -36,6 +36,9 @@ jobs:
           npm version prerelease --preid=dev --no-git-tag-version
           echo "dev version: $(node -p "require('./package.json').version")"
 
+      - name: Sync plugin manifest versions
+        run: node ./scripts/sync-version.mjs
+
       - name: Publish to npm (dist-tag next)
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
@@ -48,6 +51,7 @@ jobs:
             fi
             echo "${VERSION} exists or publish failed, bumping prerelease..."
             npm version prerelease --preid=dev --no-git-tag-version
+            node ./scripts/sync-version.mjs
           done
           echo "Failed to publish after 20 attempts"
           cat /tmp/puberr

--- a/README.md
+++ b/README.md
@@ -38,6 +38,15 @@ npx --yes huaweicloud-devkit install --target codex
 
 > The Codex CLI must be installed first.
 
+```bash
+npx --yes huaweicloud-devkit doctor                        # self-check
+npx --yes huaweicloud-devkit status --target codex
+npx --yes huaweicloud-devkit update --target codex         # update
+npx --yes huaweicloud-devkit uninstall --target codex
+```
+
+> **Codex Desktop** (Windows): use `--target codex-desktop` with the same commands.
+
 ### CodeArts Agent
 
 ```bash
@@ -50,6 +59,7 @@ npx --yes huaweicloud-devkit install --target codearts
 npx --yes huaweicloud-devkit install-hcloud   # install KooCLI
 npx --yes huaweicloud-devkit doctor           # self-check
 npx --yes huaweicloud-devkit status --target codearts
+npx --yes huaweicloud-devkit update --target codearts
 npx --yes huaweicloud-devkit uninstall --target codearts
 ```
 
@@ -64,6 +74,15 @@ npx --yes huaweicloud-devkit install --target workbuddy
 ```
 
 **Restart the session** after installation.
+
+```bash
+npx --yes huaweicloud-devkit doctor
+npx --yes huaweicloud-devkit status --target workbuddy
+npx --yes huaweicloud-devkit update --target workbuddy   # update
+npx --yes huaweicloud-devkit uninstall --target workbuddy
+```
+
+> **Updating**: `update` is incremental per agent — it refreshes only the installed files and leaves your config untouched. Use `update --target all` to update every installed agent at once.
 
 ### Other Agents
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -38,6 +38,15 @@ npx --yes huaweicloud-devkit install --target codex
 
 > 需要先安装 Codex CLI。
 
+```bash
+npx --yes huaweicloud-devkit doctor                        # 自检
+npx --yes huaweicloud-devkit status --target codex
+npx --yes huaweicloud-devkit update --target codex         # 更新
+npx --yes huaweicloud-devkit uninstall --target codex
+```
+
+> **Codex Desktop**（Windows）：将 `--target codex` 换成 `--target codex-desktop`，命令相同。
+
 ### CodeArts Agent（码道）
 
 ```bash
@@ -50,6 +59,7 @@ npx --yes huaweicloud-devkit install --target codearts
 npx --yes huaweicloud-devkit install-hcloud   # 安装 KooCLI
 npx --yes huaweicloud-devkit doctor           # 自检
 npx --yes huaweicloud-devkit status --target codearts
+npx --yes huaweicloud-devkit update --target codearts
 npx --yes huaweicloud-devkit uninstall --target codearts
 ```
 
@@ -64,6 +74,15 @@ npx --yes huaweicloud-devkit install --target workbuddy
 ```
 
 安装后**重启会话**。
+
+```bash
+npx --yes huaweicloud-devkit doctor
+npx --yes huaweicloud-devkit status --target workbuddy
+npx --yes huaweicloud-devkit update --target workbuddy   # 更新
+npx --yes huaweicloud-devkit uninstall --target workbuddy
+```
+
+> **更新机制**：`update` 按 agent 增量更新，只刷新必要文件、不动你的配置文件。`update --target all` 可一次更新所有已安装的 agent。
 
 ### 其他 Agent
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -33,7 +33,6 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 
 | Tool | Purpose |
 |------|---------|
-| `huaweicloud_sandbox_exec` | One-shot command execution (no session reuse) |
 | `huaweicloud_sandbox_exec_with_session` | Session-based execution (state persists) |
 | `huaweicloud_sandbox_close_session` | Close a persistent terminal session |
 
@@ -43,7 +42,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 2. **Sign agreement** (if needed): `huaweicloud_sandbox_sign_agreement` — when `agreement_signed=false`
 3. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
 4. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
-5. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work, `huaweicloud_sandbox_exec` for one-shot
+5. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
 6. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
 
 ## Critical Warnings
@@ -52,7 +51,6 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 |------|-----|
 | Agreement required first | `sandbox_connect` fails if user hasn't signed agreements; run `sandbox_check_user` first |
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
-| No session reuse in `exec` | Each `exec` call creates a new connection; previous state is lost |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |
 | Node.js >= 22 required | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket) |

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -2,7 +2,7 @@ import { getCredentials } from './hwlink-api.mjs';
 
 const HDKIT_BASE_URL =
   process.env.HDKITSERVICE_ENDPOINT ||
-  'http://113.44.143.91:3002/rest/developer/server/hdkitservice/';
+  'https://devkit.huaweicloud.com/rest/developer/server/hdkitservice/';
 
 async function hdkitRequest(method, path, body, timeoutMs = 300000) {
   const { ak, sk, securitytoken } = getCredentials();

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -129,11 +129,21 @@ function removeIfExists(p) {
 
 function updateOpenCodeConfig(pluginDir) {
   const configPath = opencodeConfigFile();
+  const mcpPath = join(pluginDir, 'src', 'mcp-server.mjs').replace(/\\/g, '/');
   let config = {};
   if (existsSync(configPath)) {
-    try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch {}
+    try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch {
+      console.log(`  \x1b[33m[WARN]\x1b[0m Could not parse ${configPath} (jsonc comments?). Skipping MCP config write; ensure "mcp.huaweicloud-devkit" points to ${mcpPath}.`);
+      return;
+    }
+    const existing = config.mcp?.['huaweicloud-devkit'];
+    if (existing && existing.type === 'local'
+        && Array.isArray(existing.command) && existing.command[0] === 'node'
+        && existing.command[1] === mcpPath) {
+      console.log(`  OpenCode MCP config unchanged: ${configPath}`);
+      return;
+    }
   }
-  const mcpPath = join(pluginDir, 'src', 'mcp-server.mjs').replace(/\\/g, '/');
   config.mcp = config.mcp || {};
   config.mcp['huaweicloud-devkit'] = {
     type: 'local',
@@ -298,6 +308,101 @@ function uninstallOpenCode() {
   removeOpenCodeConfig();
 }
 
+// Remove huawei* entries in targetDir that no longer exist in sourceDir (stale files from an older version).
+function pruneStale(targetDir, sourceDir) {
+  if (!existsSync(targetDir) || !existsSync(sourceDir)) return 0;
+  const sourceNames = new Set(readdirSync(sourceDir));
+  let removed = 0;
+  for (const entry of readdirSync(targetDir, { withFileTypes: true })) {
+    if (!entry.name.startsWith('huawei')) continue;
+    if (!sourceNames.has(entry.name)) {
+      removeIfExists(join(targetDir, entry.name));
+      removed++;
+    }
+  }
+  return removed;
+}
+
+// Incremental update: overwrite copied files, prune stale ones, and only touch the config when necessary.
+async function updateOpenCode() {
+  const skillsSrc = join(PLUGIN_ROOT, 'skills');
+  const commandsSrc = join(PACKAGE_ROOT, 'integrations', 'opencode', 'commands');
+  const srcDir = join(PLUGIN_ROOT, 'src');
+  const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginDest = opencodePluginsDir();
+
+  copyDir(skillsSrc, opencodeSkillsDir());
+  const staleSkills = pruneStale(opencodeSkillsDir(), skillsSrc);
+  console.log(`  Skills updated -> ${opencodeSkillsDir()}${staleSkills > 0 ? ` (removed ${staleSkills} stale)` : ''}`);
+  copyDir(commandsSrc, opencodeCommandsDir());
+  const staleCommands = pruneStale(opencodeCommandsDir(), commandsSrc);
+  console.log(`  Commands updated -> ${opencodeCommandsDir()}${staleCommands > 0 ? ` (removed ${staleCommands} stale)` : ''}`);
+  copyDir(srcDir, join(pluginDest, 'src'));
+  console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
+  copyDir(safetyDir, join(pluginDest, 'safety'));
+  console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
+  updateOpenCodeConfig(pluginDest);
+  mkdirSync(pluginDest, { recursive: true });
+  writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
+}
+
+function codexMcpServerPath() {
+  return join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
+}
+
+function codexConfigSectionText(mcpPath) {
+  return [
+    '[mcp_servers.huaweicloud-devkit]',
+    'command = "node"',
+    `args = ["${mcpPath}"]`,
+    '',
+    '[mcp_servers.huaweicloud-devkit.env]',
+    'HUAWEICLOUD_AGENT_TOOLKIT_MODE = "local"',
+    '',
+  ].join('\n');
+}
+
+// Returns true when the config file was written, false when it was already correct.
+function ensureCodexConfigSection(mcpPath) {
+  const configPath = codexConfigToml();
+  let existing = '';
+  if (existsSync(configPath)) {
+    try { existing = readFileSync(configPath, 'utf8'); } catch {}
+    if (existing.includes('[mcp_servers.huaweicloud-devkit]')) {
+      if (existing.includes(`args = ["${mcpPath}"]`)) {
+        console.log(`  Config unchanged: ${configPath}`);
+        return false;
+      }
+      removeCodexConfigSection();
+      existing = '';
+      if (existsSync(configPath)) {
+        try { existing = readFileSync(configPath, 'utf8'); } catch {}
+      }
+    }
+  }
+  mkdirSync(dirname(configPath), { recursive: true });
+  if (existing && !existing.endsWith('\n')) existing += '\n';
+  writeFileSync(configPath, existing + codexConfigSectionText(mcpPath));
+  console.log(`  Config updated: ${configPath}`);
+  return true;
+}
+
+function removeCodexConfigSection() {
+  const configPath = codexConfigToml();
+  if (!existsSync(configPath)) return;
+  const lines = readFileSync(configPath, 'utf8').split(/\r?\n/);
+  const out = [];
+  let skip = false;
+  for (const line of lines) {
+    if (/^\[mcp_servers\.huaweicloud-devkit(\]|\.)/.test(line)) { skip = true; continue; }
+    if (skip && line.startsWith('[')) skip = false;
+    if (!skip) out.push(line);
+  }
+  while (out.length > 0 && out[out.length - 1].trim() === '') out.pop();
+  writeFileSync(configPath, out.join('\n') + (out.length > 0 ? '\n' : ''));
+  console.log('  Config cleaned');
+}
+
 async function installCodexDesktop() {
   const skillsSrc = join(PLUGIN_ROOT, 'skills');
   const commandsSrc = join(PACKAGE_ROOT, 'integrations', 'opencode', 'commands');
@@ -315,7 +420,7 @@ async function installCodexDesktop() {
   console.log(`  Safety Policy -> ${join(codexDesktopPluginsDir(), 'safety')}`);
 
   // Generate .mcp.json with absolute paths for Codex Desktop MCP server discovery
-  const mcpServerAbsPath = join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
+  const mcpServerAbsPath = codexMcpServerPath();
   const mcpConfig = {
     mcpServers: {
       'huaweicloud-devkit': {
@@ -335,29 +440,50 @@ async function installCodexDesktop() {
     console.log(`  Plugin Manifest -> ${join(codexDesktopPluginsDir(), '.codex-plugin')}`);
   }
 
-  const mcpPath = join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
-  const configPath = codexConfigToml();
-  const section = [
-    '[mcp_servers.huaweicloud-devkit]',
-    'command = "node"',
-    `args = ["${mcpPath}"]`,
-    '',
-    '[mcp_servers.huaweicloud-devkit.env]',
-    'HUAWEICLOUD_AGENT_TOOLKIT_MODE = "local"',
-    '',
-  ].join('\n');
-  let existing = '';
-  if (existsSync(configPath)) {
-    try { existing = readFileSync(configPath, 'utf8'); } catch {}
-    if (existing.includes('[mcp_servers.huaweicloud-devkit]')) {
-      console.log(`  Config already configured: ${configPath}`);
-      return;
-    }
+  ensureCodexConfigSection(mcpServerAbsPath);
+}
+
+// Incremental update: overwrite copied files, prune stale ones, and only touch the config when necessary.
+async function updateCodexDesktop() {
+  const skillsSrc = join(PLUGIN_ROOT, 'skills');
+  const commandsSrc = join(PACKAGE_ROOT, 'integrations', 'opencode', 'commands');
+  const srcDir = join(PLUGIN_ROOT, 'src');
+  const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginDest = codexDesktopPluginsDir();
+
+  copyDir(skillsSrc, codexDesktopSkillsDir());
+  const staleSkills = pruneStale(codexDesktopSkillsDir(), skillsSrc);
+  console.log(`  Skills updated -> ${codexDesktopSkillsDir()}${staleSkills > 0 ? ` (removed ${staleSkills} stale)` : ''}`);
+  copyDir(commandsSrc, codexDesktopCommandsDir());
+  const staleCommands = pruneStale(codexDesktopCommandsDir(), commandsSrc);
+  console.log(`  Commands updated -> ${codexDesktopCommandsDir()}${staleCommands > 0 ? ` (removed ${staleCommands} stale)` : ''}`);
+  mkdirSync(pluginDest, { recursive: true });
+  copyDir(srcDir, join(pluginDest, 'src'));
+  console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
+  copyDir(safetyDir, join(pluginDest, 'safety'));
+  console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
+
+  const mcpServerAbsPath = codexMcpServerPath();
+  const mcpConfig = {
+    mcpServers: {
+      'huaweicloud-devkit': {
+        command: 'node',
+        args: [mcpServerAbsPath],
+        env: { HUAWEICLOUD_AGENT_TOOLKIT_MODE: 'local' },
+      },
+    },
+  };
+  writeFileSync(join(pluginDest, '.mcp.json'), JSON.stringify(mcpConfig, null, 2));
+  console.log(`  MCP Config updated -> ${join(pluginDest, '.mcp.json')}`);
+
+  const codexPluginSrc = join(PLUGIN_ROOT, '.codex-plugin');
+  if (existsSync(codexPluginSrc)) {
+    copyDir(codexPluginSrc, join(pluginDest, '.codex-plugin'));
+    console.log(`  Plugin Manifest updated -> ${join(pluginDest, '.codex-plugin')}`);
   }
-  mkdirSync(dirname(configPath), { recursive: true });
-  if (existing && !existing.endsWith('\n')) existing += '\n';
-  writeFileSync(configPath, existing + section);
-  console.log(`  Config updated: ${configPath}`);
+
+  ensureCodexConfigSection(mcpServerAbsPath);
+  writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
 }
 
 function uninstallCodexDesktop() {
@@ -388,32 +514,28 @@ function uninstallCodexDesktop() {
   if (removeIfExists(codexDesktopPluginsDir())) {
     console.log('  Removed MCP server and safety policy');
   }
-  const configPath = codexConfigToml();
-  if (existsSync(configPath)) {
-    const lines = readFileSync(configPath, 'utf8').split(/\r?\n/);
-    const out = [];
-    let skip = false;
-    for (const line of lines) {
-      if (/^\[mcp_servers\.huaweicloud-devkit(\]|\.)/.test(line)) { skip = true; continue; }
-      if (skip && line.startsWith('[')) skip = false;
-      if (!skip) out.push(line);
-    }
-    while (out.length > 0 && out[out.length - 1].trim() === '') out.pop();
-    writeFileSync(configPath, out.join('\n') + (out.length > 0 ? '\n' : ''));
-    console.log('  Config cleaned');
-  }
+  removeCodexConfigSection();
 }
 
 function registerCodeartsMcp(configPath) {
   const mcpPath = join(codeartsPluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
-  let config = {};
-  if (existsSync(configPath)) {
-    try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch {}
-  }
-  config.mcpServers = config.mcpServers || {};
   const env = { HUAWEICLOUD_AGENT_TOOLKIT_MODE: 'local' };
   const hcloudBin = findHcloudBin();
   if (hcloudBin) env.HCLOUD_BIN = hcloudBin.replace(/\\/g, '/');
+  let config = {};
+  if (existsSync(configPath)) {
+    try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch {
+      console.log(`  \x1b[33m[WARN]\x1b[0m Could not parse ${configPath}. Skipping MCP config write; ensure "mcpServers.huaweicloud-devkit" points to ${mcpPath}.`);
+      return;
+    }
+    const existing = config.mcpServers?.['huaweicloud-devkit'];
+    if (existing && existing.command === 'node'
+        && Array.isArray(existing.args) && existing.args[0] === mcpPath) {
+      console.log(`  MCP config unchanged: ${configPath}`);
+      return;
+    }
+  }
+  config.mcpServers = config.mcpServers || {};
   config.mcpServers['huaweicloud-devkit'] = {
     command: 'node',
     args: [mcpPath],
@@ -443,6 +565,28 @@ async function installCodeArts() {
 
   registerCodeartsMcp(codeartsMcpSettingsFile());
   registerCodeartsMcp(codeartsProjectMcpSettingsFile());
+}
+
+// Incremental update: overwrite copied files, prune stale ones, and only touch the config when necessary.
+async function updateCodeArts() {
+  const skillsSrc = join(PLUGIN_ROOT, 'skills');
+  const srcDir = join(PLUGIN_ROOT, 'src');
+  const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginDest = codeartsPluginsDir();
+
+  for (const dir of [codeartsSkillsDir(), codeartsProjectSkillsDir()]) {
+    copyDir(skillsSrc, dir);
+    const stale = pruneStale(dir, skillsSrc);
+    console.log(`  Skills updated -> ${dir}${stale > 0 ? ` (removed ${stale} stale)` : ''}`);
+  }
+  copyDir(srcDir, join(pluginDest, 'src'));
+  console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
+  copyDir(safetyDir, join(pluginDest, 'safety'));
+  console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
+  registerCodeartsMcp(codeartsMcpSettingsFile());
+  registerCodeartsMcp(codeartsProjectMcpSettingsFile());
+  mkdirSync(pluginDest, { recursive: true });
+  writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
 }
 
 function uninstallCodeArts() {
@@ -494,6 +638,38 @@ function codeartsStatus() {
   }
 }
 
+// Returns true when the config file was written, false when it was already correct.
+function ensureWorkbuddyMcpConfig() {
+  const configPath = workbuddyMcpConfigFile();
+  const mcpPath = join(workbuddyPluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
+  const env = { HUAWEICLOUD_AGENT_TOOLKIT_MODE: 'local' };
+  const hcloudBin = findHcloudBin();
+  if (hcloudBin) env.HCLOUD_BIN = hcloudBin.replace(/\\/g, '/');
+  let config = {};
+  if (existsSync(configPath)) {
+    try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch {
+      console.log(`  \x1b[33m[WARN]\x1b[0m Could not parse ${configPath}. Skipping MCP config write; ensure "mcpServers.huaweicloud-devkit" points to ${mcpPath}.`);
+      return false;
+    }
+    const existing = config.mcpServers?.['huaweicloud-devkit'];
+    if (existing && existing.command === 'node'
+        && Array.isArray(existing.args) && existing.args[0] === mcpPath) {
+      console.log(`  MCP config unchanged: ${configPath}`);
+      return false;
+    }
+  }
+  config.mcpServers = config.mcpServers || {};
+  config.mcpServers['huaweicloud-devkit'] = {
+    command: 'node',
+    args: [mcpPath],
+    env,
+  };
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2));
+  console.log(`  MCP config updated: ${configPath}`);
+  return true;
+}
+
 async function installWorkBuddy() {
   const skillsSrc = join(PLUGIN_ROOT, 'skills');
   const srcDir = join(PLUGIN_ROOT, 'src');
@@ -508,25 +684,26 @@ async function installWorkBuddy() {
   copyDir(safetyDir, join(pluginDest, 'safety'));
   console.log(`  Safety Policy -> ${join(pluginDest, 'safety')}`);
 
-  // Write MCP config to ~/.workbuddy/mcp.json
-  const mcpPath = join(pluginDest, 'src', 'mcp-server.mjs').replace(/\\/g, '/');
-  const configPath = workbuddyMcpConfigFile();
-  let config = {};
-  if (existsSync(configPath)) {
-    try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch {}
-  }
-  const env = { HUAWEICLOUD_AGENT_TOOLKIT_MODE: 'local' };
-  const hcloudBin = findHcloudBin();
-  if (hcloudBin) env.HCLOUD_BIN = hcloudBin.replace(/\\/g, '/');
-  config.mcpServers = config.mcpServers || {};
-  config.mcpServers['huaweicloud-devkit'] = {
-    command: 'node',
-    args: [mcpPath],
-    env,
-  };
-  mkdirSync(dirname(configPath), { recursive: true });
-  writeFileSync(configPath, JSON.stringify(config, null, 2));
-  console.log(`  MCP config updated: ${configPath}`);
+  ensureWorkbuddyMcpConfig();
+}
+
+// Incremental update: overwrite copied files, prune stale ones, and only touch the config when necessary.
+async function updateWorkBuddy() {
+  const skillsSrc = join(PLUGIN_ROOT, 'skills');
+  const srcDir = join(PLUGIN_ROOT, 'src');
+  const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginDest = workbuddyPluginsDir();
+
+  copyDir(skillsSrc, workbuddySkillsDir());
+  const stale = pruneStale(workbuddySkillsDir(), skillsSrc);
+  console.log(`  Skills updated -> ${workbuddySkillsDir()}${stale > 0 ? ` (removed ${stale} stale)` : ''}`);
+  copyDir(srcDir, join(pluginDest, 'src'));
+  console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
+  copyDir(safetyDir, join(pluginDest, 'safety'));
+  console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
+  ensureWorkbuddyMcpConfig();
+  mkdirSync(pluginDest, { recursive: true });
+  writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
 }
 
 function uninstallWorkBuddy() {
@@ -905,13 +1082,105 @@ async function cmdUpdate() {
   console.log(BANNER);
   const target = parseTarget();
 
-  if (target === 'opencode' || target === 'all') {
-    if (!existsSync(join(opencodePluginsDir(), 'src', 'mcp-server.mjs'))
-        && !existsSync(join(workbuddyPluginsDir(), 'src', 'mcp-server.mjs'))
-        && !codexStatus()) {
+  if (target === 'opencode') {
+    if (!existsSync(join(opencodePluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
       return;
     }
+    console.log('[OpenCode]');
+    await updateOpenCode();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mMCP 工具在重启 OpenCode 会话后才生效。\x1b[0m`);
+    return;
+  }
+
+  if (target === 'codex-desktop') {
+    if (!existsSync(join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
+      return;
+    }
+    console.log('[Codex Desktop]');
+    await updateCodexDesktop();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mMCP 工具在重启 Codex Desktop 会话后才生效。\x1b[0m`);
+    return;
+  }
+
+  if (target === 'codex') {
+    if (!hasCodexCLI()) {
+      console.log(`  \x1b[31mCodex CLI not found.\x1b[0m`);
+      if (process.platform === 'win32') {
+        console.log(`  \x1b[33mTip: use --target codex-desktop for Codex Desktop on Windows\x1b[0m`);
+      }
+      console.log(`  \x1b[31mInstall Codex CLI: https://github.com/openai/codex-cli\x1b[0m`);
+      process.exitCode = 1;
+      return;
+    }
+    console.log('[Codex]');
+    installCodex();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mRestart the Codex session for changes to take effect.\x1b[0m`);
+    return;
+  }
+
+  if (target === 'codearts') {
+    if (!existsSync(join(codeartsPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
+      return;
+    }
+    console.log('[CodeArts]');
+    await updateCodeArts();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mMCP 工具在重启 CodeArts 会话后才生效。\x1b[0m`);
+    return;
+  }
+
+  if (target === 'workbuddy') {
+    if (!existsSync(join(workbuddyPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
+      return;
+    }
+    console.log('[WorkBuddy]');
+    await updateWorkBuddy();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mMCP 工具在重启 WorkBuddy 会话后才生效。\x1b[0m`);
+    return;
+  }
+
+  if (target === 'all') {
+    let updatedAny = false;
+    if (existsSync(join(opencodePluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('[OpenCode]');
+      await updateOpenCode();
+      updatedAny = true;
+    }
+    if (existsSync(join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\n[Codex Desktop]');
+      await updateCodexDesktop();
+      updatedAny = true;
+    }
+    if (existsSync(join(codeartsPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\n[CodeArts]');
+      await updateCodeArts();
+      updatedAny = true;
+    }
+    if (existsSync(join(workbuddyPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\n[WorkBuddy]');
+      await updateWorkBuddy();
+      updatedAny = true;
+    }
+    if (codexStatus()) {
+      console.log('\n[Codex]');
+      installCodex();
+      updatedAny = true;
+    }
+    if (!updatedAny) {
+      console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
+      return;
+    }
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mMCP 工具在重启各 agent 会话后才生效。\x1b[0m`);
+    return;
   }
 
   await cmdUninstall();

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -6,7 +6,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 import { searchMarketplace } from './search-market.mjs';
-import { execOneShot, execWithSession, closeSession, DEFAULT_WORKSPACE_ID } from './sandbox/session-manager.mjs';
+import { execWithSession, closeSession, DEFAULT_WORKSPACE_ID } from './sandbox/session-manager.mjs';
 import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials, hdkitRelease } from './sandbox/hdkitservice-api.mjs';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { readGlobalCredentials, writeObsConfig as writeObsConfigFile } from './auth/credentials.mjs';
@@ -310,20 +310,6 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
-    name: 'huaweicloud_sandbox_exec',
-    description: 'Execute a command on a Huawei Cloud workspace terminal via hwlink (one-shot, no session reuse). Each call creates a new connection. Shell state does NOT persist across calls.',
-    inputSchema: {
-      type: 'object',
-      required: ['command'],
-      properties: {
-        command: { type: 'string', description: 'The shell command to execute on the remote workspace' },
-        workspace_id: { type: 'string', description: 'The workspace ID' },
-        username: { type: 'string', description: 'Login username for the remote terminal (default: root)' },
-        timeout_ms: { type: 'number', description: 'Execution timeout in milliseconds (default: 30000)' },
-      },
-    },
-  },
-  {
     name: 'huaweicloud_sandbox_exec_with_session',
     description: 'Execute a command on a workspace terminal with session reuse (state persists across calls). Shell state (cd, env vars, aliases) carries over between calls.',
     inputSchema: {
@@ -458,13 +444,6 @@ export async function callTool(name, args = {}) {
       return getAuthStatus(args.target || 'all');
     case 'huaweicloud_auth_sync':
       return syncAuth(args.target || 'all');
-    case 'huaweicloud_sandbox_exec': {
-      const sandboxWsId1 = args.workspace_id || DEFAULT_WORKSPACE_ID;
-      const sandboxUser1 = args.username || 'root';
-      const sandboxTimeout1 = args.timeout_ms || 30000;
-      const sandboxResult1 = await execOneShot(sandboxWsId1, args.command, sandboxUser1, sandboxTimeout1);
-      return { stdout: sandboxResult1.stdout, exitCode: sandboxResult1.exitCode };
-    }
     case 'huaweicloud_sandbox_exec_with_session': {
       const sandboxWsId2 = args.workspace_id || DEFAULT_WORKSPACE_ID;
       const sandboxUser2 = args.username || 'root';

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -93,7 +93,6 @@ test('MCP server initializes, lists tools, and plans CLI commands', async () => 
     assert.ok(toolNames.includes('huaweicloud_show_profile_redacted'));
     assert.ok(toolNames.includes('huaweicloud_auth_status'));
     assert.ok(toolNames.includes('huaweicloud_auth_sync'));
-    assert.ok(toolNames.includes('huaweicloud_sandbox_exec'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_check_user'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_connect'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_release'));

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -57,7 +57,6 @@ test('TOOL_DEFINITIONS includes all required tools including sandbox', () => {
     'huaweicloud_setup_obs_config',
     'huaweicloud_auth_status',
     'huaweicloud_auth_sync',
-    'huaweicloud_sandbox_exec',
     'huaweicloud_sandbox_exec_with_session',
     'huaweicloud_sandbox_close_session',
     'huaweicloud_sandbox_check_user',


### PR DESCRIPTION
## Incremental per-agent update mechanism

`npx huaweicloud-devkit update --target <agent>` no longer does uninstall + reinstall. Each agent now gets an incremental updater that overwrites only necessary files and leaves config files untouched unless the MCP server path changed.

- **OpenCode** (`updateOpenCode`): overwrite skills/commands/MCP src/safety, prune stale `huawei*` entries, idempotent `updateOpenCodeConfig` (skips rewrite when entry matches; warns and skips on unparseable jsonc instead of clobbering user config)
- **Codex Desktop** (`updateCodexDesktop`): same overwrite + prune pattern; `ensureCodexConfigSection` upserts `[mcp_servers.huaweicloud-devkit]` in `~/.codex/config.toml` only when missing or when the args path changed (other `[mcp_servers.*]` sections preserved)
- **Codex CLI**: re-runs `codex plugin marketplace add` + `codex plugin add` only; no longer touches Codex Desktop files (fixes update wiping desktop install)
- **CodeArts** (`updateCodeArts`): overwrite user + project skills, MCP src/safety; idempotent `registerCodeartsMcp` for both mcp_settings.json files
- **WorkBuddy** (`updateWorkBuddy`): overwrite skills/src/safety; new idempotent `ensureWorkbuddyMcpConfig`
- **`--target all`**: updates only the agents actually installed (checks each plugin dir / `codexStatus`), skips the rest
- `.installed` markers are refreshed so `doctor` still reminds to restart sessions

## Dev publish manifest version sync

`.github/workflows/publish-dev.yml` now runs `node ./scripts/sync-version.mjs` after the version bump (and inside the publish retry loop). Previously only `package.json` was bumped, so every dev release shipped `plugin.json` version `1.0.0` and Codex never saw plugin version changes.

## hdkit sandbox endpoint

`plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs` default endpoint changed from `http://113.44.143.91:3002` to `https://devkit.huaweicloud.com` (env override `HDKITSERVICE_ENDPOINT` still supported).

## Verification

- `npm test`: 85/85 pass, `npm run validate` passes
- Fake-home e2e per agent: config files byte-identical after update, corrupted skills restored, stale skills pruned, path-change case rewrites only the affected section
