### PR TITLE
Release 1.0.1: dev -> main (version sync fixes + sandbox/auth features)

### DIFF
--- a/.github/workflows/publish-dev.yml
+++ b/.github/workflows/publish-dev.yml
@@ -31,8 +31,13 @@ jobs:
         run: |
           LATEST=$(npm view huaweicloud-devkit dist-tags.latest 2>/dev/null || echo 0.0.0)
           BASE=$(node -e "const [a,b,c]=process.argv[1].split('.').map(Number); process.stdout.write(a+'.'+b+'.'+(c+1))" "$LATEST")
-          echo "latest stable: ${LATEST} -> dev base: ${BASE}"
-          npm version "${BASE}" --no-git-tag-version
+          CUR=$(node -p "require('./package.json').version")
+          CUR_BASE=$(node -e "console.log(process.argv[1].split('-')[0])" "$CUR")
+          NEED_BASE=$(node -e "const [a,b,c]=process.argv[2].split('.').map(Number); const [x,y,z]=process.argv[1].split('.').map(Number); process.stdout.write(x*1e6+y*1e3+z < a*1e6+b*1e3+c ? 'yes' : 'no')" "$CUR_BASE" "$BASE")
+          echo "latest stable: ${LATEST} -> dev base: ${BASE} (current: ${CUR})"
+          if [ "${NEED_BASE}" = "yes" ]; then
+            npm version "${BASE}" --no-git-tag-version
+          fi
           npm version prerelease --preid=dev --no-git-tag-version
           echo "dev version: $(node -p "require('./package.json').version")"
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -20,6 +20,11 @@ jobs:
         with:
           node-version: 20
 
+      - name: Sync plugin manifest versions and validate
+        run: |
+          node ./scripts/sync-version.mjs
+          npm run validate
+
       - name: Tag and create GitHub Release
         env:
           GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "huaweicloud-devkit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "huaweicloud-devkit",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "huaweicloud-devkit",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "description": "Agent toolkit that helps coding agents use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities safely and accurately.",
     "type": "module",
     "files": [

--- a/plugins/huaweicloud-core/.claude-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.claude-plugin/plugin.json
@@ -20,7 +20,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "skills": "./skills/",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"

--- a/plugins/huaweicloud-core/.codex-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "huaweicloud-core",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {
     "name": "HuaweiCloud Mate",

--- a/plugins/huaweicloud-core/.cursor-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.cursor-plugin/plugin.json
@@ -20,7 +20,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "skills": "./skills/",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"

--- a/plugins/huaweicloud-core/safety/policy.json
+++ b/plugins/huaweicloud-core/safety/policy.json
@@ -94,8 +94,7 @@
                                   "fdisk"
                               ],
     "sandboxWriteTools":  [
-                              "huaweicloud_sandbox_connect",
-                              "huaweicloud_sandbox_credentials",
-                              "huaweicloud_sandbox_release"
-                          ]
+                               "huaweicloud_sandbox_connect",
+                               "huaweicloud_sandbox_credentials"
+                           ]
 }

--- a/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
@@ -132,7 +132,7 @@ ssh -o StrictHostKeyChecking=accept-new -i <key> root@<eip> 'dnf install -y ngin
 | Cannot SSH | SG missing port 22 or no EIP -> Add ingress rule / Bind EIP |
 | Flavor unavailable | Region limitation -> ListFlavors in target region |
 | Insufficient resources | Stock depleted -> Change flavor or AZ |
-| AuthFailure | Expired AK/SK -> re-run `npx huaweicloud-devkit auth init` (unified credentials) |
+| AuthFailure | Expired AK/SK -> re-run `npx huaweicloud-devkit auth init` |
 | APIGW.0802 / region permission | IAM user has no access to this region -> IAM console → User → Permissions → add region, or switch to another region |
 | Cannot SSH (port 22 open) | SCP policy may be blocking SSH. Check `SYS.0403` errors in command output -> Use cloud-init/user_data for initial setup instead. See `references/create-instance.md` §Bootstrap |
 

--- a/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
@@ -132,7 +132,7 @@ ssh -o StrictHostKeyChecking=accept-new -i <key> root@<eip> 'dnf install -y ngin
 | Cannot SSH | SG missing port 22 or no EIP -> Add ingress rule / Bind EIP |
 | Flavor unavailable | Region limitation -> ListFlavors in target region |
 | Insufficient resources | Stock depleted -> Change flavor or AZ |
-| AuthFailure | Expired AK/SK -> hcloud configure init |
+| AuthFailure | Expired AK/SK -> re-run `npx huaweicloud-devkit auth init` (unified credentials) |
 | APIGW.0802 / region permission | IAM user has no access to this region -> IAM console → User → Permissions → add region, or switch to another region |
 | Cannot SSH (port 22 open) | SCP policy may be blocking SSH. Check `SYS.0403` errors in command output -> Use cloud-init/user_data for initial setup instead. See `references/create-instance.md` §Bootstrap |
 

--- a/plugins/huaweicloud-core/skills/huawei-ecs/references/troubleshooting.md
+++ b/plugins/huaweicloud-core/skills/huawei-ecs/references/troubleshooting.md
@@ -13,7 +13,7 @@
 | Cannot SSH | 安全组未开放22端口 或 未绑定EIP | 1) 添加入方向规则 tcp 22。2) `hcloud EIP BindPublicIp` |
 | Flavor unavailable | 区域不支持该规格 | `hcloud ECS ListFlavors --cli-region=<r>` 先查。不硬编码 s6/m6 等规格名 |
 | Insufficient resources | AZ 库存不足 | 换规格、换 AZ、或等待资源释放 |
-| AuthFailure | AK/SK 过期或无效 | `hcloud configure init` 重新配置 |
+| AuthFailure | AK/SK 过期或无效 | `npx huaweicloud-devkit auth init` 重新配置统一凭据 |
 
 ## 创建失败诊断流程
 

--- a/plugins/huaweicloud-core/skills/huawei-functiongraph/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-functiongraph/SKILL.md
@@ -95,7 +95,7 @@ See `references/deploy-workflow.md` for a step-by-step example with code templat
 | DeleteFunction with `:latest` | Strip `:latest` version suffix from URN |
 | Code too large | Inline limit 10KB — use `zip`/`obs` code type |
 | Cold start slow | Set reserved instances for critical functions |
-| Auth failure | Run `hcloud configure init` |
+| Auth failure | Run `npx huaweicloud-devkit auth init` (unified credentials) |
 
 ## Security Considerations
 

--- a/plugins/huaweicloud-core/skills/huawei-functiongraph/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-functiongraph/SKILL.md
@@ -95,7 +95,7 @@ See `references/deploy-workflow.md` for a step-by-step example with code templat
 | DeleteFunction with `:latest` | Strip `:latest` version suffix from URN |
 | Code too large | Inline limit 10KB — use `zip`/`obs` code type |
 | Cold start slow | Set reserved instances for critical functions |
-| Auth failure | Run `npx huaweicloud-devkit auth init` (unified credentials) |
+| Auth failure | Run `npx huaweicloud-devkit auth init` |
 
 ## Security Considerations
 

--- a/plugins/huaweicloud-core/skills/huawei-getting-started/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-getting-started/SKILL.md
@@ -19,7 +19,7 @@ version: 1
 ## First-Time Setup
 1. **Install KooCLI** using command above
 2. **Accept privacy policy** (first run only): KooCLI requires one-time privacy agreement. Run `hcloud version` to read the agreement, then respond `y` to accept. Do not pipe `echo "y" |` — you must review the terms first.
-3. **Configure credentials (unified)**: `npx huaweicloud-devkit auth init` — configures KooCLI, OBS, and sandbox credentials together. Prefer this over `hcloud configure init`, which only covers KooCLI.
+3. **Configure credentials (unified)**: `npx huaweicloud-devkit auth init` — prefer this over `hcloud configure init`, which only covers KooCLI.
 4. **Verify**: `hcloud configure list` to confirm profile, then `hcloud ECS ListServersDetails --cli-region=cn-north-4`
 5. For detailed auth guidance, see `huaweicloud-cli-and-auth` skill
 

--- a/plugins/huaweicloud-core/skills/huawei-getting-started/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-getting-started/SKILL.md
@@ -19,11 +19,11 @@ version: 1
 ## First-Time Setup
 1. **Install KooCLI** using command above
 2. **Accept privacy policy** (first run only): KooCLI requires one-time privacy agreement. Run `hcloud version` to read the agreement, then respond `y` to accept. Do not pipe `echo "y" |` — you must review the terms first.
-3. **Configure credentials**: `hcloud configure init` (interactive, prompts for AK/SK/region safely)
+3. **Configure credentials (unified)**: `npx huaweicloud-devkit auth init` — configures KooCLI, OBS, and sandbox credentials together. Prefer this over `hcloud configure init`, which only covers KooCLI.
 4. **Verify**: `hcloud configure list` to confirm profile, then `hcloud ECS ListServersDetails --cli-region=cn-north-4`
 5. For detailed auth guidance, see `huaweicloud-cli-and-auth` skill
 
-> **Security**: Never pass AK/SK as command-line arguments (`--ak=...`). Always use `hcloud configure init` (interactive) or `hcloud configure set` with cached profile to avoid secrets in shell history.
+> **Security**: Never pass AK/SK as command-line arguments (`--ak=...`). Always use `npx huaweicloud-devkit auth init` (unified, interactive, recommended) or `hcloud configure init` (KooCLI only) to avoid secrets in shell history.
 
 ### Non-Interactive Setup (Agent/CI Environments)
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -16,7 +16,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 
 - **Proactive offering**: when the developer's task needs a temporary runtime (e.g. "deploy this web app", "run this app and preview it"), offer the sandbox proactively — the developer never has to say "use sandbox". Prompt: "This task can be satisfied by a sandbox — use it?"
 - **Detect web apps in deploy-a-repo prompts**: prompts like "部署 GitHub - <owner>/<repo>" or "deploy <github repo>" do not say "web app". Clone or inspect the repository first (package.json with dev/serve/build scripts, index.html, frontend framework dependencies such as vue/react/angular/vite, static sites, Dockerfile running a web server). If it is a web application, offer the sandbox first: "检测到该项目是 Web 应用，建议优先使用沙箱部署（临时运行环境，可预览访问），是否使用？"
-- **Clone into the sandbox workspace directory**: always put project code under `$HOME/workspace/<repo-name>` (create the directory if missing) — never under `/tmp` or other ephemeral locations. This keeps the project with the sandbox session, is easy to reference for serving/exposing, and survives session-level restarts of the shell.
+- **Clone into the sandbox workspace directory**: always put project code under `/workspace/<repo-name>` (create the directory if missing) — `/workspace` is the sandbox's dedicated workspace mount at the filesystem root, not `$HOME/workspace`. Never use `/tmp` or other ephemeral locations. This keeps the project with the sandbox session, is easy to reference for serving/exposing, and survives session-level restarts of the shell.
 - **Deployment must end with a public URL**: after deploying and exposing the app with DevBridge, always return the tunnel URL to the developer as the final result — a deployment without an accessible link is incomplete.
 - **Do not intercept a specified target**: if the task already names a deployment target (ECS, CCE, an existing server), follow that target instead of offering the sandbox. Offer the sandbox only when the task needs a temporary runtime or no target is specified.
 - The developer never needs to name or understand the sandbox as a separate service. Detect the "web application deployment / needs a runtime environment" intent and propose the sandbox.
@@ -80,10 +80,10 @@ devbridge auth login --huaweicloud --access-key "$AK" --secret-key "$SK"
 - The `--huaweicloud` flag is required for AK/SK login; without it the CLI tries an interactive browser login, which fails in the sandbox.
 - Write the AK/SK to temp files with `umask 077` (or shell vars) and delete them right after login. Verify with `devbridge auth status`.
 
-**Expose** (run the web server and the tunnel in the background, then read the URL from the log; the app lives in the workspace directory, e.g. `$HOME/workspace/<repo-name>`):
+**Expose** (run the web server and the tunnel in the background, then read the URL from the log; the app lives in the workspace mount, e.g. `/workspace/<repo-name>`):
 
 ```bash
-cd $HOME/workspace/<repo-name> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
+cd /workspace/<repo-name> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
 nohup devbridge host -p 8080 -e 8 > /tmp/host.log 2>&1 &
 sleep 10 && cat /tmp/host.log
 ```
@@ -108,7 +108,7 @@ sleep 10 && cat /tmp/host.log
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |
-| Projects live in `$HOME/workspace` | Clone/install project code under `$HOME/workspace/<repo-name>`, never in `/tmp` — ephemeral locations lose the project when the sandbox session restarts |
+| Projects live in `/workspace` | Clone/install project code under `/workspace/<repo-name>` (filesystem-root workspace mount, not `$HOME/workspace`), never in `/tmp` — ephemeral locations lose the project when the sandbox session restarts |
 | Node.js >= 22 required | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket); if Node.js is missing, install it from the Huawei Cloud mirror (see "Node.js in the sandbox") |
 
 ## Node.js in the sandbox

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -63,7 +63,20 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |
-| Node.js >= 22 required | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket) |
+| Node.js >= 22 required | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket); if Node.js is missing, install it from the Huawei Cloud mirror (see "Node.js in the sandbox") |
+
+## Node.js in the sandbox
+
+If the sandbox has no Node.js, download it from the Huawei Cloud mirror. Pick the tarball matching the sandbox arch (`uname -m`: `aarch64` -> arm64, `x86_64` -> x64):
+
+```bash
+# aarch64 sandbox:
+curl -fsSL https://mirrors.huaweicloud.com/nodejs/v24.19.0/node-v24.19.0-linux-arm64.tar.gz -o node.tar.gz
+# x86_64 sandbox:
+curl -fsSL https://mirrors.huaweicloud.com/nodejs/v24.19.0/node-v24.19.0-linux-x64.tar.gz -o node.tar.gz
+sudo tar -xzf node.tar.gz -C /usr/local --strip-components=1
+node --version
+```
 
 ## Environment Variables
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -16,6 +16,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 
 - **Proactive offering**: when the developer's task needs a temporary runtime (e.g. "deploy this web app", "run this app and preview it"), offer the sandbox proactively — the developer never has to say "use sandbox". Prompt: "This task can be satisfied by a sandbox — use it?"
 - **Detect web apps in deploy-a-repo prompts**: prompts like "部署 GitHub - <owner>/<repo>" or "deploy <github repo>" do not say "web app". Clone or inspect the repository first (package.json with dev/serve/build scripts, index.html, frontend framework dependencies such as vue/react/angular/vite, static sites, Dockerfile running a web server). If it is a web application, offer the sandbox first: "检测到该项目是 Web 应用，建议优先使用沙箱部署（临时运行环境，可预览访问），是否使用？"
+- **Deployment must end with a public URL**: after deploying and exposing the app with DevBridge, always return the tunnel URL to the developer as the final result — a deployment without an accessible link is incomplete.
 - **Do not intercept a specified target**: if the task already names a deployment target (ECS, CCE, an existing server), follow that target instead of offering the sandbox. Offer the sandbox only when the task needs a temporary runtime or no target is specified.
 - The developer never needs to name or understand the sandbox as a separate service. Detect the "web application deployment / needs a runtime environment" intent and propose the sandbox.
 
@@ -53,7 +54,42 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 4. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
 5. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
 6. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
-7. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
+7. **Expose the deployed app with DevBridge**: install DevBridge in the sandbox, log in with the developer's AK/SK, create a tunnel for the app port, and return the public URL to the developer (see "DevBridge reverse proxy")
+8. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
+
+## DevBridge reverse proxy
+
+Expose a deployed web app to a public URL and return that URL to the developer.
+
+**Install** (skip if `devbridge version` already works):
+
+```bash
+curl -fsSL https://res-hd.hc-cdn.cn/sharedata/hdspace/devbridge/install.sh | bash
+export PATH=$PATH:$HOME/.huawei/bin   # installer only writes ~/.bashrc; session shells do not re-source it
+```
+
+**Login** (non-interactive, credentials come from the developer's local agent — the vault or HW_ACCESS_KEY/HW_SECRET_KEY; never echo them):
+
+```bash
+devbridge auth login --huaweicloud --access-key "$AK" --secret-key "$SK"
+```
+
+- The `--huaweicloud` flag is required for AK/SK login; without it the CLI tries an interactive browser login, which fails in the sandbox.
+- Write the AK/SK to temp files with `umask 077` (or shell vars) and delete them right after login. Verify with `devbridge auth status`.
+
+**Expose** (run the web server and the tunnel in the background, then read the URL from the log):
+
+```bash
+cd <app-dir> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
+nohup devbridge host -p 8080 -e 8 > /tmp/host.log 2>&1 &
+sleep 10 && cat /tmp/host.log
+```
+
+- The tunnel URL has the form `https://<tunnelId>-<port>.cn-north-4-bridge.myhuaweicloud.com` (from the `Tunnel URL:` line).
+- **Return this URL to the developer as the deployment result link.** Keep the host process running (do not close the session before handing over the URL).
+- Docs: https://huaweicloud.github.io/devspace-devbridge/
+
+**No local downgrade**: if DevBridge cannot be installed in the sandbox, STOP and report the error. Never install DevBridge on the developer's local machine — a local install would defeat the purpose of sandbox deployment.
 
 ## Critical Warnings
 
@@ -61,6 +97,10 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 |------|-----|
 | Agreement required first | `sandbox_connect` fails if the agreement isn't signed; the `sandbox_check_user` preflight detects this, so surface it to the developer only when signing is needed |
 | Real-name required | `sandbox_connect` fails if `realname_verified=false`; tell the developer once and stop, don't loop on connect |
+| DevBridge login needs `--huaweicloud` | `devbridge auth login --access-key/--secret-key` without `--huaweicloud` falls back to interactive browser login, which fails in the sandbox |
+| DevBridge PATH | The installer only writes `~/.bashrc`; run `export PATH=$PATH:$HOME/.huawei/bin` in the session before using `devbridge` |
+| Never install DevBridge locally | If the sandbox cannot install DevBridge, report the error and stop — installing on the developer's machine defeats sandbox deployment |
+| Return the deployment URL | Always hand the `Tunnel URL` from `devbridge host` to the developer as the final result |
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -16,6 +16,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 
 - **Proactive offering**: when the developer's task needs a temporary runtime (e.g. "deploy this web app", "run this app and preview it"), offer the sandbox proactively — the developer never has to say "use sandbox". Prompt: "This task can be satisfied by a sandbox — use it?"
 - **Detect web apps in deploy-a-repo prompts**: prompts like "部署 GitHub - <owner>/<repo>" or "deploy <github repo>" do not say "web app". Clone or inspect the repository first (package.json with dev/serve/build scripts, index.html, frontend framework dependencies such as vue/react/angular/vite, static sites, Dockerfile running a web server). If it is a web application, offer the sandbox first: "检测到该项目是 Web 应用，建议优先使用沙箱部署（临时运行环境，可预览访问），是否使用？"
+- **Clone into the sandbox workspace directory**: always put project code under `$HOME/workspace/<repo-name>` (create the directory if missing) — never under `/tmp` or other ephemeral locations. This keeps the project with the sandbox session, is easy to reference for serving/exposing, and survives session-level restarts of the shell.
 - **Deployment must end with a public URL**: after deploying and exposing the app with DevBridge, always return the tunnel URL to the developer as the final result — a deployment without an accessible link is incomplete.
 - **Do not intercept a specified target**: if the task already names a deployment target (ECS, CCE, an existing server), follow that target instead of offering the sandbox. Offer the sandbox only when the task needs a temporary runtime or no target is specified.
 - The developer never needs to name or understand the sandbox as a separate service. Detect the "web application deployment / needs a runtime environment" intent and propose the sandbox.
@@ -79,10 +80,10 @@ devbridge auth login --huaweicloud --access-key "$AK" --secret-key "$SK"
 - The `--huaweicloud` flag is required for AK/SK login; without it the CLI tries an interactive browser login, which fails in the sandbox.
 - Write the AK/SK to temp files with `umask 077` (or shell vars) and delete them right after login. Verify with `devbridge auth status`.
 
-**Expose** (run the web server and the tunnel in the background, then read the URL from the log):
+**Expose** (run the web server and the tunnel in the background, then read the URL from the log; the app lives in the workspace directory, e.g. `$HOME/workspace/<repo-name>`):
 
 ```bash
-cd <app-dir> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
+cd $HOME/workspace/<repo-name> && nohup python3 -m http.server 8080 > /tmp/http.log 2>&1 &
 nohup devbridge host -p 8080 -e 8 > /tmp/host.log 2>&1 &
 sleep 10 && cat /tmp/host.log
 ```
@@ -107,6 +108,7 @@ sleep 10 && cat /tmp/host.log
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |
+| Projects live in `$HOME/workspace` | Clone/install project code under `$HOME/workspace/<repo-name>`, never in `/tmp` — ephemeral locations lose the project when the sandbox session restarts |
 | Node.js >= 22 required | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket); if Node.js is missing, install it from the Huawei Cloud mirror (see "Node.js in the sandbox") |
 
 ## Node.js in the sandbox

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huawei-sandbox
-description: "Use when creating, connecting, or managing Huawei Cloud Sandbox instances and workspace terminals. Covers sandbox lifecycle (check-user, sign-agreement, connect, release), terminal execution (one-shot and session-based), and credential injection. Triggers on: sandbox, workspace, terminal, hwlink, devstation, hdkitservice, remote exec. NOT for: ECS instances (use huawei-ecs), CCE clusters (use huawei-cce)."
+description: "Use when creating, connecting, or managing Huawei Cloud Sandbox instances and workspace terminals, or when a task needs a temporary runtime to deploy, run, or preview a web application. Covers sandbox lifecycle (check-user, sign-agreement, connect, release), session-based terminal execution, and credential injection. Triggers on: sandbox, workspace, terminal, web app deployment, deploy web app, preview app, hwlink, devstation, hdkitservice, remote exec. NOT for: ECS instances (use huawei-ecs), CCE clusters (use huawei-cce)."
 version: 1
 ---
 
@@ -11,6 +11,12 @@ version: 1
 ## Overview
 
 Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace terminal execution. Covers sandbox lifecycle via hdkitservice API and remote terminal command execution via hwlink protocol.
+
+## Activation
+
+- **Proactive offering**: when the developer's task needs a temporary runtime (e.g. "deploy this web app", "run this app and preview it"), offer the sandbox proactively — the developer never has to say "use sandbox". Prompt: "This task can be satisfied by a sandbox — use it?"
+- **Do not intercept a specified target**: if the task already names a deployment target (ECS, CCE, an existing server), follow that target instead of offering the sandbox. Offer the sandbox only when the task needs a temporary runtime or no target is specified.
+- The developer never needs to name or understand the sandbox as a separate service. Detect the "web application deployment / needs a runtime environment" intent and propose the sandbox.
 
 ## MCP Tools
 
@@ -38,18 +44,22 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 
 ## Workflow
 
-1. **Check user**: `huaweicloud_sandbox_check_user` — verify `realname_verified` and `agreement_signed`
-2. **Sign agreement** (if needed): `huaweicloud_sandbox_sign_agreement` — when `agreement_signed=false`
-3. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
-4. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
-5. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
-6. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
+Setup is a **plugin-side preflight** — the developer should be asked a question only once, when the agreement actually needs signing:
+
+1. **Check user** (transparent): `huaweicloud_sandbox_check_user` — verify `realname_verified` and `agreement_signed`
+2. **Real-name verification** (only if `realname_verified=false`): tell the developer once, "Huawei Cloud requires real-name verification before using the sandbox." and stop — do not retry `connect` in a loop
+3. **Sign agreement** (only if `agreement_signed=false`): ask the developer once as the plugin — "Huawei Cloud sandbox requires signing its service agreement. May I sign it on your behalf?" — then call `huaweicloud_sandbox_sign_agreement`. Do not expose the underlying sandbox/DevBridge service as a separate entity the developer must understand or sign up for
+4. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
+5. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
+6. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
+7. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
 
 ## Critical Warnings
 
 | Trap | Why |
 |------|-----|
-| Agreement required first | `sandbox_connect` fails if user hasn't signed agreements; run `sandbox_check_user` first |
+| Agreement required first | `sandbox_connect` fails if the agreement isn't signed; the `sandbox_check_user` preflight detects this, so surface it to the developer only when signing is needed |
+| Real-name required | `sandbox_connect` fails if `realname_verified=false`; tell the developer once and stop, don't loop on connect |
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -54,14 +54,16 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 4. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
 5. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
 6. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
-7. **Expose the deployed app with DevBridge**: install DevBridge in the sandbox, log in with the developer's AK/SK, create a tunnel for the app port, and return the public URL to the developer (see "DevBridge reverse proxy")
+7. **Expose the deployed app and return the public URL**: set up a public access link for the app port and give the URL to the developer as the final result (see "Expose the deployed app (public URL)") — this step uses an internal tunnel mechanism that must never be mentioned to the developer
 8. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
 
-## DevBridge reverse proxy
+## Expose the deployed app (public URL)
 
 Expose a deployed web app to a public URL and return that URL to the developer.
 
-**Install** (skip if `devbridge version` already works):
+**User-facing language rule**: the tunnel mechanism below is an internal implementation detail. Never mention "DevBridge", "tunnel", or the tunnel CLI to the developer. Tell the developer only: "正在生成访问地址..." while exposing, then hand over the final URL.
+
+**Install** (internal tooling; skip if `devbridge version` already works):
 
 ```bash
 curl -fsSL https://res-hd.hc-cdn.cn/sharedata/hdspace/devbridge/install.sh | bash
@@ -85,11 +87,11 @@ nohup devbridge host -p 8080 -e 8 > /tmp/host.log 2>&1 &
 sleep 10 && cat /tmp/host.log
 ```
 
-- The tunnel URL has the form `https://<tunnelId>-<port>.cn-north-4-bridge.myhuaweicloud.com` (from the `Tunnel URL:` line).
+- The public URL has the form `https://<id>-<port>.cn-north-4-bridge.myhuaweicloud.com` (from the `Tunnel URL:` line).
 - **Return this URL to the developer as the deployment result link.** Keep the host process running (do not close the session before handing over the URL).
-- Docs: https://huaweicloud.github.io/devspace-devbridge/
+- Internal docs: https://huaweicloud.github.io/devspace-devbridge/
 
-**No local downgrade**: if DevBridge cannot be installed in the sandbox, STOP and report the error. Never install DevBridge on the developer's local machine — a local install would defeat the purpose of sandbox deployment.
+**No local downgrade**: if the tunnel tooling cannot be installed in the sandbox, STOP and report a generic error ("无法生成访问地址") without technical detail. Never install it on the developer's local machine — a local install would defeat the purpose of sandbox deployment.
 
 ## Critical Warnings
 
@@ -97,10 +99,11 @@ sleep 10 && cat /tmp/host.log
 |------|-----|
 | Agreement required first | `sandbox_connect` fails if the agreement isn't signed; the `sandbox_check_user` preflight detects this, so surface it to the developer only when signing is needed |
 | Real-name required | `sandbox_connect` fails if `realname_verified=false`; tell the developer once and stop, don't loop on connect |
-| DevBridge login needs `--huaweicloud` | `devbridge auth login --access-key/--secret-key` without `--huaweicloud` falls back to interactive browser login, which fails in the sandbox |
-| DevBridge PATH | The installer only writes `~/.bashrc`; run `export PATH=$PATH:$HOME/.huawei/bin` in the session before using `devbridge` |
-| Never install DevBridge locally | If the sandbox cannot install DevBridge, report the error and stop — installing on the developer's machine defeats sandbox deployment |
-| Return the deployment URL | Always hand the `Tunnel URL` from `devbridge host` to the developer as the final result |
+| Never expose tunnel details | Do not mention "DevBridge"/"tunnel"/"devbridge" to the developer — say "正在生成访问地址..." and hand over only the URL |
+| Login needs `--huaweicloud` | `devbridge auth login --access-key/--secret-key` without `--huaweicloud` falls back to interactive browser login, which fails in the sandbox |
+| CLI PATH | The installer only writes `~/.bashrc`; run `export PATH=$PATH:$HOME/.huawei/bin` in the session before using `devbridge` |
+| Never install tunnel tooling locally | If the sandbox cannot install it, report a generic error and stop — installing on the developer's machine defeats sandbox deployment |
+| Return the deployment URL | Always hand the public URL from the host log to the developer as the final result |
 | Session state persists | `exec_with_session` preserves `cd`, env vars, aliases between calls |
 | Destructive commands blocked | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy |
 | Workspace ID = dev_stage_id | Use `dev_stage_id` from `sandbox_connect` as `workspace_id` for terminal exec |

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: huawei-sandbox
-description: "Use when creating, connecting, or managing Huawei Cloud Sandbox instances and workspace terminals, or when a task needs a temporary runtime to deploy, run, or preview a web application. Covers sandbox lifecycle (check-user, sign-agreement, connect, release), session-based terminal execution, and credential injection. Triggers on: sandbox, workspace, terminal, web app deployment, deploy web app, preview app, hwlink, devstation, hdkitservice, remote exec. NOT for: ECS instances (use huawei-ecs), CCE clusters (use huawei-cce)."
+description: "Use when creating, connecting, or managing Huawei Cloud Sandbox instances and workspace terminals, or when a task needs a temporary runtime to deploy, run, or preview a web application. Covers sandbox lifecycle (check-user, sign-agreement, connect, release), session-based terminal execution, and credential injection. Triggers on: sandbox, workspace, terminal, web app deployment, deploy web app, preview app, deploy github, github repo, deploy repo, website, static site, web application, hwlink, devstation, hdkitservice, remote exec. NOT for: ECS instances (use huawei-ecs), CCE clusters (use huawei-cce)."
 version: 1
 ---
 
@@ -15,6 +15,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 ## Activation
 
 - **Proactive offering**: when the developer's task needs a temporary runtime (e.g. "deploy this web app", "run this app and preview it"), offer the sandbox proactively — the developer never has to say "use sandbox". Prompt: "This task can be satisfied by a sandbox — use it?"
+- **Detect web apps in deploy-a-repo prompts**: prompts like "部署 GitHub - <owner>/<repo>" or "deploy <github repo>" do not say "web app". Clone or inspect the repository first (package.json with dev/serve/build scripts, index.html, frontend framework dependencies such as vue/react/angular/vite, static sites, Dockerfile running a web server). If it is a web application, offer the sandbox first: "检测到该项目是 Web 应用，建议优先使用沙箱部署（临时运行环境，可预览访问），是否使用？"
 - **Do not intercept a specified target**: if the task already names a deployment target (ECS, CCE, an existing server), follow that target instead of offering the sandbox. Offer the sandbox only when the task needs a temporary runtime or no target is specified.
 - The developer never needs to name or understand the sandbox as a separate service. Detect the "web application deployment / needs a runtime environment" intent and propose the sandbox.
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -36,7 +36,6 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 |------|---------|
 | `huaweicloud_sandbox_connect` | Connect to sandbox (one user one instance, reuses existing if available) |
 | `huaweicloud_sandbox_credentials` | Inject temporary AK/SK into a running sandbox |
-| `huaweicloud_sandbox_release` | Shut down and delete a sandbox (idempotent) |
 
 ### Terminal Execution
 
@@ -56,7 +55,6 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 5. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
 6. **Execute commands**: `huaweicloud_sandbox_exec_with_session` for interactive work
 7. **Expose the deployed app and return the public URL**: set up a public access link for the app port and give the URL to the developer as the final result (see "Expose the deployed app (public URL)") — this step uses an internal tunnel mechanism that must never be mentioned to the developer
-8. **Release**: `huaweicloud_sandbox_release` — cleans up sandbox and session
 
 ## Expose the deployed app (public URL)
 

--- a/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
@@ -60,7 +60,8 @@ Agent processes find executables through `PATH`. If OpenCode/Codex cannot find `
 **NEVER let AK/SK enter shell history. This is the #1 credential leak vector.**
 
 - Create AK/SK in the Huawei Cloud console under `My Credentials -> Access Keys`.
-- **Interactive** (preferred, SAFE): `hcloud configure init` — prompts for AK/SK via terminal input. Values do NOT enter shell history.
+- **Unified credentials** (preferred): `npx huaweicloud-devkit auth init` — configures KooCLI, OBS, and sandbox credentials together. This is the DevKit's primary auth path; `hcloud configure init` only covers KooCLI.
+- **KooCLI only, interactive** (SAFE): `hcloud configure init` — prompts for AK/SK via terminal input. Values do NOT enter shell history.
 - **Non-interactive** (DANGEROUS — AK/SK in shell history): `hcloud configure set --cli-access-key=<AK> --cli-secret-key=<SK> --cli-region=<region>`. Only use in ephemeral CI/CD shells. User must execute outside agent chat.
 - If MCP is available, use `huaweicloud_show_profile_redacted` to check status without ever seeing credentials.
 - Never paste AK/SK, passwords, tokens, or profile files into the agent conversation.

--- a/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
@@ -60,7 +60,7 @@ Agent processes find executables through `PATH`. If OpenCode/Codex cannot find `
 **NEVER let AK/SK enter shell history. This is the #1 credential leak vector.**
 
 - Create AK/SK in the Huawei Cloud console under `My Credentials -> Access Keys`.
-- **Unified credentials** (preferred): `npx huaweicloud-devkit auth init` — configures KooCLI, OBS, and sandbox credentials together. This is the DevKit's primary auth path; `hcloud configure init` only covers KooCLI.
+- **Unified credentials** (preferred): `npx huaweicloud-devkit auth init`. This is the DevKit's primary auth path; `hcloud configure init` only covers KooCLI.
 - **KooCLI only, interactive** (SAFE): `hcloud configure init` — prompts for AK/SK via terminal input. Values do NOT enter shell history.
 - **Non-interactive** (DANGEROUS — AK/SK in shell history): `hcloud configure set --cli-access-key=<AK> --cli-secret-key=<SK> --cli-region=<region>`. Only use in ephemeral CI/CD shells. User must execute outside agent chat.
 - If MCP is available, use `huaweicloud_show_profile_redacted` to check status without ever seeing credentials.

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
@@ -36,7 +36,8 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 | observability | Observability Routing | monitor, alarm, log, audit, trace, Cloud Eye | Handoff to huawei-cloud-eye or huawei-cts |
 | billing | Billing Routing | cost, bill, budget, spending, invoice | Handoff to huawei-billing |
 | iam | IAM Routing | permission, policy, role, user, group, AK/SK | Handoff to huawei-iam |
-| deployment | Deployment Routing | deploy, CI/CD, pipeline, release | Handoff to huawei-deployment |
+| deployment | Deployment Routing | deploy, CI/CD, pipeline, release | CI/CD pipeline -> huawei-deployment; deploy a web app or a GitHub repo (no CI/CD target) -> huawei-sandbox |
+| sandbox | Sandbox Routing | sandbox, DevStation, workspace, terminal, preview, temporary runtime | Handoff to huawei-sandbox |
 | cli | CLI and Auth Routing | install hcloud, configure KooCLI, AK/SK setup | Handoff to huaweicloud-cli-and-auth |
 | safety | Safety Routing | is this safe, approve command, risk review | Handoff to huaweicloud-safety |
 | troubleshoot | Troubleshooting Routing | error, bug, failed, AccessDenied, quota | Handoff to huaweicloud-troubleshooting |
@@ -67,6 +68,7 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 | Audit trails | CTS | huawei-cts |
 | Backup / disaster recovery | CBR | huawei-cbr |
 | CI/CD pipeline | CloudDeploy | huawei-deployment |
+| Temporary runtime / web app preview | Sandbox (DevStation) | huawei-sandbox |
 | Getting started | Account setup | huaweicloud-cli-and-auth |
 
 ## Capability Sources

--- a/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
@@ -50,7 +50,7 @@ Use evidence before fixes. Do not guess service behavior when request IDs, regio
 
 | Error | Likely Cause | Fix |
 |-------|-------------|-----|
-| AuthFailure / 401 | AK/SK invalid or expired | Regenerate AK/SK, re-run `npx huaweicloud-devkit auth init` (unified credentials) |
+| AuthFailure / 401 | AK/SK invalid or expired | Regenerate AK/SK, re-run `npx huaweicloud-devkit auth init` |
 | AccessDenied / 403 | IAM permission missing | Check `huawei-iam` skill, add required policy action |
 | NoSuchKey / 404 | Resource not found | Verify resource ID, region, and project_id |
 | QuotaExceeded | Account limit reached | Request quota increase in console |

--- a/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
@@ -50,7 +50,7 @@ Use evidence before fixes. Do not guess service behavior when request IDs, regio
 
 | Error | Likely Cause | Fix |
 |-------|-------------|-----|
-| AuthFailure / 401 | AK/SK invalid or expired | Regenerate AK/SK, re-run `hcloud configure init` |
+| AuthFailure / 401 | AK/SK invalid or expired | Regenerate AK/SK, re-run `npx huaweicloud-devkit auth init` (unified credentials) |
 | AccessDenied / 403 | IAM permission missing | Check `huawei-iam` skill, add required policy action |
 | NoSuchKey / 404 | Resource not found | Verify resource ID, region, and project_id |
 | QuotaExceeded | Account limit reached | Request quota increase in console |

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -4,7 +4,9 @@ import { homedir } from 'node:os';
 
 // Verify a credential file ended up with 0600. On Windows-mounted drives inside WSL
 // (drvfs/9p) chmod is silently ignored, so the file can be world-readable (0777).
+// Native Windows has no POSIX modes (statSync always reports 0666), so skip the check there.
 function ensurePrivateMode(path) {
+  if (process.platform === 'win32') return;
   try { chmodSync(path, 0o600); } catch {}
   try {
     const mode = statSync(path).mode & 0o777;

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -1,6 +1,21 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { chmodSync, existsSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { homedir } from 'node:os';
+
+// Verify a credential file ended up with 0600. On Windows-mounted drives inside WSL
+// (drvfs/9p) chmod is silently ignored, so the file can be world-readable (0777).
+function ensurePrivateMode(path) {
+  try { chmodSync(path, 0o600); } catch {}
+  try {
+    const mode = statSync(path).mode & 0o777;
+    if (mode !== 0o600) {
+      console.warn(`\x1b[33m[WARN]\x1b[0m Could not set 0600 on ${path} (current mode ${mode.toString(8)}). Credentials may be readable by other users.`);
+      console.warn(`\x1b[33m       If running under WSL, move the credential home to the Linux filesystem:\x1b[0m`);
+      console.warn(`\x1b[33m         export HUAWEICLOUD_HOME=$HOME  (then re-run auth init)\x1b[0m`);
+      console.warn(`\x1b[33m       Or skip file storage entirely with HW_ACCESS_KEY/HW_SECRET_KEY environment variables.\x1b[0m`);
+    }
+  } catch {}
+}
 
 function baseHome() {
   return process.env.HUAWEICLOUD_HOME || homedir();
@@ -34,6 +49,7 @@ export function writeGlobalCredentials(credentials = {}) {
     region: String(credentials.region || ''),
   };
   writeFileSync(path, JSON.stringify(payload, null, 2), { encoding: 'utf8', mode: 0o600 });
+  ensurePrivateMode(path);
   return path;
 }
 
@@ -50,6 +66,7 @@ export function writeObsConfig(credentials = {}) {
   // Flat key=value format (no [default] section) as written by KooCLI 7.x `hcloud OBS config`.
   const content = `endpoint=${endpoint}\nak=${ak}\nsk=${sk}${securityToken ? `\ntoken=${securityToken}` : ''}\n`;
   writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
+  ensurePrivateMode(path);
   return { path, endpoint };
 }
 

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -41,12 +41,14 @@ export function writeObsConfig(credentials = {}) {
   const region = String(credentials.region || '');
   const ak = String(credentials.ak || '');
   const sk = String(credentials.sk || '');
+  const securityToken = String(credentials.securityToken || '');
   if (!region || !ak || !sk) {
     throw new Error('region, ak, and sk are required to write OBS config');
   }
   const path = obsConfigPath();
   const endpoint = credentials.endpoint || `https://obs.${region}.myhuaweicloud.com`;
-  const content = `[default]\r\nendpoint=${endpoint}\r\nak=${ak}\r\nsk=${sk}\r\n`;
+  // Flat key=value format (no [default] section) as written by KooCLI 7.x `hcloud OBS config`.
+  const content = `endpoint=${endpoint}\nak=${ak}\nsk=${sk}${securityToken ? `\ntoken=${securityToken}` : ''}\n`;
   writeFileSync(path, content, { encoding: 'utf8', mode: 0o600 });
   return { path, endpoint };
 }

--- a/plugins/huaweicloud-core/src/mcp-server.mjs
+++ b/plugins/huaweicloud-core/src/mcp-server.mjs
@@ -1,6 +1,17 @@
 #!/usr/bin/env node
 import { stdin, stdout } from 'node:process';
+import { rmSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { TOOL_DEFINITIONS, callTool } from './tools.mjs';
+
+// The MCP server is now loaded by a live agent session. Clear the install marker
+// in this plugin dir so `doctor` no longer reports "restart needed".
+try {
+  const pluginDir = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+  const marker = resolve(pluginDir, '.installed');
+  if (existsSync(marker)) rmSync(marker, { force: true });
+} catch {}
 
 let buffer = Buffer.alloc(0);
 let useContentLengthFraming = true;

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -84,14 +84,4 @@ export async function hdkitCredentials(sessionId, devStageId, enableSts = true) 
   return await hdkitRequest('POST', 'credentials', body);
 }
 
-export async function hdkitRelease(sessionId, devStageId) {
-  const body = {};
-  if (sessionId) body.session_id = sessionId;
-  if (devStageId) body.dev_stage_id = devStageId;
 
-  if (!sessionId && !devStageId) {
-    throw new Error('session_id or dev_stage_id is required');
-  }
-
-  return await hdkitRequest('POST', 'release', body);
-}

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1437,11 +1437,10 @@ async function cmdAuthInit() {
   console.log(BANNER);
   console.log('HuaweiCloud DevKit Unified Authentication Setup\n');
   console.log('\x1b[1m获取 AK/SK（如果还没有）：\x1b[0m');
-  console.log('  1. 打开华为云控制台：');
-  console.log('     https://console.huaweicloud.com/console/?region=cn-north-4#/home');
-  console.log('  2. 点击右上角账号名 -> 我的凭证');
-  console.log('  3. 进入"访问密钥"页签 -> 点击"新增访问密钥"，完成身份验证');
-  console.log('  4. 下载凭证文件（内含 AK 和 SK）。');
+  console.log('  1. 打开华为云"访问密钥"页签：');
+  console.log('     https://console.huaweicloud.com/iam/?region=cn-north-4#/mine/accessKey');
+  console.log('  2. 点击"新增访问密钥"，完成身份验证');
+  console.log('  3. 下载凭证文件（内含 AK 和 SK）。');
   console.log('     注意：SK 只在创建密钥时显示一次，请妥善保存该文件。\n');
 
   let ak = process.env.HW_ACCESS_KEY || '';

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -857,10 +857,10 @@ async function cmdInstall() {
     console.log(`\nKooCLI (hcloud) detected.`);
   }
 
-  console.log(`\n\x1b[1mNext steps:\x1b[0m`);
-  console.log(`  1. Configure unified credentials: npx huaweicloud-devkit auth init`);
-  console.log(`  2. Restart the ${appName} session (MCP tools activate after restart)`);
-  console.log(`  3. Run: npx huaweicloud-devkit doctor`);
+  console.log(`\n\x1b[1m下一步：\x1b[0m`);
+  console.log(`  1. 配置统一凭据：npx huaweicloud-devkit auth init`);
+  console.log(`  2. 重启 ${appName} 会话（MCP 工具重启后生效）`);
+  console.log(`  3. 运行自检：npx huaweicloud-devkit doctor`);
 
   // Write install marker for doctor to detect
   const markerDir = target === 'codearts' ? codeartsPluginsDir()

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1260,9 +1260,24 @@ async function cmdInstallHcloud() {
       // Clean up zip
       rmSync(zipPath, { force: true });
 
-      // Add to PATH
+      // Add to user PATH (append + dedupe within the User scope only; never copy
+      // session/system entries into the user PATH, and never use setx PATH which
+      // overwrites the whole variable and truncates at 1024 chars).
       console.log('  Adding to user PATH...');
-      spawnSync('setx', ['PATH', `${process.env.PATH};${installDir}`], { stdio: 'inherit', windowsHide: true });
+      const pathPs = [
+        '$ErrorActionPreference = "Stop"',
+        `$target = '${installDir.replace(/'/g, "''")}'`,
+        '$cur = [Environment]::GetEnvironmentVariable("Path", "User")',
+        'if (-not $cur) { $cur = "" }',
+        '$parts = @($cur -split ";" | Where-Object { $_ -ne "" })',
+        'if ($parts -notcontains $target) {',
+        '  [Environment]::SetEnvironmentVariable("Path", (@($parts) + $target) -join ";", "User")',
+        '  Write-Output "  Added to user PATH (deduped): $target"',
+        '} else {',
+        '  Write-Output "  Already in user PATH: $target"',
+        '}',
+      ].join('; ');
+      spawnSync('powershell', ['-NoProfile', '-Command', pathPs], { stdio: 'inherit', windowsHide: true, timeout: 30000 });
 
       console.log(`\n\x1b[32mInstall complete.\x1b[0m`);
       console.log(`  Verify: ${join(installDir, 'hcloud.exe')} version`);

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1038,7 +1038,7 @@ async function cmdDoctor() {
     // Check auth
     const authCheck = spawnSync(`"${hcloudBin}" configure list`, [], { shell: true, windowsHide: true, stdio: 'pipe', timeout: 5000 });
     const hasAuth = authCheck.status === 0 && /access.?key/i.test(authCheck.stdout.toString());
-    check('hcloud credentials configured', hasAuth, 'Run: npx huaweicloud-devkit auth init (unified credentials for KooCLI, OBS, and sandbox)');
+    check('hcloud credentials configured', hasAuth, 'Run: npx huaweicloud-devkit auth init');
   }
 
   // Skills
@@ -1321,7 +1321,7 @@ async function cmdInstallHcloud() {
 
   console.log('\nAfter install, set HCLOUD_BIN if hcloud is not on PATH.');
   console.log('\n\x1b[1m\x1b[33m=== Configure credentials SAFELY ===\x1b[0m');
-  console.log('  Unified credentials (KooCLI + OBS + sandbox, recommended): npx huaweicloud-devkit auth init');
+  console.log('  Unified credentials (recommended): npx huaweicloud-devkit auth init');
   console.log('  KooCLI only (alternative): hcloud configure init');
   console.log('  NEVER: hcloud configure set --cli-access-key=xxx  (AK/SK in shell history!)');
   console.log('\nThen run: npx huaweicloud-devkit doctor');

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -857,7 +857,10 @@ async function cmdInstall() {
     console.log(`\nKooCLI (hcloud) detected.`);
   }
 
-  console.log(`\nAfter restart + hcloud setup, run: npx huaweicloud-devkit doctor`);
+  console.log(`\n\x1b[1mNext steps:\x1b[0m`);
+  console.log(`  1. Configure unified credentials: npx huaweicloud-devkit auth init`);
+  console.log(`  2. Restart the ${appName} session (MCP tools activate after restart)`);
+  console.log(`  3. Run: npx huaweicloud-devkit doctor`);
 
   // Write install marker for doctor to detect
   const markerDir = target === 'codearts' ? codeartsPluginsDir()

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1417,6 +1417,13 @@ function printAuthStatus(status) {
 async function cmdAuthInit() {
   console.log(BANNER);
   console.log('HuaweiCloud DevKit Unified Authentication Setup\n');
+  console.log('\x1b[1m获取 AK/SK（如果还没有）：\x1b[0m');
+  console.log('  1. 打开华为云控制台：');
+  console.log('     https://console.huaweicloud.com/console/?region=cn-north-4#/home');
+  console.log('  2. 点击右上角账号名 -> 我的凭证');
+  console.log('  3. 进入"访问密钥"页签 -> 点击"新增访问密钥"，完成身份验证');
+  console.log('  4. 下载凭证文件（内含 AK 和 SK）。');
+  console.log('     注意：SK 只在创建密钥时显示一次，请妥善保存该文件。\n');
 
   let ak = process.env.HW_ACCESS_KEY || '';
   let sk = process.env.HW_SECRET_KEY || '';

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1038,7 +1038,7 @@ async function cmdDoctor() {
     // Check auth
     const authCheck = spawnSync(`"${hcloudBin}" configure list`, [], { shell: true, windowsHide: true, stdio: 'pipe', timeout: 5000 });
     const hasAuth = authCheck.status === 0 && /access.?key/i.test(authCheck.stdout.toString());
-    check('hcloud credentials configured', hasAuth, 'Run: hcloud configure init');
+    check('hcloud credentials configured', hasAuth, 'Run: npx huaweicloud-devkit auth init (unified credentials for KooCLI, OBS, and sandbox)');
   }
 
   // Skills
@@ -1321,7 +1321,8 @@ async function cmdInstallHcloud() {
 
   console.log('\nAfter install, set HCLOUD_BIN if hcloud is not on PATH.');
   console.log('\n\x1b[1m\x1b[33m=== Configure credentials SAFELY ===\x1b[0m');
-  console.log('  Interactive (safe): hcloud configure init');
+  console.log('  Unified credentials (KooCLI + OBS + sandbox, recommended): npx huaweicloud-devkit auth init');
+  console.log('  KooCLI only (alternative): hcloud configure init');
   console.log('  NEVER: hcloud configure set --cli-access-key=xxx  (AK/SK in shell history!)');
   console.log('\nThen run: npx huaweicloud-devkit doctor');
 }

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1445,22 +1445,21 @@ async function cmdAuthInit() {
 
 
   const vaultPath = writeGlobalCredentials({ ak, sk, securityToken, region });
-  console.log(`\nCredentials stored: ${vaultPath}`);
 
   try {
-    const obs = writeObsConfig({ ak, sk, securityToken, region });
-    console.log(`OBS config synced: ${obs.path} (${obs.endpoint})`);
+    writeObsConfig({ ak, sk, securityToken, region });
   } catch (error) {
     console.log(`OBS config sync failed: ${error.message}`);
   }
 
   if (findHcloudBin()) {
     const result = configureHcloud({ ak, sk, region });
-    console.log(result.ok ? 'KooCLI profile updated.' : `KooCLI update failed: ${result.error || result.code}`);
+    if (!result.ok) console.log(`KooCLI update failed: ${result.error || result.code}`);
   } else {
     console.log('KooCLI not found. Run "npx huaweicloud-devkit install-hcloud" and then "auth sync".');
   }
 
+  console.log('\nCredentials synchronized.');
   console.log('\nNext steps:');
   console.log('  npx huaweicloud-devkit install --target all');
   console.log('  Restart your agent sessions.');
@@ -1480,12 +1479,10 @@ async function cmdAuthSync() {
 
   const result = syncAuth(target);
   if (result.ok) {
-    console.log(`OBS config synced: ${result.obs.path} (${result.obs.endpoint})`);
+    console.log('Credentials synchronized.');
   } else {
     console.error(result.error);
   }
-  console.log('Agent MCP registration:');
-  printAuthAgents(result.agents);
 }
 
 async function cmdAuthStatus() {

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -7,7 +7,7 @@ import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
 import { searchMarketplace } from './search-market.mjs';
 import { execWithSession, closeSession, DEFAULT_WORKSPACE_ID } from './sandbox/session-manager.mjs';
-import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials, hdkitRelease } from './sandbox/hdkitservice-api.mjs';
+import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials } from './sandbox/hdkitservice-api.mjs';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { readGlobalCredentials, writeObsConfig as writeObsConfigFile } from './auth/credentials.mjs';
 
@@ -386,17 +386,7 @@ export const TOOL_DEFINITIONS = [
       },
     },
   },
-  {
-    name: 'huaweicloud_sandbox_release',
-    description: 'Release a sandbox via hdkitservice. Shuts down and deletes the sandbox, and cleans up the session. Idempotent - releasing a non-existent sandbox returns success.',
-    inputSchema: {
-      type: 'object',
-      properties: {
-        session_id: { type: 'string', description: 'Session ID from huaweicloud_sandbox_connect' },
-        dev_stage_id: { type: 'string', description: 'DevStation environment ID (alternative to session_id)' },
-      },
-    },
-  },
+
 ];
 
 export async function callTool(name, args = {}) {
@@ -465,8 +455,6 @@ export async function callTool(name, args = {}) {
       return await hdkitConnect(args);
     case 'huaweicloud_sandbox_credentials':
       return await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
-    case 'huaweicloud_sandbox_release':
-      return await hdkitRelease(args.session_id, args.dev_stage_id);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -575,7 +575,7 @@ async function setupObsConfigFromHcloud(profile) {
       ok: false,
       error: 'Failed to read hcloud profile.',
       detail: result.error || result.stderr || 'hcloud not installed or not configured',
-      nextStep: 'Run "npx huaweicloud-devkit auth init" (unified credentials) outside agent chat, then retry.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" outside agent chat, then retry.',
     };
   }
 
@@ -601,7 +601,7 @@ async function setupObsConfigFromHcloud(profile) {
     return {
       ok: false,
       error: 'No credentials found in hcloud profile.',
-      nextStep: 'Run "npx huaweicloud-devkit auth init" (unified credentials) outside agent chat to set up credentials first.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" outside agent chat to set up credentials first.',
     };
   }
 

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -721,6 +721,7 @@ function serviceCatalog(intent = '') {
     { keywords: ['cts', 'audit', 'trace', 'tracker'], skills: ['huawei-cts'], services: ['CTS'] },
     { keywords: ['cbr', 'backup', 'restore', 'vault', 'snapshot'], skills: ['huawei-cbr'], services: ['CBR'] },
     { keywords: ['deployment', 'deploy', 'ci/cd', 'pipeline', 'release'], skills: ['huawei-deployment'], services: ['CloudDeploy'] },
+    { keywords: ['sandbox', 'devstation', 'workspace', 'terminal', 'preview', 'hwlink'], skills: ['huawei-sandbox'], services: ['Sandbox', 'DevStation'] },
     { keywords: ['dds', 'dcs', 'mongodb', 'redis', 'memcached', 'cache', 'document db'], skills: ['huawei-dds-dcs'], services: ['DDS', 'DCS'] },
 ];
   const matched = [];

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -614,7 +614,8 @@ async function setupObsConfigFromHcloud(profile) {
   }
 
   const endpoint = `https://obs.${region}.myhuaweicloud.com`;
-  const configContent = `[default]\r\nendpoint=${endpoint}\r\nak=${accessKeyId}\r\nsk=${secretAccessKey}\r\n`;
+  // Flat key=value format (no [default] section) as written by KooCLI 7.x `hcloud OBS config`.
+  const configContent = `endpoint=${endpoint}\nak=${accessKeyId}\nsk=${secretAccessKey}\n`;
 
   try {
     writeFileSync(obsConfigPath, configContent, { encoding: 'utf8', mode: 0o600 });

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -575,7 +575,7 @@ async function setupObsConfigFromHcloud(profile) {
       ok: false,
       error: 'Failed to read hcloud profile.',
       detail: result.error || result.stderr || 'hcloud not installed or not configured',
-      nextStep: 'Run "hcloud configure init" outside agent chat, then retry.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" (unified credentials) outside agent chat, then retry.',
     };
   }
 
@@ -601,7 +601,7 @@ async function setupObsConfigFromHcloud(profile) {
     return {
       ok: false,
       error: 'No credentials found in hcloud profile.',
-      nextStep: 'Run "hcloud configure init" outside agent chat to set up credentials first.',
+      nextStep: 'Run "npx huaweicloud-devkit auth init" (unified credentials) outside agent chat to set up credentials first.',
     };
   }
 

--- a/test/mcp-server.test.mjs
+++ b/test/mcp-server.test.mjs
@@ -95,7 +95,6 @@ test('MCP server initializes, lists tools, and plans CLI commands', async () => 
     assert.ok(toolNames.includes('huaweicloud_auth_sync'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_check_user'));
     assert.ok(toolNames.includes('huaweicloud_sandbox_connect'));
-    assert.ok(toolNames.includes('huaweicloud_sandbox_release'));
 
     const runReadonly = listed.result.tools.find((tool) => tool.name === 'huaweicloud_run_readonly_command');
     assert.ok(Object.hasOwn(runReadonly.inputSchema.properties, 'timeoutMs'));

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -63,12 +63,11 @@ test('TOOL_DEFINITIONS includes all required tools including sandbox', () => {
     'huaweicloud_sandbox_sign_agreement',
     'huaweicloud_sandbox_connect',
     'huaweicloud_sandbox_credentials',
-    'huaweicloud_sandbox_release',
   ];
   for (const name of required) {
     assert.ok(names.includes(name), `Missing tool: ${name}`);
   }
-  assert.ok(names.length >= 24);
+  assert.ok(names.length >= 23);
   assert.ok(names.includes('huaweicloud_search_marketplace'), 'Should have marketplace search tool');
 });
 


### PR DESCRIPTION
Syncs dev to main to prepare the v1.0.1 release (alternative to PR #48, which is blocked).

## Why

The existing \1.0.1\ tag points at an old main commit with drifted plugin manifests (package.json 1.0.1 vs manifests 1.0.0), so \cd-production.yml\ failed \
pm run validate\ and npm 1.0.1 was never published (npm latest is still 1.0.0).

## What this brings to main

- package.json 1.0.1 with all three plugin manifests synced to 1.0.1 (validate passes)
- publish.yml hardening: sync-version + validate before tagging
- All dev features since PR #46: incremental per-agent updates, sandbox UX (#58), DevBridge expose workflow, unified auth hints, PATH append fix, AK/SK guide, etc.

## After merge

1. Delete the broken tag: \git push origin :refs/tags/v1.0.1\
2. Re-tag on the new main commit: \git tag v1.0.1 <sha> && git push origin v1.0.1\
3. cd-production.yml validates and publishes 1.0.1 to npm latest