### PR TITLE
docs(workbuddy): document install → restart → verify flow and MCP registration blind spot

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,8 @@ npx --yes huaweicloud-devkit install --target workbuddy
 
 **Restart the session** after installation.
 
+> **Install → restart → verify.** `install --target workbuddy` writes the MCP registration to `~/.workbuddy/mcp.json`, but MCP tools only activate after you restart the WorkBuddy session. Verify with `npx huaweicloud-devkit doctor` (it flags a pending restart) or `npx huaweicloud-devkit status --target workbuddy`. If the sandbox MCP tools are missing mid-session, restart the session — don't hand-write an MCP bridge client.
+
 ```bash
 npx --yes huaweicloud-devkit doctor
 npx --yes huaweicloud-devkit status --target workbuddy

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -76,6 +76,8 @@ npx --yes huaweicloud-devkit install --target workbuddy
 
 安装后**重启会话**。
 
+> **安装 → 重启 → 验证。** `install --target workbuddy` 会把 MCP 注册写入 `~/.workbuddy/mcp.json`，但 MCP 工具需重启 WorkBuddy 会话后才生效。运行 `npx huaweicloud-devkit doctor`（会标记待重启）或 `npx huaweicloud-devkit status --target workbuddy` 验证。若会话内 sandbox MCP 工具不可用，请重启会话，不要手写 MCP 桥接客户端。
+
 ```bash
 npx --yes huaweicloud-devkit doctor
 npx --yes huaweicloud-devkit status --target workbuddy


### PR DESCRIPTION
Closes #77

## What was verified

Issue #77 reports that after `install --target workbuddy`, MCP tools are not registered in the current session (requiring a session restart), and the agent had to hand-write an MCP stdio bridge client. Independent verification of the current `dev` tree found:

- **Restart prompt (proposed fix #2) — already implemented.** `install` prints an aggressive `MCP 工具在重启 <Agent> 会话后才生效` warning box and a `下一步` (next-steps) block that explicitly says to restart the session (commit `ba0be6b`, `b18d65c`, `77e8292`).
- **Doctor pending-restart detection (proposed fix #3) — already implemented.** `doctor` detects a `.installed` marker and shows a `请重启 <Agent>！MCP 工具尚未激活` box; the marker is cleared once the MCP server actually loads (commit `304d45d`).

## What was changed (proposed fix #4)

The remaining gap was documentation. The WorkBuddy section of the README only said `Restart the session` without explaining the MCP-registration blind spot or how to verify. Added an explicit **install → restart → verify** note (English + Chinese) covering:

- `install --target workbuddy` writes MCP registration to `~/.workbuddy/mcp.json`, but tools only activate after restarting the WorkBuddy session.
- Verify with `doctor` (flags a pending restart) or `status --target workbuddy`.
- If sandbox MCP tools are missing mid-session, restart instead of hand-writing an MCP bridge client.

Files: `README.md`, `README.zh-CN.md` (2 lines each).

## Deferred

Proposed fix #1 (CLI fallback subcommands such as `devkit sandbox connect/exec`, `devkit tunnel host`) is a larger feature that introduces new CLI surface area and is out of scope for this documentation-only change; it can be tracked separately.