### PR TITLE
fix: sync plugin manifests to 1.0.1, harden publish.yml against version drift

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           node-version: 20
 
+      - name: Sync plugin manifest versions and validate
+        run: |
+          node ./scripts/sync-version.mjs
+          npm run validate
+
       - name: Tag and create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/plugins/huaweicloud-core/.claude-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.claude-plugin/plugin.json
@@ -20,7 +20,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "skills": "./skills/",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"

--- a/plugins/huaweicloud-core/.codex-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "huaweicloud-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {
     "name": "HuaweiCloud Mate",

--- a/plugins/huaweicloud-core/.cursor-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.cursor-plugin/plugin.json
@@ -20,7 +20,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "skills": "./skills/",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"


### PR DESCRIPTION
## Problem

The v1.0.1 tag triggered `cd-production.yml`, which failed at `npm run validate`:

```
AssertionError: package.json version must match plugins/huaweicloud-core/.codex-plugin/plugin.json
+ actual '1.0.1' - expected '1.0.0'
```

The 1.0.1 version bump updated `package.json` but not the three plugin manifests (codex/claude/cursor). The production publish pipeline (`publish.yml` tags + `cd-production.yml` validates on tag push) had no protection against this drift — unlike `publish-dev.yml` which we fixed earlier.

## Changes

- **Synced the three plugin manifests to 1.0.1** via `scripts/sync-version.mjs` (`.codex-plugin`, `.claude-plugin`, `.cursor-plugin`)
- **Hardened `publish.yml`**: before tagging/release creation, it now runs:
  ```
  node ./scripts/sync-version.mjs
  npm run validate
  ```
  so a release tag can never be created with drifted manifest versions again.

## Note for maintainers

The existing `v1.0.1` tag points at a commit with drifted manifests and the publish failed — nothing was published to npm for 1.0.1. After merging this, either delete/recreate the `v1.0.1` tag, or bump to the next version and re-run `publish.yml` so `cd-production.yml` can complete.

## Verification

- `npm run validate` passes with all manifests at 1.0.1
- `npm test`: 86/86 pass
