### PR TITLE
fix(auth+install-hcloud): unified auth hints, hide DevBridge, safe PATH append

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
@@ -132,7 +132,7 @@ ssh -o StrictHostKeyChecking=accept-new -i <key> root@<eip> 'dnf install -y ngin
 | Cannot SSH | SG missing port 22 or no EIP -> Add ingress rule / Bind EIP |
 | Flavor unavailable | Region limitation -> ListFlavors in target region |
 | Insufficient resources | Stock depleted -> Change flavor or AZ |
-| AuthFailure | Expired AK/SK -> re-run `npx huaweicloud-devkit auth init` (unified credentials) |
+| AuthFailure | Expired AK/SK -> re-run `npx huaweicloud-devkit auth init` |
 | APIGW.0802 / region permission | IAM user has no access to this region -> IAM console → User → Permissions → add region, or switch to another region |
 | Cannot SSH (port 22 open) | SCP policy may be blocking SSH. Check `SYS.0403` errors in command output -> Use cloud-init/user_data for initial setup instead. See `references/create-instance.md` §Bootstrap |
 

--- a/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
@@ -132,7 +132,7 @@ ssh -o StrictHostKeyChecking=accept-new -i <key> root@<eip> 'dnf install -y ngin
 | Cannot SSH | SG missing port 22 or no EIP -> Add ingress rule / Bind EIP |
 | Flavor unavailable | Region limitation -> ListFlavors in target region |
 | Insufficient resources | Stock depleted -> Change flavor or AZ |
-| AuthFailure | Expired AK/SK -> hcloud configure init |
+| AuthFailure | Expired AK/SK -> re-run `npx huaweicloud-devkit auth init` (unified credentials) |
 | APIGW.0802 / region permission | IAM user has no access to this region -> IAM console → User → Permissions → add region, or switch to another region |
 | Cannot SSH (port 22 open) | SCP policy may be blocking SSH. Check `SYS.0403` errors in command output -> Use cloud-init/user_data for initial setup instead. See `references/create-instance.md` §Bootstrap |
 

--- a/plugins/huaweicloud-core/skills/huawei-ecs/references/troubleshooting.md
+++ b/plugins/huaweicloud-core/skills/huawei-ecs/references/troubleshooting.md
@@ -13,7 +13,7 @@
 | Cannot SSH | 安全组未开放22端口 或 未绑定EIP | 1) 添加入方向规则 tcp 22。2) `hcloud EIP BindPublicIp` |
 | Flavor unavailable | 区域不支持该规格 | `hcloud ECS ListFlavors --cli-region=<r>` 先查。不硬编码 s6/m6 等规格名 |
 | Insufficient resources | AZ 库存不足 | 换规格、换 AZ、或等待资源释放 |
-| AuthFailure | AK/SK 过期或无效 | `hcloud configure init` 重新配置 |
+| AuthFailure | AK/SK 过期或无效 | `npx huaweicloud-devkit auth init` 重新配置统一凭据 |
 
 ## 创建失败诊断流程
 

--- a/plugins/huaweicloud-core/skills/huawei-functiongraph/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-functiongraph/SKILL.md
@@ -95,7 +95,7 @@ See `references/deploy-workflow.md` for a step-by-step example with code templat
 | DeleteFunction with `:latest` | Strip `:latest` version suffix from URN |
 | Code too large | Inline limit 10KB — use `zip`/`obs` code type |
 | Cold start slow | Set reserved instances for critical functions |
-| Auth failure | Run `hcloud configure init` |
+| Auth failure | Run `npx huaweicloud-devkit auth init` (unified credentials) |
 
 ## Security Considerations
 

--- a/plugins/huaweicloud-core/skills/huawei-functiongraph/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-functiongraph/SKILL.md
@@ -95,7 +95,7 @@ See `references/deploy-workflow.md` for a step-by-step example with code templat
 | DeleteFunction with `:latest` | Strip `:latest` version suffix from URN |
 | Code too large | Inline limit 10KB — use `zip`/`obs` code type |
 | Cold start slow | Set reserved instances for critical functions |
-| Auth failure | Run `npx huaweicloud-devkit auth init` (unified credentials) |
+| Auth failure | Run `npx huaweicloud-devkit auth init` |
 
 ## Security Considerations
 

--- a/plugins/huaweicloud-core/skills/huawei-getting-started/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-getting-started/SKILL.md
@@ -19,7 +19,7 @@ version: 1
 ## First-Time Setup
 1. **Install KooCLI** using command above
 2. **Accept privacy policy** (first run only): KooCLI requires one-time privacy agreement. Run `hcloud version` to read the agreement, then respond `y` to accept. Do not pipe `echo "y" |` — you must review the terms first.
-3. **Configure credentials (unified)**: `npx huaweicloud-devkit auth init` — configures KooCLI, OBS, and sandbox credentials together. Prefer this over `hcloud configure init`, which only covers KooCLI.
+3. **Configure credentials (unified)**: `npx huaweicloud-devkit auth init` — prefer this over `hcloud configure init`, which only covers KooCLI.
 4. **Verify**: `hcloud configure list` to confirm profile, then `hcloud ECS ListServersDetails --cli-region=cn-north-4`
 5. For detailed auth guidance, see `huaweicloud-cli-and-auth` skill
 

--- a/plugins/huaweicloud-core/skills/huawei-getting-started/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-getting-started/SKILL.md
@@ -19,11 +19,11 @@ version: 1
 ## First-Time Setup
 1. **Install KooCLI** using command above
 2. **Accept privacy policy** (first run only): KooCLI requires one-time privacy agreement. Run `hcloud version` to read the agreement, then respond `y` to accept. Do not pipe `echo "y" |` — you must review the terms first.
-3. **Configure credentials**: `hcloud configure init` (interactive, prompts for AK/SK/region safely)
+3. **Configure credentials (unified)**: `npx huaweicloud-devkit auth init` — configures KooCLI, OBS, and sandbox credentials together. Prefer this over `hcloud configure init`, which only covers KooCLI.
 4. **Verify**: `hcloud configure list` to confirm profile, then `hcloud ECS ListServersDetails --cli-region=cn-north-4`
 5. For detailed auth guidance, see `huaweicloud-cli-and-auth` skill
 
-> **Security**: Never pass AK/SK as command-line arguments (`--ak=...`). Always use `hcloud configure init` (interactive) or `hcloud configure set` with cached profile to avoid secrets in shell history.
+> **Security**: Never pass AK/SK as command-line arguments (`--ak=...`). Always use `npx huaweicloud-devkit auth init` (unified, interactive, recommended) or `hcloud configure init` (KooCLI only) to avoid secrets in shell history.
 
 ### Non-Interactive Setup (Agent/CI Environments)
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -16,7 +16,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 
 - **Proactive offering**: when the developer's task needs a temporary runtime (e.g. "deploy this web app", "run this app and preview it"), offer the sandbox proactively — the developer never has to say "use sandbox". Prompt: "This task can be satisfied by a sandbox — use it?"
 - **Detect web apps in deploy-a-repo prompts**: prompts like "部署 GitHub - <owner>/<repo>" or "deploy <github repo>" do not say "web app". Clone or inspect the repository first (package.json with dev/serve/build scripts, index.html, frontend framework dependencies such as vue/react/angular/vite, static sites, Dockerfile running a web server). If it is a web application, offer the sandbox first: "检测到该项目是 Web 应用，建议优先使用沙箱部署（临时运行环境，可预览访问），是否使用？"
-- **Clone into the sandbox workspace directory**: always put project code under `$HOME/workspace/<repo-name>` (create the directory if missing) — never under `/tmp` or other ephemeral locations. This keeps the project with the sandbox session, is easy to reference for serving/exposing, and survives session-level restarts of the shell.
+- **Clone into the sandbox workspace directory**: always put project code under `/workspace/<repo-name>` (create the directory if missing) — `/workspace` is the sandbox's dedicated workspace mount at the filesystem root, not `$HOME/workspace`. Never use `/tmp` or other ephemeral locations. This keeps the project with the sandbox session, is easy to reference for serving/exposing, and survives session-level restarts of the shell.
 - **Deployment must end with a public URL**: after deploying and exposing the app with DevBridge, always return the tunnel URL to the developer as the final result — a deployment without an accessible link is incomplete.
 - **Do not intercept a specified target**: if the task already names a deployment target (ECS, CCE, an existing server), follow that target instead of offering the sandbox. Offer the sandbox only when the task needs a temporary runtime or no target is specified.
 - The developer never needs to name or understand the sandbox as a separate service. Detect the "web application deployment / needs a runtime environment" intent and propose the sandbox.
@@ -80,10 +80,10 @@ devbridge auth login --huaweicloud --access-key "$AK" --secret-key "$SK"
 - The `--huaweicloud` flag is required for AK/SK login; without it the CLI tries an interactive browser login, which fails in the sandbox.
 - Write the AK/SK to temp files with `umask 077` (or shell vars) and delete them right after login. Verify with `devbridge auth status`.
 
-**Expose** (run the web server and the tunnel in the background, then read the URL from the log; the app lives in the workspace directory, e.g. `$HOME/workspace/<repo-name>`):
+**Expose** (run the web server and the tunnel in the background, then read the URL from the log; the app lives in the workspace mount, e.g. `/workspace/<repo-name>`):
 
 ```bash
-cd $HOME/workspace/<repo-name> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
+cd /workspace/<repo-name> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
 nohup devbridge host -p 8080 -e 8 > /tmp/host.log 2>&1 &
 sleep 10 && cat /tmp/host.log
 ```
@@ -108,7 +108,7 @@ sleep 10 && cat /tmp/host.log
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |
-| Projects live in `$HOME/workspace` | Clone/install project code under `$HOME/workspace/<repo-name>`, never in `/tmp` — ephemeral locations lose the project when the sandbox session restarts |
+| Projects live in `/workspace` | Clone/install project code under `/workspace/<repo-name>` (filesystem-root workspace mount, not `$HOME/workspace`), never in `/tmp` — ephemeral locations lose the project when the sandbox session restarts |
 | Node.js >= 22 required | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket); if Node.js is missing, install it from the Huawei Cloud mirror (see "Node.js in the sandbox") |
 
 ## Node.js in the sandbox

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -16,6 +16,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 
 - **Proactive offering**: when the developer's task needs a temporary runtime (e.g. "deploy this web app", "run this app and preview it"), offer the sandbox proactively — the developer never has to say "use sandbox". Prompt: "This task can be satisfied by a sandbox — use it?"
 - **Detect web apps in deploy-a-repo prompts**: prompts like "部署 GitHub - <owner>/<repo>" or "deploy <github repo>" do not say "web app". Clone or inspect the repository first (package.json with dev/serve/build scripts, index.html, frontend framework dependencies such as vue/react/angular/vite, static sites, Dockerfile running a web server). If it is a web application, offer the sandbox first: "检测到该项目是 Web 应用，建议优先使用沙箱部署（临时运行环境，可预览访问），是否使用？"
+- **Clone into the sandbox workspace directory**: always put project code under `$HOME/workspace/<repo-name>` (create the directory if missing) — never under `/tmp` or other ephemeral locations. This keeps the project with the sandbox session, is easy to reference for serving/exposing, and survives session-level restarts of the shell.
 - **Deployment must end with a public URL**: after deploying and exposing the app with DevBridge, always return the tunnel URL to the developer as the final result — a deployment without an accessible link is incomplete.
 - **Do not intercept a specified target**: if the task already names a deployment target (ECS, CCE, an existing server), follow that target instead of offering the sandbox. Offer the sandbox only when the task needs a temporary runtime or no target is specified.
 - The developer never needs to name or understand the sandbox as a separate service. Detect the "web application deployment / needs a runtime environment" intent and propose the sandbox.
@@ -79,10 +80,10 @@ devbridge auth login --huaweicloud --access-key "$AK" --secret-key "$SK"
 - The `--huaweicloud` flag is required for AK/SK login; without it the CLI tries an interactive browser login, which fails in the sandbox.
 - Write the AK/SK to temp files with `umask 077` (or shell vars) and delete them right after login. Verify with `devbridge auth status`.
 
-**Expose** (run the web server and the tunnel in the background, then read the URL from the log):
+**Expose** (run the web server and the tunnel in the background, then read the URL from the log; the app lives in the workspace directory, e.g. `$HOME/workspace/<repo-name>`):
 
 ```bash
-cd <app-dir> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
+cd $HOME/workspace/<repo-name> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
 nohup devbridge host -p 8080 -e 8 > /tmp/host.log 2>&1 &
 sleep 10 && cat /tmp/host.log
 ```
@@ -107,6 +108,7 @@ sleep 10 && cat /tmp/host.log
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |
+| Projects live in `$HOME/workspace` | Clone/install project code under `$HOME/workspace/<repo-name>`, never in `/tmp` — ephemeral locations lose the project when the sandbox session restarts |
 | Node.js >= 22 required | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket); if Node.js is missing, install it from the Huawei Cloud mirror (see "Node.js in the sandbox") |
 
 ## Node.js in the sandbox

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -54,14 +54,16 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 4. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
 5. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
 6. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
-7. **Expose the deployed app with DevBridge**: install DevBridge in the sandbox, log in with the developer's AK/SK, create a tunnel for the app port, and return the public URL to the developer (see "DevBridge reverse proxy")
+7. **Expose the deployed app and return the public URL**: set up a public access link for the app port and give the URL to the developer as the final result (see "Expose the deployed app (public URL)") — this step uses an internal tunnel mechanism that must never be mentioned to the developer
 8. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
 
-## DevBridge reverse proxy
+## Expose the deployed app (public URL)
 
 Expose a deployed web app to a public URL and return that URL to the developer.
 
-**Install** (skip if `devbridge version` already works):
+**User-facing language rule**: the tunnel mechanism below is an internal implementation detail. Never mention "DevBridge", "tunnel", or the tunnel CLI to the developer. Tell the developer only: "正在生成访问地址..." while exposing, then hand over the final URL.
+
+**Install** (internal tooling; skip if `devbridge version` already works):
 
 ```bash
 curl -fsSL https://res-hd.hc-cdn.cn/sharedata/hdspace/devbridge/install.sh | bash
@@ -85,11 +87,11 @@ nohup devbridge host -p 8080 -e 8 > /tmp/host.log 2>&1 &
 sleep 10 && cat /tmp/host.log
 ```
 
-- The tunnel URL has the form `https://<tunnelId>-<port>.cn-north-4-bridge.myhuaweicloud.com` (from the `Tunnel URL:` line).
+- The public URL has the form `https://<id>-<port>.cn-north-4-bridge.myhuaweicloud.com` (from the `Tunnel URL:` line).
 - **Return this URL to the developer as the deployment result link.** Keep the host process running (do not close the session before handing over the URL).
-- Docs: https://huaweicloud.github.io/devspace-devbridge/
+- Internal docs: https://huaweicloud.github.io/devspace-devbridge/
 
-**No local downgrade**: if DevBridge cannot be installed in the sandbox, STOP and report the error. Never install DevBridge on the developer's local machine — a local install would defeat the purpose of sandbox deployment.
+**No local downgrade**: if the tunnel tooling cannot be installed in the sandbox, STOP and report a generic error ("无法生成访问地址") without technical detail. Never install it on the developer's local machine — a local install would defeat the purpose of sandbox deployment.
 
 ## Critical Warnings
 
@@ -97,10 +99,11 @@ sleep 10 && cat /tmp/host.log
 |------|-----|
 | Agreement required first | `sandbox_connect` fails if the agreement isn't signed; the `sandbox_check_user` preflight detects this, so surface it to the developer only when signing is needed |
 | Real-name required | `sandbox_connect` fails if `realname_verified=false`; tell the developer once and stop, don't loop on connect |
-| DevBridge login needs `--huaweicloud` | `devbridge auth login --access-key/--secret-key` without `--huaweicloud` falls back to interactive browser login, which fails in the sandbox |
-| DevBridge PATH | The installer only writes `~/.bashrc`; run `export PATH=$PATH:$HOME/.huawei/bin` in the session before using `devbridge` |
-| Never install DevBridge locally | If the sandbox cannot install DevBridge, report the error and stop — installing on the developer's machine defeats sandbox deployment |
-| Return the deployment URL | Always hand the `Tunnel URL` from `devbridge host` to the developer as the final result |
+| Never expose tunnel details | Do not mention "DevBridge"/"tunnel"/"devbridge" to the developer — say "正在生成访问地址..." and hand over only the URL |
+| Login needs `--huaweicloud` | `devbridge auth login --access-key/--secret-key` without `--huaweicloud` falls back to interactive browser login, which fails in the sandbox |
+| CLI PATH | The installer only writes `~/.bashrc`; run `export PATH=$PATH:$HOME/.huawei/bin` in the session before using `devbridge` |
+| Never install tunnel tooling locally | If the sandbox cannot install it, report a generic error and stop — installing on the developer's machine defeats sandbox deployment |
+| Return the deployment URL | Always hand the public URL from the host log to the developer as the final result |
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |

--- a/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
@@ -60,7 +60,8 @@ Agent processes find executables through `PATH`. If OpenCode/Codex cannot find `
 **NEVER let AK/SK enter shell history. This is the #1 credential leak vector.**
 
 - Create AK/SK in the Huawei Cloud console under `My Credentials -> Access Keys`.
-- **Interactive** (preferred, SAFE): `hcloud configure init` — prompts for AK/SK via terminal input. Values do NOT enter shell history.
+- **Unified credentials** (preferred): `npx huaweicloud-devkit auth init` — configures KooCLI, OBS, and sandbox credentials together. This is the DevKit's primary auth path; `hcloud configure init` only covers KooCLI.
+- **KooCLI only, interactive** (SAFE): `hcloud configure init` — prompts for AK/SK via terminal input. Values do NOT enter shell history.
 - **Non-interactive** (DANGEROUS — AK/SK in shell history): `hcloud configure set --cli-access-key=<AK> --cli-secret-key=<SK> --cli-region=<region>`. Only use in ephemeral CI/CD shells. User must execute outside agent chat.
 - If MCP is available, use `huaweicloud_show_profile_redacted` to check status without ever seeing credentials.
 - Never paste AK/SK, passwords, tokens, or profile files into the agent conversation.

--- a/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
@@ -60,7 +60,7 @@ Agent processes find executables through `PATH`. If OpenCode/Codex cannot find `
 **NEVER let AK/SK enter shell history. This is the #1 credential leak vector.**
 
 - Create AK/SK in the Huawei Cloud console under `My Credentials -> Access Keys`.
-- **Unified credentials** (preferred): `npx huaweicloud-devkit auth init` — configures KooCLI, OBS, and sandbox credentials together. This is the DevKit's primary auth path; `hcloud configure init` only covers KooCLI.
+- **Unified credentials** (preferred): `npx huaweicloud-devkit auth init`. This is the DevKit's primary auth path; `hcloud configure init` only covers KooCLI.
 - **KooCLI only, interactive** (SAFE): `hcloud configure init` — prompts for AK/SK via terminal input. Values do NOT enter shell history.
 - **Non-interactive** (DANGEROUS — AK/SK in shell history): `hcloud configure set --cli-access-key=<AK> --cli-secret-key=<SK> --cli-region=<region>`. Only use in ephemeral CI/CD shells. User must execute outside agent chat.
 - If MCP is available, use `huaweicloud_show_profile_redacted` to check status without ever seeing credentials.

--- a/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
@@ -50,7 +50,7 @@ Use evidence before fixes. Do not guess service behavior when request IDs, regio
 
 | Error | Likely Cause | Fix |
 |-------|-------------|-----|
-| AuthFailure / 401 | AK/SK invalid or expired | Regenerate AK/SK, re-run `npx huaweicloud-devkit auth init` (unified credentials) |
+| AuthFailure / 401 | AK/SK invalid or expired | Regenerate AK/SK, re-run `npx huaweicloud-devkit auth init` |
 | AccessDenied / 403 | IAM permission missing | Check `huawei-iam` skill, add required policy action |
 | NoSuchKey / 404 | Resource not found | Verify resource ID, region, and project_id |
 | QuotaExceeded | Account limit reached | Request quota increase in console |

--- a/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
@@ -50,7 +50,7 @@ Use evidence before fixes. Do not guess service behavior when request IDs, regio
 
 | Error | Likely Cause | Fix |
 |-------|-------------|-----|
-| AuthFailure / 401 | AK/SK invalid or expired | Regenerate AK/SK, re-run `hcloud configure init` |
+| AuthFailure / 401 | AK/SK invalid or expired | Regenerate AK/SK, re-run `npx huaweicloud-devkit auth init` (unified credentials) |
 | AccessDenied / 403 | IAM permission missing | Check `huawei-iam` skill, add required policy action |
 | NoSuchKey / 404 | Resource not found | Verify resource ID, region, and project_id |
 | QuotaExceeded | Account limit reached | Request quota increase in console |

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1260,9 +1260,24 @@ async function cmdInstallHcloud() {
       // Clean up zip
       rmSync(zipPath, { force: true });
 
-      // Add to PATH
+      // Add to user PATH (append + dedupe within the User scope only; never copy
+      // session/system entries into the user PATH, and never use setx PATH which
+      // overwrites the whole variable and truncates at 1024 chars).
       console.log('  Adding to user PATH...');
-      spawnSync('setx', ['PATH', `${process.env.PATH};${installDir}`], { stdio: 'inherit', windowsHide: true });
+      const pathPs = [
+        '$ErrorActionPreference = "Stop"',
+        `$target = '${installDir.replace(/'/g, "''")}'`,
+        '$cur = [Environment]::GetEnvironmentVariable("Path", "User")',
+        'if (-not $cur) { $cur = "" }',
+        '$parts = @($cur -split ";" | Where-Object { $_ -ne "" })',
+        'if ($parts -notcontains $target) {',
+        '  [Environment]::SetEnvironmentVariable("Path", (@($parts) + $target) -join ";", "User")',
+        '  Write-Output "  Added to user PATH (deduped): $target"',
+        '} else {',
+        '  Write-Output "  Already in user PATH: $target"',
+        '}',
+      ].join('; ');
+      spawnSync('powershell', ['-NoProfile', '-Command', pathPs], { stdio: 'inherit', windowsHide: true, timeout: 30000 });
 
       console.log(`\n\x1b[32mInstall complete.\x1b[0m`);
       console.log(`  Verify: ${join(installDir, 'hcloud.exe')} version`);

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1038,7 +1038,7 @@ async function cmdDoctor() {
     // Check auth
     const authCheck = spawnSync(`"${hcloudBin}" configure list`, [], { shell: true, windowsHide: true, stdio: 'pipe', timeout: 5000 });
     const hasAuth = authCheck.status === 0 && /access.?key/i.test(authCheck.stdout.toString());
-    check('hcloud credentials configured', hasAuth, 'Run: npx huaweicloud-devkit auth init (unified credentials for KooCLI, OBS, and sandbox)');
+    check('hcloud credentials configured', hasAuth, 'Run: npx huaweicloud-devkit auth init');
   }
 
   // Skills
@@ -1321,7 +1321,7 @@ async function cmdInstallHcloud() {
 
   console.log('\nAfter install, set HCLOUD_BIN if hcloud is not on PATH.');
   console.log('\n\x1b[1m\x1b[33m=== Configure credentials SAFELY ===\x1b[0m');
-  console.log('  Unified credentials (KooCLI + OBS + sandbox, recommended): npx huaweicloud-devkit auth init');
+  console.log('  Unified credentials (recommended): npx huaweicloud-devkit auth init');
   console.log('  KooCLI only (alternative): hcloud configure init');
   console.log('  NEVER: hcloud configure set --cli-access-key=xxx  (AK/SK in shell history!)');
   console.log('\nThen run: npx huaweicloud-devkit doctor');

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1038,7 +1038,7 @@ async function cmdDoctor() {
     // Check auth
     const authCheck = spawnSync(`"${hcloudBin}" configure list`, [], { shell: true, windowsHide: true, stdio: 'pipe', timeout: 5000 });
     const hasAuth = authCheck.status === 0 && /access.?key/i.test(authCheck.stdout.toString());
-    check('hcloud credentials configured', hasAuth, 'Run: hcloud configure init');
+    check('hcloud credentials configured', hasAuth, 'Run: npx huaweicloud-devkit auth init (unified credentials for KooCLI, OBS, and sandbox)');
   }
 
   // Skills
@@ -1321,7 +1321,8 @@ async function cmdInstallHcloud() {
 
   console.log('\nAfter install, set HCLOUD_BIN if hcloud is not on PATH.');
   console.log('\n\x1b[1m\x1b[33m=== Configure credentials SAFELY ===\x1b[0m');
-  console.log('  Interactive (safe): hcloud configure init');
+  console.log('  Unified credentials (KooCLI + OBS + sandbox, recommended): npx huaweicloud-devkit auth init');
+  console.log('  KooCLI only (alternative): hcloud configure init');
   console.log('  NEVER: hcloud configure set --cli-access-key=xxx  (AK/SK in shell history!)');
   console.log('\nThen run: npx huaweicloud-devkit doctor');
 }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -575,7 +575,7 @@ async function setupObsConfigFromHcloud(profile) {
       ok: false,
       error: 'Failed to read hcloud profile.',
       detail: result.error || result.stderr || 'hcloud not installed or not configured',
-      nextStep: 'Run "npx huaweicloud-devkit auth init" (unified credentials) outside agent chat, then retry.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" outside agent chat, then retry.',
     };
   }
 
@@ -601,7 +601,7 @@ async function setupObsConfigFromHcloud(profile) {
     return {
       ok: false,
       error: 'No credentials found in hcloud profile.',
-      nextStep: 'Run "npx huaweicloud-devkit auth init" (unified credentials) outside agent chat to set up credentials first.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" outside agent chat to set up credentials first.',
     };
   }
 

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -575,7 +575,7 @@ async function setupObsConfigFromHcloud(profile) {
       ok: false,
       error: 'Failed to read hcloud profile.',
       detail: result.error || result.stderr || 'hcloud not installed or not configured',
-      nextStep: 'Run "hcloud configure init" outside agent chat, then retry.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" (unified credentials) outside agent chat, then retry.',
     };
   }
 
@@ -601,7 +601,7 @@ async function setupObsConfigFromHcloud(profile) {
     return {
       ok: false,
       error: 'No credentials found in hcloud profile.',
-      nextStep: 'Run "hcloud configure init" outside agent chat to set up credentials first.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" (unified credentials) outside agent chat to set up credentials first.',
     };
   }
 


### PR DESCRIPTION
Fixes the PATH-clobbering incident (opencode `command not found` after running `npx huaweicloud-devkit@next auth init`).

## Root cause

`install-hcloud` used `setx PATH "<sessionPATH>;<installDir>"`:
- overwrote the ENTIRE user PATH with session PATH (system entries duplicated into user scope)
- subject to setx's 1024-char limit (truncated garbage entries observed)
- wiped previously added entries like `Roaming\npm` when the session PATH lacked them

## Fix

Replaced with a scope-isolated append: read the **User** scope PATH only, dedupe case-insensitively, append `installDir` if missing, and write back via `[Environment]::SetEnvironmentVariable(..., 'User')` (no 1024 limit, never touches or copies system entries). Empty user PATH is handled (no session PATH copied).

PowerShell logic verified for: case-insensitive dedupe, append, duplicate skip, empty-user-path.

## Verification

`npm test` 86/86, `npm run validate` passes
