### PR TITLE
feat: purge credential vault on full uninstall, safer auth init prompts

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -908,6 +908,19 @@ async function cmdUninstall() {
       }
     }
   }
+  if (target === 'all') {
+    const vaultPath = globalCredentialsPath();
+    if (removeIfExists(vaultPath)) {
+      console.log('  Removed credential vault');
+    }
+    const vaultDir = dirname(vaultPath);
+    try {
+      if (existsSync(vaultDir) && readdirSync(vaultDir).length === 0) {
+        rmSync(vaultDir, { recursive: true, force: true });
+        console.log(`  Removed empty directory: ${vaultDir}`);
+      }
+    } catch {}
+  }
   console.log(`\n\x1b[32mUninstall complete.\x1b[0m`);
 }
 
@@ -1325,7 +1338,9 @@ function readLineQuestion(prompt) {
 
 async function readSecret(prompt) {
   if (!process.stdin.isTTY || !process.stdout.isTTY) {
-    return readLineQuestion(prompt);
+    throw new Error(
+      `Cannot read "${prompt.trim()}" securely in a non-interactive session. Set HW_ACCESS_KEY/HW_SECRET_KEY environment variables instead, or run "npx huaweicloud-devkit auth init" in a real terminal.`
+    );
   }
 
   process.stdout.write(prompt);
@@ -1408,21 +1423,26 @@ async function cmdAuthInit() {
   let securityToken = process.env.HW_SECURITY_TOKEN || '';
   let region = process.env.HW_REGION || process.env.HUAWEICLOUD_REGION || '';
 
-  if (!ak) ak = await readSecret('Access Key ID (AK): ');
+  const interactive = process.stdin.isTTY && process.stdout.isTTY;
+  if (!interactive && (!ak || !sk)) {
+    console.error('\x1b[31mNon-interactive session detected. Provide credentials via environment variables instead:\x1b[0m');
+    console.error('  HW_ACCESS_KEY, HW_SECRET_KEY');
+    console.error('  (Or run "npx huaweicloud-devkit auth init" in a real terminal.)');
+    process.exitCode = 1;
+    return;
+  }
+
+  if (!ak) ak = await readLineQuestion('Access Key ID (AK): ');
   if (!sk) sk = await readSecret('Secret Access Key (SK): ');
-  if (!securityToken) securityToken = await readLineQuestion('Security Token (optional, press Enter to skip): ');
-  if (!region) region = await readLineQuestion('Region (e.g. cn-north-4): ');
+  if (interactive && !securityToken) securityToken = await readLineQuestion('Security Token (optional, press Enter to skip): ');
+  if (!region) region = 'cn-north-4';
 
   if (!ak || !sk) {
     console.error('\nAK and SK are required.');
     process.exitCode = 1;
     return;
   }
-  if (!region) {
-    console.error('\nRegion is required to generate the OBS endpoint.');
-    process.exitCode = 1;
-    return;
-  }
+
 
   const vaultPath = writeGlobalCredentials({ ak, sk, securityToken, region });
   console.log(`\nCredentials stored: ${vaultPath}`);


### PR DESCRIPTION
## Purge credential vault on full uninstall

`uninstall --target all` now also deletes `~/.config/huaweicloud/credentials.json`, and removes `~/.config/huaweicloud/` itself when it becomes empty. Single-target uninstalls keep the vault so other installed agents keep working.

## Safer auth init prompts

- **Non-TTY sessions** (piped/agent/CI): no longer fall back to echo-ing secret prompts. `readSecret` now throws with guidance, and `auth init` exits early with an error asking for `HW_ACCESS_KEY` / `HW_SECRET_KEY` environment variables (or a real terminal). Prevents AK/SK from leaking into logs.
- **AK input is visible** (`readLineQuestion`), **SK stays hidden** (`readSecret`, raw mode, no echo).
- **Region defaults to `cn-north-4`** when not provided (env `HW_REGION` / `HUAWEICLOUD_REGION` still take priority); the "Region is required" error was removed.
- Security Token prompt only appears in interactive sessions.

## Verification

- `npm test`: 86/86 pass, `npm run validate` passes
- Non-TTY without env vars: errors with guidance, no prompt
- Non-TTY with env AK/SK only: vault written with `region: "cn-north-4"`, OBS endpoint generated from it
