### PR TITLE
feat(skills): sandbox-first scenario routing for free/quick web app deployment

### DIFF
--- a/plugins/huaweicloud-core/skills/huaweicloud-capability-discovery/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-capability-discovery/SKILL.md
@@ -22,6 +22,17 @@ Use this skill to turn vague developer intent into a precise Huawei Cloud capabi
 8. Treat Terraform as a secondary V1 path for reviewed IaC, not the default.
 9. When no built-in devkit skill matches, browse the community skill marketplace at https://github.com/huaweicloud/huaweicloud-skills. Fetch the index from https://raw.githubusercontent.com/huaweicloud/huaweicloud-skills/master/skills-index/index.json.
 
+## Scenario Routing
+
+Match the scenario before picking a service. For "deploy a web app" requests, layer the recommendation instead of defaulting to a production service:
+
+| Scenario | Recommended path |
+|----------|------------------|
+| hello world / prototype / demo / temporary preview (free, quick try) | `huawei-sandbox` first — temporary runtime + public URL, ~8h validity, zero billed resources |
+| production / long-term / custom domain / high availability | `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce` for containers) |
+
+Route to the sandbox when the developer signals free/quick preview intent ("免费", "快速", "预览", "hello world", "原型", "演示"); route to production services only when production-grade hosting is explicitly required.
+
 ## Region Intent
 
 - Extract region intent from the user's words before querying. Examples: Singapore -> `ap-southeast-3` first, Hong Kong -> `ap-southeast-2`, Beijing -> `cn-north-4`, Shanghai -> `cn-east-3`.

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
@@ -48,7 +48,7 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 
 | Workload | Primary Service | Skill |
 |----------|----------------|-------|
-| Web application hosting | ECS | huawei-ecs |
+| Web application hosting (production / long-term) | ECS | huawei-ecs |
 | Containerized microservices | CCE | huawei-cce |
 | Static file storage / CDN | OBS | huawei-obs |
 | Relational database (MySQL/PG) | RDS | huawei-rds |
@@ -70,6 +70,8 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 | CI/CD pipeline | CloudDeploy | huawei-deployment |
 | Temporary runtime / web app preview | Sandbox (DevStation) | huawei-sandbox |
 | Getting started | Account setup | huaweicloud-cli-and-auth |
+
+**Web app scenario layering**: for "deploy a web app", prefer `huawei-sandbox` for free/quick try (hello world, prototype, demo, temporary preview — temporary runtime + public URL, ~8h validity, zero billed resources); route to `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce`) for production / long-term / custom-domain / high-availability hosting.
 
 ## Capability Sources
 

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/references/select.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/references/select.md
@@ -26,3 +26,13 @@ Route based on answers:
 - SQL + massive scale / distributed -> huawei-gaussdb
 - Document model (MongoDB-compatible) -> huawei-dds-dcs
 - Cache / key-value -> huawei-dds-dcs (DCS)
+
+## Example: I need to deploy a web app
+
+Ask:
+- Is this a quick try / prototype / demo / temporary preview (free)?
+- Or production (long-term, custom domain, high availability)?
+
+Route by scenario:
+- Free / quick try / prototype / demo / temporary preview -> huawei-sandbox (temporary runtime + public URL, ~8h validity, zero billed resources)
+- Production / long-term / custom domain / high availability -> huawei-functiongraph / huawei-ecs (or huawei-cce for containers)


### PR DESCRIPTION
## Summary

Closes #76

When a user asks WorkBuddy to "deploy a hello world web app to Huawei Cloud for free", the meta-skills currently route toward FunctionGraph/ECS, even though the free sandbox (DevStation) + tunnel is the better fit for quick/free previews. This PR adds scenario-layered routing to the three routing meta-skills so free/quick-try web requests land on the sandbox first.

## Changes

- `huaweicloud-capability-discovery/SKILL.md`: new **Scenario Routing** section — free/quick preview → `huawei-sandbox` first; production / long-term / custom-domain / HA → FunctionGraph / ECS / CCE.
- `huaweicloud-core/SKILL.md`: Service Map marks "Web application hosting" as production/long-term, and adds a **Web app scenario layering** note.
- `huaweicloud-core/references/select.md`: adds a "deploy a web app" decision example that routes by scenario.

## Routing rule

| Scenario | Recommended path |
|---|---|
| hello world / prototype / demo / temporary preview (free, quick try) | `huawei-sandbox` (temporary runtime + public URL, ~8h validity, zero billed resources) |
| production / long-term / custom domain / high availability | `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce`) |

## Verification

- `npm test` → 86 passed
- `npm run validate` → Validated HuaweiCloud Devkit with 28 skills