### PR TITLE
feat(install): Chinese next-steps prompt with unified auth init first

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1437,11 +1437,10 @@ async function cmdAuthInit() {
   console.log(BANNER);
   console.log('HuaweiCloud DevKit Unified Authentication Setup\n');
   console.log('\x1b[1m获取 AK/SK（如果还没有）：\x1b[0m');
-  console.log('  1. 打开华为云控制台：');
-  console.log('     https://console.huaweicloud.com/console/?region=cn-north-4#/home');
-  console.log('  2. 点击右上角账号名 -> 我的凭证');
-  console.log('  3. 进入"访问密钥"页签 -> 点击"新增访问密钥"，完成身份验证');
-  console.log('  4. 下载凭证文件（内含 AK 和 SK）。');
+  console.log('  1. 打开华为云"访问密钥"页签：');
+  console.log('     https://console.huaweicloud.com/iam/?region=cn-north-4#/mine/accessKey');
+  console.log('  2. 点击"新增访问密钥"，完成身份验证');
+  console.log('  3. 下载凭证文件（内含 AK 和 SK）。');
   console.log('     注意：SK 只在创建密钥时显示一次，请妥善保存该文件。\n');
 
   let ak = process.env.HW_ACCESS_KEY || '';

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -857,10 +857,10 @@ async function cmdInstall() {
     console.log(`\nKooCLI (hcloud) detected.`);
   }
 
-  console.log(`\n\x1b[1mNext steps:\x1b[0m`);
-  console.log(`  1. Configure unified credentials: npx huaweicloud-devkit auth init`);
-  console.log(`  2. Restart the ${appName} session (MCP tools activate after restart)`);
-  console.log(`  3. Run: npx huaweicloud-devkit doctor`);
+  console.log(`\n\x1b[1m下一步：\x1b[0m`);
+  console.log(`  1. 配置统一凭据：npx huaweicloud-devkit auth init`);
+  console.log(`  2. 重启 ${appName} 会话（MCP 工具重启后生效）`);
+  console.log(`  3. 运行自检：npx huaweicloud-devkit doctor`);
 
   // Write install marker for doctor to detect
   const markerDir = target === 'codearts' ? codeartsPluginsDir()

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -857,7 +857,10 @@ async function cmdInstall() {
     console.log(`\nKooCLI (hcloud) detected.`);
   }
 
-  console.log(`\nAfter restart + hcloud setup, run: npx huaweicloud-devkit doctor`);
+  console.log(`\n\x1b[1mNext steps:\x1b[0m`);
+  console.log(`  1. Configure unified credentials: npx huaweicloud-devkit auth init`);
+  console.log(`  2. Restart the ${appName} session (MCP tools activate after restart)`);
+  console.log(`  3. Run: npx huaweicloud-devkit doctor`);
 
   // Write install marker for doctor to detect
   const markerDir = target === 'codearts' ? codeartsPluginsDir()


### PR DESCRIPTION
Improves the post-install prompt for a clearer, unified-auth-first flow in Chinese.

- Replaced the single line `After restart + hcloud setup, run: ... doctor` with a 3-step "下一步" block:
  1. 配置统一凭据：npx huaweicloud-devkit auth init
  2. 重启 <agent> 会话（MCP 工具重启后生效）
  3. 运行自检：npx huaweicloud-devkit doctor
- Unified credentials (`auth init`) now comes first, so users configure AK/SK (KooCLI + OBS + sandbox in one step) before restarting
- The AK/SK acquisition guide (console -> My Credentials -> Access Keys) is printed at the start of `auth init` itself, so users see it when they run step 1

Verification: `npm test` 86/86, `npm run validate` passes
