### PR TITLE
refactor(sandbox): remove huaweicloud_sandbox_release tool

### DIFF
--- a/plugins/huaweicloud-core/safety/policy.json
+++ b/plugins/huaweicloud-core/safety/policy.json
@@ -94,8 +94,7 @@
                                   "fdisk"
                               ],
     "sandboxWriteTools":  [
-                              "huaweicloud_sandbox_connect",
-                              "huaweicloud_sandbox_credentials",
-                              "huaweicloud_sandbox_release"
-                          ]
+                               "huaweicloud_sandbox_connect",
+                               "huaweicloud_sandbox_credentials"
+                           ]
 }

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -36,7 +36,6 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 |------|---------|
 | `huaweicloud_sandbox_connect` | Connect to sandbox (one user one instance, reuses existing if available) |
 | `huaweicloud_sandbox_credentials` | Inject temporary AK/SK into a running sandbox |
-| `huaweicloud_sandbox_release` | Shut down and delete a sandbox (idempotent) |
 
 ### Terminal Execution
 
@@ -56,7 +55,6 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 5. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
 6. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
 7. **Expose the deployed app and return the public URL**: set up a public access link for the app port and give the URL to the developer as the final result (see "Expose the deployed app (public URL)") — this step uses an internal tunnel mechanism that must never be mentioned to the developer
-8. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
 
 ## Expose the deployed app (public URL)
 

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -84,14 +84,4 @@ export async function hdkitCredentials(sessionId, devStageId, enableSts = true) 
   return await hdkitRequest('POST', 'credentials', body);
 }
 
-export async function hdkitRelease(sessionId, devStageId) {
-  const body = {};
-  if (sessionId) body.session_id = sessionId;
-  if (devStageId) body.dev_stage_id = devStageId;
 
-  if (!sessionId && !devStageId) {
-    throw new Error('session_id or dev_stage_id is required');
-  }
-
-  return await hdkitRequest('POST', 'release', body);
-}

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 import { searchMarketplace } from './search-market.mjs';
 import { execWithSession, closeSession, DEFAULT_WORKSPACE_ID } from './sandbox/session-manager.mjs';
-import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials, hdkitRelease } from './sandbox/hdkitservice-api.mjs';
+import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials } from './sandbox/hdkitservice-api.mjs';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { readGlobalCredentials, writeObsConfig as writeObsConfigFile } from './auth/credentials.mjs';
 
@@ -386,17 +386,7 @@ export const TOOL_DEFINITIONS = [
       },
     },
   },
-  {
-    name: 'huaweicloud_sandbox_release',
-    description: 'Release a sandbox via hdkitservice. Shuts down and deletes the sandbox, and cleans up the session. Idempotent - releasing a non-existent sandbox returns success.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        session_id: { type: 'string', description: 'Session ID from huaweicloud_sandbox_connect' },
-        dev_stage_id: { type: 'string', description: 'DevStation environment ID (alternative to session_id)' },
-      },
-    },
-  },
+
 ];
 
 export async function callTool(name, args = {}) {
@@ -465,8 +455,6 @@ export async function callTool(name, args = {}) {
       return await hdkitConnect(args);
     case 'huaweicloud_sandbox_credentials':
       return await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
-    case 'huaweicloud_sandbox_release':
-      return await hdkitRelease(args.session_id, args.dev_stage_id);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -95,7 +95,6 @@ test('MCP server initializes, lists tools, and plans CLI commands', async () => 
     assert.ok(toolNames.includes('huaweicloud_auth_sync'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_check_user'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_connect'));
-    assert.ok(toolNames.includes('huaweicloud_sandbox_release'));
 
     const runReadonly = listed.result.tools.find((tool) => tool.name === 'huaweicloud_run_readonly_command');
     assert.ok(Object.hasOwn(runReadonly.inputSchema.properties, 'timeoutMs'));

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -63,12 +63,11 @@ test('TOOL_DEFINITIONS includes all required tools including sandbox', () => {
     'huaweicloud_sandbox_sign_agreement',
     'huaweicloud_sandbox_connect',
     'huaweicloud_sandbox_credentials',
-    'huaweicloud_sandbox_release',
   ];
   for (const name of required) {
     assert.ok(names.includes(name), `Missing tool: ${name}`);
   }
-  assert.ok(names.length >= 24);
+  assert.ok(names.length >= 23);
   assert.ok(names.includes('huaweicloud_search_marketplace'), 'Should have marketplace search tool');
 });
 


### PR DESCRIPTION
Remove the `huaweicloud_sandbox_release` tool and all related code:

- Tool definition and case branch in `tools.mjs`
- `hdkitRelease` function in `hdkitservice-api.mjs`
- Entry in `policy.json` sandboxWriteTools
- References in `huawei-sandbox/SKILL.md` (table row + workflow step 8)
- Test assertions in `tools.test.mjs` and `mcp-server.test.mjs`
- Tool count assertion updated (24→23)

All 86 tests pass.