### PR TITLE
fix: use file:// URL for ws-exec dynamic import (Windows)

### DIFF
--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -1,10 +1,10 @@
 import { spawn } from 'node:child_process';
 import { join, dirname } from 'node:path';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { createConnection, getCredentials } from './hwlink-api.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
-const WS_EXEC_SRC = join(__dirname, '..', 'ws-exec');
+export const WS_EXEC_INDEX_URL = pathToFileURL(join(__dirname, '..', 'ws-exec', 'index.js')).href;
 
 const DEFAULT_WORKSPACE_ID = process.env.HW_WORKSPACE_ID || '0107bd9997aa4287bd2b4890b49af07d';
 
@@ -55,7 +55,7 @@ async function getSession(workspaceId, username, timeoutMs) {
   const { ak, sk, securitytoken } = getCredentials();
   const { wsUrl, source } = await createConnection(workspaceId, ak, sk, securitytoken);
 
-  const { connectHwlinkTerminalSession } = await import(join(WS_EXEC_SRC, 'index.js'));
+  const { connectHwlinkTerminalSession } = await import(WS_EXEC_INDEX_URL);
   const session = await connectHwlinkTerminalSession({
     url: wsUrl,
     source,
@@ -71,7 +71,7 @@ export async function execOneShot(workspaceId, command, username, timeoutMs) {
   const { ak, sk, securitytoken } = getCredentials();
   const { wsUrl, source } = await createConnection(workspaceId, ak, sk, securitytoken);
 
-  const { executeHwlinkCommand } = await import(join(WS_EXEC_SRC, 'index.js'));
+  const { executeHwlinkCommand } = await import(WS_EXEC_INDEX_URL);
   return await executeHwlinkCommand({
     url: wsUrl,
     source,

--- a/test/session-manager.test.mjs
+++ b/test/session-manager.test.mjs
@@ -1,0 +1,13 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { WS_EXEC_INDEX_URL } from '../plugins/huaweicloud-core/src/sandbox/session-manager.mjs';
+
+test('ws-exec dynamic import uses file:// URL (Windows-safe)', async () => {
+  assert.ok(
+    WS_EXEC_INDEX_URL.startsWith('file://'),
+    `expected file:// URL, got: ${WS_EXEC_INDEX_URL}`
+  );
+  const mod = await import(WS_EXEC_INDEX_URL);
+  assert.equal(typeof mod.connectHwlinkTerminalSession, 'function');
+  assert.equal(typeof mod.executeHwlinkCommand, 'function');
+});


### PR DESCRIPTION
## Problem

On Windows, `session-manager.mjs` dynamically imports ws-exec via `import(join(WS_EXEC_SRC, 'index.js'))`, producing a path like `C:\Users\...\ws-exec\index.js`. ESM treats `C:` as a URL scheme and throws:

`ERR_UNSUPPORTED_ESM_URL_SCHEME: Received protocol 'c:'`

POSIX absolute paths happen to work in `import()`, so this only breaks Windows.

## Fix

Convert the module path to a proper `file://` URL with `pathToFileURL` once (exported as `WS_EXEC_INDEX_URL`), and use it at both dynamic import sites. Cross-platform safe:

- Windows: `file:///C:/Users/.../ws-exec/index.js`
- POSIX: `file:///.../ws-exec/index.js`

## Test

New regression test `test/session-manager.test.mjs` asserts the URL starts with `file://` and that the dynamic import actually resolves with `connectHwlinkTerminalSession` / `executeHwlinkCommand`.

Verified: `npm test` 86/86 pass, `npm run validate` ok.