### PR TITLE
fix: publish-dev bump tolerance + sandbox UX (#58) + WSL 0600 credential guard

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -31,8 +31,13 @@ jobs:
         run: |
           LATEST=$(npm view huaweicloud-devkit dist-tags.latest 2>/dev/null || echo 0.0.0)
           BASE=$(node -e "const [a,b,c]=process.argv[1].split('.').map(Number); process.stdout.write(a+'.'+b+'.'+(c+1))" "$LATEST")
-          echo "latest stable: ${LATEST} -> dev base: ${BASE}"
-          npm version "${BASE}" --no-git-tag-version
+          CUR=$(node -p "require('./package.json').version")
+          CUR_BASE=$(node -e "console.log(process.argv[1].split('-')[0])" "$CUR")
+          NEED_BASE=$(node -e "const [a,b,c]=process.argv[2].split('.').map(Number); const [x,y,z]=process.argv[1].split('.').map(Number); process.stdout.write(x*1e6+y*1e3+z < a*1e6+b*1e3+c ? 'yes' : 'no')" "$CUR_BASE" "$BASE")
+          echo "latest stable: ${LATEST} -> dev base: ${BASE} (current: ${CUR})"
+          if [ "${NEED_BASE}" = "yes" ]; then
+            npm version "${BASE}" --no-git-tag-version
+          fi
           npm version prerelease --preid=dev --no-git-tag-version
           echo "dev version: $(node -p "require('./package.json').version")"
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huawei-sandbox
-description: "Use when creating, connecting, or managing Huawei Cloud Sandbox instances and workspace terminals. Covers sandbox lifecycle (check-user, sign-agreement, connect, release), terminal execution (one-shot and session-based), and credential injection. Triggers on: sandbox, workspace, terminal, hwlink, devstation, hdkitservice, remote exec. NOT for: ECS instances (use huawei-ecs), CCE clusters (use huawei-cce)."
+description: "Use when creating, connecting, or managing Huawei Cloud Sandbox instances and workspace terminals, or when a task needs a temporary runtime to deploy, run, or preview a web application. Covers sandbox lifecycle (check-user, sign-agreement, connect, release), session-based terminal execution, and credential injection. Triggers on: sandbox, workspace, terminal, web app deployment, deploy web app, preview app, hwlink, devstation, hdkitservice, remote exec. NOT for: ECS instances (use huawei-ecs), CCE clusters (use huawei-cce)."
 version: 1
 ---
 
@@ -11,6 +11,12 @@ version: 1
 ## Overview
 
 Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace terminal execution. Covers sandbox lifecycle via hdkitservice API and remote terminal command execution via hwlink protocol.
+
+## Activation
+
+- **Proactive offering**: when the developer's task needs a temporary runtime (e.g. "deploy this web app", "run this app and preview it"), offer the sandbox proactively — the developer never has to say "use sandbox". Prompt: "This task can be satisfied by a sandbox — use it?"
+- **Do not intercept a specified target**: if the task already names a deployment target (ECS, CCE, an existing server), follow that target instead of offering the sandbox. Offer the sandbox only when the task needs a temporary runtime or no target is specified.
+- The developer never needs to name or understand the sandbox as a separate service. Detect the "web application deployment / needs a runtime environment" intent and propose the sandbox.
 
 ## MCP Tools
 
@@ -38,18 +44,22 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 
 ## Workflow
 
-1. **Check user**: `huaweicloud_sandbox_check_user` — verify `realname_verified` and `agreement_signed`
-2. **Sign agreement** (if needed): `huaweicloud_sandbox_sign_agreement` — when `agreement_signed=false`
-3. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
-4. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
-5. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
-6. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
+Setup is a **plugin-side preflight** — the developer should be asked a question only once, when the agreement actually needs signing:
+
+1. **Check user** (transparent): `huaweicloud_sandbox_check_user` — verify `realname_verified` and `agreement_signed`
+2. **Real-name verification** (only if `realname_verified=false`): tell the developer once, "Huawei Cloud requires real-name verification before using the sandbox." and stop — do not retry `connect` in a loop
+3. **Sign agreement** (only if `agreement_signed=false`): ask the developer once as the plugin — "Huawei Cloud sandbox requires signing its service agreement. May I sign it on your behalf?" — then call `huaweicloud_sandbox_sign_agreement`. Do not expose the underlying sandbox/DevBridge service as a separate entity the developer must understand or sign up for
+4. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
+5. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
+6. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
+7. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
 
 ## Critical Warnings
 
 | Trap | Why |
 |------|-----|
-| Agreement required first | `sandbox_connect` fails if user hasn't signed agreements; run `sandbox_check_user` first |
+| Agreement required first | `sandbox_connect` fails if the agreement isn't signed; the `sandbox_check_user` preflight detects this, so surface it to the developer only when signing is needed |
+| Real-name required | `sandbox_connect` fails if `realname_verified=false`; tell the developer once and stop, don't loop on connect |
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -4,7 +4,9 @@ import { homedir } from 'node:os';
 
 // Verify a credential file ended up with 0600. On Windows-mounted drives inside WSL
 // (drvfs/9p) chmod is silently ignored, so the file can be world-readable (0777).
+// Native Windows has no POSIX modes (statSync always reports 0666), so skip the check there.
 function ensurePrivateMode(path) {
+  if (process.platform === 'win32') return;
   try { chmodSync(path, 0o600); } catch {}
   try {
     const mode = statSync(path).mode & 0o777;

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -1,6 +1,21 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
+
+// Verify a credential file ended up with 0600. On Windows-mounted drives inside WSL
+// (drvfs/9p) chmod is silently ignored, so the file can be world-readable (0777).
+function ensurePrivateMode(path) {
+  try { chmodSync(path, 0o600); } catch {}
+  try {
+    const mode = statSync(path).mode & 0o777;
+    if (mode !== 0o600) {
+      console.warn(`\x1b[33m[WARN]\x1b[0m Could not set 0600 on ${path} (current mode ${mode.toString(8)}). Credentials may be readable by other users.`);
+      console.warn(`\x1b[33m       If running under WSL, move the credential home to the Linux filesystem:\x1b[0m`);
+      console.warn(`\x1b[33m         export HUAWEICLOUD_HOME=$HOME  (then re-run auth init)\x1b[0m`);
+      console.warn(`\x1b[33m       Or skip file storage entirely with HW_ACCESS_KEY/HW_SECRET_KEY environment variables.\x1b[0m`);
+    }
+  } catch {}
+}
 
 function baseHome() {
   return process.env.HUAWEICLOUD_HOME || homedir();
@@ -34,6 +49,7 @@ export function writeGlobalCredentials(credentials = {}) {
     region: String(credentials.region || ''),
   };
   writeFileSync(path, JSON.stringify(payload, null, 2), { encoding: 'utf8', mode: 0o600 });
+  ensurePrivateMode(path);
   return path;
 }
 
@@ -50,6 +66,7 @@ export function writeObsConfig(credentials = {}) {
   // Flat key=value format (no [default] section) as written by KooCLI 7.x `hcloud OBS config`.
   const content = `endpoint=${endpoint}\nak=${ak}\nsk=${sk}${securityToken ? `\ntoken=${securityToken}` : ''}\n`;
   writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
+  ensurePrivateMode(path);
   return { path, endpoint };
 }
 


### PR DESCRIPTION
Implements #58 (sandbox/DevBridge UX) and adds a WSL credential-permission guard.

## 1. Sandbox guidance rework (`plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md`)

Fixes #58, superseding PR #59 with the review supplements included:

- **Proactive offering**: new `## Activation` section — for tasks needing a temporary runtime ("deploy this web app", "preview this app") the agent offers the sandbox proactively ("This task can be satisfied by a sandbox — use it?"); the developer never has to say "use sandbox"
- **No interception**: if the task already names a deployment target (ECS/CCE/existing server), follow that target instead — the sandbox is offered only when no target is specified (avoids shadowing huawei-ecs/huawei-cce)
- **Agreement hidden as plugin-side preflight**: `check_user` + `sign_agreement` are transparent setup steps; the developer is asked once, as the plugin, only when signing is actually needed — the underlying DevBridge entity is not exposed
- **Real-name branch**: if `realname_verified=false`, tell the developer once ("Huawei Cloud requires real-name verification before using the sandbox.") and stop — no connect retry loop
- **Stale doc fixed**: description no longer mentions the removed one-shot `huaweicloud_sandbox_exec` tool; triggers expanded with "web app deployment / deploy web app / preview app"

## 2. Credential permission guard (`plugins/huaweicloud-core/src/auth/credentials.mjs`)

`writeGlobalCredentials` and `writeObsConfig` now verify the file ends up with 0600 after writing (`chmodSync` + `statSync` check). On WSL Windows-mounted drives (drvfs/9p) chmod is silently ignored and the file becomes world-readable 0777 — this change prints a loud warning with remediation (point `HUAWEICLOUD_HOME` at the Linux filesystem, or use `HW_ACCESS_KEY`/`HW_SECRET_KEY` env vars).

## Verification

- `npm test`: 86/86 pass, `npm run validate` passes, markdownlint 0 issues
- WSL e2e: on `/root` (ext4) credentials land with `-rw-------` and no warning; on `/mnt/c` (v9fs) the file lands 0777 and both warnings fire with guidance
