### PR TITLE
fix(huawei-sandbox): clear cached sessions on release and document re-deploy flow

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -45,6 +45,15 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 5. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
 6. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
 
+## Re-deploy
+
+A "re-deploy" (重新部署) must tear down the previous sandbox before creating a new one — `huaweicloud_sandbox_connect` reuses the existing sandbox (one user one instance), so calling connect again without a release returns the stale sandbox.
+
+1. **Release the old sandbox**: `huaweicloud_sandbox_release` with the previous `session_id`/`dev_stage_id` (also clears any cached terminal sessions)
+2. **Connect again**: `huaweicloud_sandbox_connect` with the git config → returns a fresh `session_id`/`dev_stage_id`
+3. **Inject credentials into the new sandbox**: `huaweicloud_sandbox_credentials` with the NEW `session_id`/`dev_stage_id` — a new sandbox has no temporary AK/SK yet, so skipping or reusing the old ids leaves the sandbox without credentials
+4. **Deploy**: `huaweicloud_sandbox_exec_with_session` with the NEW `dev_stage_id`
+
 ## Critical Warnings
 
 | Trap | Why |
@@ -53,6 +62,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |
+| Re-deploy needs a fresh sandbox | `sandbox_connect` reuses the existing sandbox; release first, then re-connect and re-inject credentials with the new ids |
 | Node.js >= 22 required | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket) |
 
 ## Environment Variables

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -6,7 +6,7 @@ import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 import { searchMarketplace } from './search-market.mjs';
-import { execWithSession, closeSession, DEFAULT_WORKSPACE_ID } from './sandbox/session-manager.mjs';
+import { execWithSession, closeSession, closeAllSessions, DEFAULT_WORKSPACE_ID } from './sandbox/session-manager.mjs';
 import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials, hdkitRelease } from './sandbox/hdkitservice-api.mjs';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { readGlobalCredentials, writeObsConfig as writeObsConfigFile } from './auth/credentials.mjs';
@@ -465,8 +465,10 @@ export async function callTool(name, args = {}) {
       return await hdkitConnect(args);
     case 'huaweicloud_sandbox_credentials':
       return await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
-    case 'huaweicloud_sandbox_release':
+    case 'huaweicloud_sandbox_release': {
+      await closeAllSessions();
       return await hdkitRelease(args.session_id, args.dev_stage_id);
+    }
     default:
       throw new Error(`Unknown tool: ${name}`);
   }


### PR DESCRIPTION
## Problem

Fixes #67 — first deploy succeeds, but "重新部署" (re-deploy) fails: after re-deploy a new sandbox is created but it cannot get AK/SK, and the agent retries in an infinite loop.

## Root cause

1. `huaweicloud_sandbox_release` released the sandbox via `hdkitRelease` but **did not clear the cached terminal sessions** in `session-manager.mjs`. On re-deploy the stale session could be reused, leaving the sandbox in an inconsistent state. The SKILL.md already documented release as "cleans up sandbox and session", but the code only cleaned up the sandbox.
2. The sandbox skill had **no re-deploy workflow**, and `huaweicloud_sandbox_connect` is documented as "one user one instance — reuses existing sandbox if available". Without guidance, an agent re-issuing `connect` without a `release` gets the stale sandbox, and a new sandbox is left without injected credentials ("获取不到 AK/SK"), which the agent then loops on.

## Changes

- `plugins/huaweicloud-core/src/tools.mjs`: `huaweicloud_sandbox_release` now calls `closeAllSessions()` before releasing, so re-deploy starts from a clean state.
- `plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md`: added a "Re-deploy" workflow (release → connect → inject credentials → deploy) and a matching critical-warning entry.

## Verification

- `npm test` — 86 pass, 0 fail
- `npm run validate` — passes