### PR TITLE
fix(huaweicloud-core): append installDir to User-scope PATH instead of setx overwrite

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1260,9 +1260,17 @@ async function cmdInstallHcloud() {
       // Clean up zip
       rmSync(zipPath, { force: true });
 
-      // Add to PATH
+      // Append installDir to the User-scope PATH only (read-modify-write in PowerShell).
+      // Avoids setx's 1024-char truncation, whole-string overwrite, and copying system entries into user scope.
       console.log('  Adding to user PATH...');
-      spawnSync('setx', ['PATH', `${process.env.PATH};${installDir}`], { stdio: 'inherit', windowsHide: true });
+      const psPathCmd = [
+        `$target = '${installDir.replace(/'/g, "''")}'`,
+        `$user = [Environment]::GetEnvironmentVariable('Path', 'User')`,
+        `$parts = @($user -split ';' | Where-Object { $_ })`,
+        `if (-not ($parts | Where-Object { $_.TrimEnd('\\') -ieq $target.TrimEnd('\\') })) { $parts += $target }`,
+        `[Environment]::SetEnvironmentVariable('Path', ($parts -join ';'), 'User')`,
+      ].join('; ');
+      spawnSync('powershell', ['-NoProfile', '-Command', psPathCmd], { stdio: 'inherit', windowsHide: true });
 
       console.log(`\n\x1b[32mInstall complete.\x1b[0m`);
       console.log(`  Verify: ${join(installDir, 'hcloud.exe')} version`);


### PR DESCRIPTION
## Summary

Fixes #65: `install-hcloud` used `setx PATH <session-path;installDir>` which **overwrote** the user-level PATH with the full session PATH (User + System), causing:

1. Existing user PATH entries (e.g. `%APPDATA%\npm`) to be silently dropped.
2. System-level entries to be duplicated into the user scope.
3. Truncation at setx's 1024-character limit, leaving half-formed garbage entries.

## Change

`plugins/huaweicloud-core/src/setup-cli.mjs` (`cmdInstallHcloud`) now appends `installDir` to the **User scope** only, via a PowerShell read-modify-write:

**Before:**
```js
spawnSync('setx', ['PATH', `${process.env.PATH};${installDir}`], ...);
```

**After:**
```js
// read User-scope PATH, dedupe case-insensitively, append installDir, write back
const psPathCmd = [
  `$target = '${installDir.replace(/'/g, "''")}'`,
  `$user = [Environment]::GetEnvironmentVariable('Path', 'User')`,
  `$parts = @($user -split ';' | Where-Object { $_ })`,
  `if (-not ($parts | Where-Object { $_.TrimEnd('\\') -ieq $target.TrimEnd('\\') })) { $parts += $target }`,
  `[Environment]::SetEnvironmentVariable('Path', ($parts -join ';'), 'User')`,
].join('; ');
spawnSync('powershell', ['-NoProfile', '-Command', psPathCmd], ...);
```

- Reads only the User scope (not the combined session PATH), so no system entries are copied in.
- Appends + dedupes (case-insensitive, trailing-backslash-tolerant) instead of overwriting.
- Writes via `[Environment]::SetEnvironmentVariable`, which has no 1024-char limit.

## Verification

- `npm test` — 86 passing
- `npm run validate` — 28 skills validated