### PR TITLE
feat(auth): add AK/SK acquisition guide to auth init

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1417,6 +1417,13 @@ function printAuthStatus(status) {
 async function cmdAuthInit() {
   console.log(BANNER);
   console.log('HuaweiCloud DevKit Unified Authentication Setup\n');
+  console.log('\x1b[1m获取 AK/SK（如果还没有）：\x1b[0m');
+  console.log('  1. 打开华为云控制台：');
+  console.log('     https://console.huaweicloud.com/console/?region=cn-north-4#/home');
+  console.log('  2. 点击右上角账号名 -> 我的凭证');
+  console.log('  3. 进入"访问密钥"页签 -> 点击"新增访问密钥"，完成身份验证');
+  console.log('  4. 下载凭证文件（内含 AK 和 SK）。');
+  console.log('     注意：SK 只在创建密钥时显示一次，请妥善保存该文件。\n');
 
   let ak = process.env.HW_ACCESS_KEY || '';
   let sk = process.env.HW_SECRET_KEY || '';


### PR DESCRIPTION
Adds a step-by-step guide at the start of \uth init\ telling users how to obtain their AK/SK:\n\n1. Open the Huawei Cloud console: https://console.huaweicloud.com/console/?region=cn-north-4#/home\n2. Account name (top right) -> My Credentials\n3. Access Keys tab -> Create Access Key, complete identity verification\n4. Download the credentials file; SK is shown only once at creation\n\nGuide is in Chinese, matching the target audience. Shown before the credential prompts so users without keys know where to get them.\n\nVerification: \
pm test\ 86/86, \
pm run validate\ passes