### PR TITLE
feat(dsh): add DeepSeek Harness target support

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -31,6 +31,34 @@ hcloud configure init  # 配置 AK/SK 和区域
 
 将 `integrations/opencode/opencode.json` 中的 MCP 配置合并到你的 OpenCode 配置中。
 
+## 安装插件 (DeepSeek Harness)
+
+```bash
+npx --yes huaweicloud-devkit install --target dsh
+```
+
+安装器会写入：
+
+- `$DSH_HOME/skills`：华为云 Skills。
+- `$DSH_HOME/huaweicloud-plugins`：MCP Server 和安全策略。
+- `$DSH_HOME/profiles/web/cordis.patch.yml`：DSH MCP 注册补丁。
+
+如果没有设置 `DSH_HOME`，默认使用 `~/.dsh`。安装后重启 DSH 会话。
+
+常用命令：
+
+```bash
+npx --yes huaweicloud-devkit status --target dsh
+npx --yes huaweicloud-devkit update --target dsh
+npx --yes huaweicloud-devkit uninstall --target dsh
+```
+
+如提示 DSH MCP 客户端未检测到，请执行：
+
+```bash
+npx @deepseek-ai/dsh plugin --profile web add @deepseek-ai/dsh-mcp-client
+```
+
 ## 验证
 
 ```bash
@@ -39,8 +67,8 @@ npm run validate
 ```
 
 预期输出：
-- 16 个测试全部通过
-- "Validated HuaweiCloud Devkit with 11 skills."
+- 测试全部通过
+- "Validated HuaweiCloud Devkit with 28 skills."
 
 ## 开发环境
 
@@ -67,5 +95,5 @@ huaweicloud-devkit/
 ├── integrations/opencode/              # OpenCode 集成
 ├── scripts/                            # 安装与校验脚本
 ├── test/                               # 测试套件
-└── docs/                               # 设计文档
+└── docs/                               # 设计文档，含 DSH 集成说明
 ```

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Help AI coding agents use Huawei Cloud safely and accurately — a single integration that gives agents cloud knowledge, CLI tooling, and safety guardrails.
 
-Supports OpenCode, Codex, CodeArts Agent, and WorkBuddy.
+Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, and DeepSeek Harness (DSH).
 
 ## Prerequisites
 
@@ -85,6 +85,29 @@ npx --yes huaweicloud-devkit uninstall --target workbuddy
 
 > **Updating**: `update` is incremental per agent — it refreshes only the installed files and leaves your config untouched. Use `update --target all` to update every installed agent at once.
 
+### DeepSeek Harness (DSH)
+
+```bash
+npx --yes huaweicloud-devkit install --target dsh
+```
+
+The installer copies Skills to `$DSH_HOME/skills`, installs the MCP server and
+safety policy under `$DSH_HOME/huaweicloud-plugins`, and maintains
+`$DSH_HOME/profiles/web/cordis.patch.yml`. **Restart the DSH session** after
+installation.
+
+```bash
+npx --yes huaweicloud-devkit doctor
+npx --yes huaweicloud-devkit status --target dsh
+npx --yes huaweicloud-devkit update --target dsh
+npx --yes huaweicloud-devkit uninstall --target dsh
+```
+
+> DSH V1 reuses the existing MCP server through
+> `@deepseek-ai/dsh-mcp-client`. If the installer reports that the DSH MCP
+> client is not detected, run:
+> `npx @deepseek-ai/dsh plugin --profile web add @deepseek-ai/dsh-mcp-client`.
+
 ### Other Agents
 
 For agents that support the Model Context Protocol (MCP):
@@ -125,6 +148,7 @@ ECS, OBS, VPC, IAM, RDS, GaussDB, FunctionGraph, APIG, CCE, SMN/DMS, ModelArts, 
 - [Architecture](docs/architecture.md)
 - [Safety Model](docs/safety-model.md)
 - [Hook Rule Model](docs/hook-rule-model.md)
+- [DeepSeek Harness Integration](docs/dsh-integration.md)
 - [Changelog](docs/CHANGELOG.md)
 - [KooCLI official docs](https://support.huaweicloud.com/qs-hcli/hcli_02_003.html)
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 帮助 AI 编码助手安全、准确地使用华为云——一站式集成云知识、CLI 工具和安全护栏。
 
-支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy。
+支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）。
 
 ## 前置条件
 
@@ -85,6 +85,27 @@ npx --yes huaweicloud-devkit uninstall --target workbuddy
 
 > **更新机制**：`update` 按 agent 增量更新，只刷新必要文件、不动你的配置文件。`update --target all` 可一次更新所有已安装的 agent。
 
+### DeepSeek Harness（DSH）
+
+```bash
+npx --yes huaweicloud-devkit install --target dsh
+```
+
+安装器会把 Skills 写入 `$DSH_HOME/skills`，把 MCP Server 和安全策略写入
+`$DSH_HOME/huaweicloud-plugins`，并自动维护
+`$DSH_HOME/profiles/web/cordis.patch.yml`。安装后**重启 DSH 会话**。
+
+```bash
+npx --yes huaweicloud-devkit doctor
+npx --yes huaweicloud-devkit status --target dsh
+npx --yes huaweicloud-devkit update --target dsh
+npx --yes huaweicloud-devkit uninstall --target dsh
+```
+
+> DSH V1 通过 `@deepseek-ai/dsh-mcp-client` 复用现有 MCP Server。
+> 如果安装器提示 DSH MCP 客户端未检测到，请按提示执行
+> `npx @deepseek-ai/dsh plugin --profile web add @deepseek-ai/dsh-mcp-client`。
+
 ### 其他 Agent
 
 支持 MCP 协议的 Agent，手动配置：
@@ -125,6 +146,7 @@ ECS、OBS、VPC、IAM、RDS、GaussDB、FunctionGraph、APIG、CCE、SMN/DMS、M
 - [架构](docs/architecture.md)
 - [安全模型](docs/safety-model.md)
 - [Hook 规则模型](docs/hook-rule-model.md)
+- [DeepSeek Harness 集成](docs/dsh-integration.md)
 - [变更记录](docs/CHANGELOG.md)
 - [KooCLI 官方文档](https://support.huaweicloud.com/qs-hcli/hcli_02_003.html)
 

--- a/docs/dsh-integration.md
+++ b/docs/dsh-integration.md
@@ -1,0 +1,102 @@
+# DeepSeek Harness Integration
+
+HuaweiCloud DevKit supports DeepSeek Harness (DSH) through the existing MCP
+server and Skills. V1 does not ship a native Cordis plugin because the MCP path
+keeps the Huawei Cloud tool schema, safety policy, and KooCLI wrapper shared
+across agents.
+
+## Architecture
+
+```mermaid
+flowchart LR
+  User["Developer in DSH"] --> DSH["DeepSeek Harness profile: web"]
+  DSH --> Client["@deepseek-ai/dsh-mcp-client"]
+  Client --> MCP["HuaweiCloud DevKit MCP Server"]
+  MCP --> Skills["Huawei Cloud Skills"]
+  MCP --> Safety["Safety Policy and Hook Risk Rules"]
+  MCP --> KooCLI["KooCLI hcloud"]
+```
+
+## Installation Layout
+
+`npx --yes huaweicloud-devkit install --target dsh` writes these files:
+
+- `$DSH_HOME/skills`: Huawei Cloud Skills used by DSH skill discovery.
+- `$DSH_HOME/huaweicloud-plugins/src`: the local MCP server implementation.
+- `$DSH_HOME/huaweicloud-plugins/safety`: shared safety policy and risk rules.
+- `$DSH_HOME/profiles/web/cordis.patch.yml`: a managed Cordis patch row that
+  connects DSH to the Huawei Cloud MCP server.
+
+If `DSH_HOME` is not set, the installer uses `~/.dsh`.
+
+## Managed Patch
+
+The installer owns only the block between these markers:
+
+```yaml
+# HuaweiCloud DevKit DSH integration start
+- insert:
+    - id: mcp-huaweicloud
+      name: '@deepseek-ai/dsh-mcp-client'
+      config:
+        serverName: huaweicloud
+        transport: stdio
+        command: node
+        args:
+          - '<DSH_HOME>/huaweicloud-plugins/src/mcp-server.mjs'
+        env:
+          HUAWEICLOUD_AGENT_TOOLKIT_MODE: local
+          HDKITSERVICE_ENDPOINT: ''
+        failOnStartupError: false
+# HuaweiCloud DevKit DSH integration end
+```
+
+Existing user patch entries are preserved. `update --target dsh` replaces the
+managed block in place, and `uninstall --target dsh` removes only that block.
+
+## Commands
+
+```bash
+npx --yes huaweicloud-devkit install --target dsh
+npx --yes huaweicloud-devkit status --target dsh
+npx --yes huaweicloud-devkit update --target dsh
+npx --yes huaweicloud-devkit uninstall --target dsh
+```
+
+After install or update, restart the DSH session so the MCP client can load the
+new patch.
+
+## MCP Client Dependency
+
+DSH needs `@deepseek-ai/dsh-mcp-client` in the `web` profile. The installer
+detects an existing package and tries a best-effort local installation when DSH
+or pnpm is available. If it cannot install the package automatically, run:
+
+```bash
+npx @deepseek-ai/dsh plugin --profile web add @deepseek-ai/dsh-mcp-client
+```
+
+If pnpm is missing, enable it first:
+
+```bash
+corepack enable pnpm
+```
+
+## Safety And Auth
+
+The DSH target uses the same MCP tools as other agents:
+
+- read-only KooCLI inspection by default;
+- explicit user approval for write-capable commands;
+- command, artifact, and deployment-plan risk checks;
+- credential redaction and no secret writes into agent configuration.
+
+Use `npx --yes huaweicloud-devkit auth init` to configure the shared credential
+vault, then restart DSH. `auth status --target dsh` reports whether the DSH MCP
+registration is present without printing credentials.
+
+## Future Native Cordis Support
+
+A native Cordis plugin can be considered later if DSH becomes a primary agent
+runtime for Huawei Cloud users. Until then, the MCP adapter keeps V1 smaller,
+safer, and easier to regression test.

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
         "codex",
         "opencode",
         "workbuddy",
+        "dsh",
+        "deepseek-harness",
         "mcp",
         "koocli",
         "hcloud"

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 
-export const SUPPORTED_AGENT_TARGETS = ['opencode', 'codex', 'codex-desktop', 'codearts', 'workbuddy'];
+export const SUPPORTED_AGENT_TARGETS = ['opencode', 'codex', 'codex-desktop', 'codearts', 'workbuddy', 'dsh'];
 
 function baseHome() {
   return process.env.HUAWEICLOUD_HOME || homedir();
@@ -71,6 +71,23 @@ function workbuddyRegistered() {
   return Boolean(cfg?.mcpServers?.['huaweicloud-devkit']);
 }
 
+function dshRoot() {
+  return process.env.DSH_HOME || join(baseHome(), '.dsh');
+}
+
+function dshRegistered() {
+  const patchPath = join(dshRoot(), 'profiles', 'web', 'cordis.patch.yml');
+  if (!existsSync(patchPath)) return false;
+  try {
+    const patch = readFileSync(patchPath, 'utf8');
+    return patch.includes('id: mcp-huaweicloud')
+      && patch.includes("@deepseek-ai/dsh-mcp-client")
+      && patch.includes('serverName: huaweicloud');
+  } catch {
+    return false;
+  }
+}
+
 export function getAgentRegistrationStatuses(target = 'all') {
   const requested = target === 'all' ? SUPPORTED_AGENT_TARGETS : [target];
   const result = { target, agents: {} };
@@ -81,6 +98,7 @@ export function getAgentRegistrationStatuses(target = 'all') {
     if (agent === 'codex') configured = codexCliRegistered();
     if (agent === 'codearts') configured = codeartsRegistered();
     if (agent === 'workbuddy') configured = workbuddyRegistered();
+    if (agent === 'dsh') configured = dshRegistered();
     result.agents[agent] = { configured };
   }
   return result;

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -995,6 +995,12 @@ function uninstallDsh() {
       }
     }
     if (removed > 0) console.log(`  Removed ${removed} skills`);
+    try {
+      if (readdirSync(skillsDir).length === 0) {
+        rmSync(skillsDir, { recursive: true, force: true });
+        console.log(`  Removed empty skills directory: ${skillsDir}`);
+      }
+    } catch {}
   }
   if (removeIfExists(dshPluginsDir())) {
     console.log('  Removed MCP server and safety policy');

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -57,6 +57,15 @@ function workbuddySkillsDir() { return join(homedir(), '.workbuddy', 'skills'); 
 function workbuddyMcpConfigFile() { return join(homedir(), '.workbuddy', 'mcp.json'); }
 function workbuddyPluginsDir() { return join(homedir(), '.workbuddy', 'huaweicloud-plugins'); }
 
+function dshRoot() { return process.env.DSH_HOME || join(homedir(), '.dsh'); }
+function dshSkillsDir() { return join(dshRoot(), 'skills'); }
+function dshProfileDir() { return join(dshRoot(), 'profiles', 'web'); }
+function dshPatchFile() { return join(dshProfileDir(), 'cordis.patch.yml'); }
+function dshPluginsDir() { return join(dshRoot(), 'huaweicloud-plugins'); }
+
+const DSH_MCP_PATCH_START = '# HuaweiCloud DevKit DSH integration start';
+const DSH_MCP_PATCH_END = '# HuaweiCloud DevKit DSH integration end';
+
 // Detect CodeArts sandbox mode (bash_mode in permission config).
 function detectCodeartsSandbox() {
   try {
@@ -759,6 +768,255 @@ function workbuddyStatus() {
   }
 }
 
+function dshMcpServerPath() {
+  return join(dshPluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
+}
+
+function dshPatchBlock() {
+  const hcloudBin = findHcloudBin();
+  const envLines = [
+    '          HUAWEICLOUD_AGENT_TOOLKIT_MODE: local',
+    "          HDKITSERVICE_ENDPOINT: ''",
+  ];
+  if (hcloudBin) {
+    envLines.push(`          HCLOUD_BIN: '${hcloudBin.replace(/\\/g, '/').replace(/'/g, "''")}'`);
+  }
+  return [
+    DSH_MCP_PATCH_START,
+    '- insert:',
+    '    - id: mcp-huaweicloud',
+    "      name: '@deepseek-ai/dsh-mcp-client'",
+    '      config:',
+    '        serverName: huaweicloud',
+    '        transport: stdio',
+    '        command: node',
+    '        args:',
+    `          - '${dshMcpServerPath().replace(/'/g, "''")}'`,
+    '        env:',
+    ...envLines,
+    '        failOnStartupError: false',
+    DSH_MCP_PATCH_END,
+  ].join('\n');
+}
+
+function escapeRegExp(value) {
+  return String(value).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function removeManagedDshPatchBlock(content) {
+  const pattern = new RegExp(`\\n?${escapeRegExp(DSH_MCP_PATCH_START)}[\\s\\S]*?${escapeRegExp(DSH_MCP_PATCH_END)}\\s*`, 'g');
+  return String(content || '').replace(pattern, '\n').replace(/\n{3,}/g, '\n\n').trimEnd();
+}
+
+function dshPatchHasOnlyCommentsOrEmptyList(content) {
+  const meaningful = String(content || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line && !line.startsWith('#'));
+  return meaningful.length === 0 || (meaningful.length === 1 && meaningful[0] === '[]');
+}
+
+function ensureDshMcpPatch() {
+  const patchFile = dshPatchFile();
+  const existing = existsSync(patchFile) ? readFileSync(patchFile, 'utf8') : '';
+  const cleaned = removeManagedDshPatchBlock(existing);
+  const block = dshPatchBlock();
+  let next;
+  if (dshPatchHasOnlyCommentsOrEmptyList(cleaned)) {
+    const prefix = cleaned
+      .split(/\r?\n/)
+      .filter((line) => line.trim() !== '[]')
+      .join('\n')
+      .trimEnd();
+    next = `${prefix ? `${prefix}\n` : ''}${block}\n`;
+  } else {
+    next = `${cleaned}\n\n${block}\n`;
+  }
+  if (existing.replace(/\r\n/g, '\n') === next) {
+    console.log(`  DSH patch unchanged: ${patchFile}`);
+    return false;
+  }
+  mkdirSync(dirname(patchFile), { recursive: true });
+  writeFileSync(patchFile, next);
+  console.log(`  DSH patch updated: ${patchFile}`);
+  return true;
+}
+
+function removeDshMcpPatch() {
+  const patchFile = dshPatchFile();
+  if (!existsSync(patchFile)) return false;
+  const existing = readFileSync(patchFile, 'utf8');
+  const cleaned = removeManagedDshPatchBlock(existing);
+  if (cleaned === existing.trimEnd()) return false;
+  const prefix = cleaned
+    .split(/\r?\n/)
+    .filter((line) => line.trim() !== '[]')
+    .join('\n')
+    .trimEnd();
+  const next = dshPatchHasOnlyCommentsOrEmptyList(cleaned)
+    ? `${prefix ? `${prefix}\n` : ''}[]\n`
+    : `${cleaned}\n`;
+  writeFileSync(patchFile, next);
+  console.log(`  DSH patch cleaned: ${patchFile}`);
+  return true;
+}
+
+function dshPatchConfigured() {
+  const patchFile = dshPatchFile();
+  if (!existsSync(patchFile)) return false;
+  try {
+    const patch = readFileSync(patchFile, 'utf8');
+    return patch.includes('id: mcp-huaweicloud')
+      && patch.includes("@deepseek-ai/dsh-mcp-client")
+      && patch.includes('serverName: huaweicloud');
+  } catch {
+    return false;
+  }
+}
+
+function commandAvailable(command, args = ['--version']) {
+  try {
+    const r = spawnSync(command, args, { shell: false, windowsHide: true, stdio: 'pipe', timeout: 10000 });
+    if (r.status === 0) return true;
+  } catch {}
+  if (process.platform === 'win32') {
+    try {
+      const w = spawnSync('where.exe', [command], { windowsHide: true, stdio: 'pipe', timeout: 10000 });
+      return w.status === 0 && w.stdout.toString().trim().length > 0;
+    } catch {}
+  }
+  return false;
+}
+
+function dshMcpClientAvailable() {
+  const modulePath = join('node_modules', '@deepseek-ai', 'dsh-mcp-client', 'package.json');
+  const candidates = [
+    join(dshProfileDir(), modulePath),
+    join(dshRoot(), 'profiles', modulePath),
+    join(dshRoot(), modulePath),
+  ];
+  if (candidates.some((p) => existsSync(p))) return true;
+  const pkgPath = join(dshProfileDir(), 'package.json');
+  if (!existsSync(pkgPath)) return false;
+  try {
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8'));
+    return Boolean(pkg.dependencies?.['@deepseek-ai/dsh-mcp-client']
+      || pkg.devDependencies?.['@deepseek-ai/dsh-mcp-client']);
+  } catch {
+    return false;
+  }
+}
+
+function tryInstallDshMcpClient() {
+  if (process.env.HUAWEICLOUD_DEVKIT_SKIP_DSH_PLUGIN_INSTALL === '1') {
+    console.log('  DSH MCP client install skipped by environment');
+    return false;
+  }
+  if (dshMcpClientAvailable()) {
+    console.log('  DSH MCP client package detected');
+    return true;
+  }
+  if (commandAvailable('dsh')) {
+    const r = spawnSync('dsh', ['plugin', '--profile', 'web', 'add', '@deepseek-ai/dsh-mcp-client'], {
+      env: { ...process.env, DSH_HOME: dshRoot() },
+      windowsHide: true,
+      stdio: 'pipe',
+      timeout: 60000,
+    });
+    if (r.status === 0) {
+      console.log('  DSH MCP client package installed via dsh');
+      return true;
+    }
+    const err = `${r.stderr || ''}${r.stdout || ''}`.trim().split(/\r?\n/).slice(-2).join(' ');
+    console.log(`  \x1b[33m[WARN]\x1b[0m DSH MCP client auto-install failed${err ? `: ${err}` : ''}`);
+  }
+  if (commandAvailable('pnpm') && existsSync(join(dshProfileDir(), 'package.json'))) {
+    const r = spawnSync('pnpm', ['--dir', dshProfileDir(), 'add', '@deepseek-ai/dsh-mcp-client'], {
+      windowsHide: true,
+      stdio: 'pipe',
+      timeout: 60000,
+    });
+    if (r.status === 0) {
+      console.log('  DSH MCP client package installed via pnpm');
+      return true;
+    }
+  }
+  console.log('  \x1b[33m[WARN]\x1b[0m DSH MCP client package not detected.');
+  console.log('  Manual: npx @deepseek-ai/dsh plugin --profile web add @deepseek-ai/dsh-mcp-client');
+  console.log('  If pnpm is missing, run: corepack enable pnpm');
+  return false;
+}
+
+async function installDsh() {
+  const skillsSrc = join(PLUGIN_ROOT, 'skills');
+  const srcDir = join(PLUGIN_ROOT, 'src');
+  const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginDest = dshPluginsDir();
+
+  copyDir(skillsSrc, dshSkillsDir());
+  console.log(`  Skills -> ${dshSkillsDir()}`);
+  copyDir(srcDir, join(pluginDest, 'src'));
+  console.log(`  MCP Server -> ${join(pluginDest, 'src')}`);
+  copyDir(safetyDir, join(pluginDest, 'safety'));
+  console.log(`  Safety Policy -> ${join(pluginDest, 'safety')}`);
+  ensureDshMcpPatch();
+  tryInstallDshMcpClient();
+  mkdirSync(pluginDest, { recursive: true });
+  writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
+}
+
+async function updateDsh() {
+  const skillsSrc = join(PLUGIN_ROOT, 'skills');
+  const srcDir = join(PLUGIN_ROOT, 'src');
+  const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginDest = dshPluginsDir();
+
+  copyDir(skillsSrc, dshSkillsDir());
+  const stale = pruneStale(dshSkillsDir(), skillsSrc);
+  console.log(`  Skills updated -> ${dshSkillsDir()}${stale > 0 ? ` (removed ${stale} stale)` : ''}`);
+  copyDir(srcDir, join(pluginDest, 'src'));
+  console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
+  copyDir(safetyDir, join(pluginDest, 'safety'));
+  console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
+  ensureDshMcpPatch();
+  tryInstallDshMcpClient();
+  mkdirSync(pluginDest, { recursive: true });
+  writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
+}
+
+function uninstallDsh() {
+  const skillsDir = dshSkillsDir();
+  let removed = 0;
+  if (existsSync(skillsDir)) {
+    for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+      if (entry.name.startsWith('huawei')) {
+        removeIfExists(join(skillsDir, entry.name));
+        removed++;
+      }
+    }
+    if (removed > 0) console.log(`  Removed ${removed} skills`);
+  }
+  if (removeIfExists(dshPluginsDir())) {
+    console.log('  Removed MCP server and safety policy');
+  }
+  removeDshMcpPatch();
+}
+
+function dshStatus() {
+  const pluginDir = dshPluginsDir();
+  const skillsDir = dshSkillsDir();
+  console.log(`  MCP Server: ${existsSync(join(pluginDir, 'src', 'mcp-server.mjs')) ? '\x1b[32mInstalled\x1b[0m' : '\x1b[31mNot installed\x1b[0m'}`);
+  console.log(`  Safety Policy: ${existsSync(join(pluginDir, 'safety', 'policy.json')) ? '\x1b[32mInstalled\x1b[0m' : '\x1b[31mNot installed\x1b[0m'}`);
+  let skillCount = 0;
+  if (existsSync(skillsDir)) {
+    skillCount = readdirSync(skillsDir, { withFileTypes: true })
+      .filter((d) => d.isDirectory() && d.name.startsWith('huawei')).length;
+  }
+  console.log(`  Skills: ${skillCount > 0 ? `\x1b[32m${skillCount} installed\x1b[0m` : '\x1b[31mNot installed\x1b[0m'}`);
+  console.log(`  DSH patch: ${dshPatchConfigured() ? '\x1b[32mConfigured\x1b[0m' : '\x1b[31mNot configured\x1b[0m'}`);
+  console.log(`  DSH MCP client package: ${dshMcpClientAvailable() ? '\x1b[32mDetected\x1b[0m' : '\x1b[33mCheck DSH profile\x1b[0m'}`);
+}
+
 function opencodeStatus() {
   const pluginDir = opencodePluginsDir();
   const skillsDir = opencodeSkillsDir();
@@ -789,6 +1047,7 @@ function parseTarget() {
   if (val === 'codex-desktop') return 'codex-desktop';
   if (val === 'codearts') return 'codearts';
   if (val === 'workbuddy') return 'workbuddy';
+  if (val === 'dsh') return 'dsh';
   if (val === 'all') return 'all';
   return 'opencode';
 }
@@ -815,6 +1074,10 @@ async function cmdInstall() {
     console.log('\n[WorkBuddy]');
     await installWorkBuddy();
   }
+  if (target === 'dsh' || target === 'all') {
+    console.log('\n[DSH]');
+    await installDsh();
+  }
   if (target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
     if (!hasCodexCLI()) {
@@ -837,11 +1100,13 @@ async function cmdInstall() {
     } else {
       installCodex();
     }
-  }  console.log(`\n\x1b[32mInstallation complete!\x1b[0m`);
+  }
+  console.log(`\n\x1b[32mInstallation complete!\x1b[0m`);
   const appName = target === 'codearts' ? 'CodeArts'
     : target === 'codex-desktop' ? 'Codex Desktop'
     : target === 'codex' ? 'Codex'
     : target === 'workbuddy' ? 'WorkBuddy'
+    : target === 'dsh' ? 'DSH'
     : 'OpenCode';
   const pad = ' '.repeat(24 - appName.length);
   console.log(`\n\x1b[1m\x1b[33m╔══════════════════════════════════════════════════════╗`);
@@ -864,7 +1129,8 @@ async function cmdInstall() {
   console.log(`  3. 运行自检：npx huaweicloud-devkit doctor`);
 
   // Write install marker for doctor to detect
-  const markerDir = target === 'codearts' ? codeartsPluginsDir()
+  const markerDir = target === 'dsh' ? dshPluginsDir()
+    : target === 'codearts' ? codeartsPluginsDir()
     : target === 'workbuddy' ? workbuddyPluginsDir()
     : target === 'codex-desktop' ? codexDesktopPluginsDir()
     : opencodePluginsDir();
@@ -881,6 +1147,9 @@ async function cmdInstall() {
   }
   if (target === 'workbuddy' || target === 'all') {
     console.log('Or describe your Huawei Cloud task in WorkBuddy');
+  }
+  if (target === 'dsh' || target === 'all') {
+    console.log('Or describe your Huawei Cloud task in DSH');
   }
 }
 
@@ -900,6 +1169,10 @@ async function cmdUninstall() {
   if (target === 'workbuddy' || target === 'all') {
     console.log('\n[WorkBuddy]');
     uninstallWorkBuddy();
+  }
+  if (target === 'dsh' || target === 'all') {
+    console.log('\n[DSH]');
+    uninstallDsh();
   }
   if (target === 'codex-desktop' || target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
@@ -945,6 +1218,10 @@ async function cmdStatus() {
     console.log('\n[WorkBuddy]');
     workbuddyStatus();
   }
+  if (target === 'dsh' || target === 'all') {
+    console.log('\n[DSH]');
+    dshStatus();
+  }
   if (target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
     if (!hasCodexCLI()) {
@@ -972,16 +1249,22 @@ async function cmdDoctor() {
   // Node.js
   check('Node.js >= 20', process.versions.node.split('.')[0] >= 20, 'Run: nvm install 20 && nvm use 20');
 
-    // MCP server — check OpenCode, Codex Desktop, CodeArts, and WorkBuddy paths
+    // MCP server — check OpenCode, Codex Desktop, CodeArts, WorkBuddy, and DSH paths
   const opencodePluginDir = opencodePluginsDir();
   const codexPluginDir = codexDesktopPluginsDir();
+  const codeartsPluginDir = codeartsPluginsDir();
   const workbuddyPluginDir = workbuddyPluginsDir();
+  const dshPluginDir = dshPluginsDir();
   const mcpOk = existsSync(join(opencodePluginDir, 'src', 'mcp-server.mjs'))
     || existsSync(join(codexPluginDir, 'src', 'mcp-server.mjs'))
-    || existsSync(join(workbuddyPluginDir, 'src', 'mcp-server.mjs'));
+    || existsSync(join(codeartsPluginDir, 'src', 'mcp-server.mjs'))
+    || existsSync(join(workbuddyPluginDir, 'src', 'mcp-server.mjs'))
+    || existsSync(join(dshPluginDir, 'src', 'mcp-server.mjs'));
   const mcpTarget = existsSync(join(opencodePluginDir, 'src', 'mcp-server.mjs')) ? 'OpenCode'
     : existsSync(join(codexPluginDir, 'src', 'mcp-server.mjs')) ? 'Codex Desktop'
-    : existsSync(join(workbuddyPluginDir, 'src', 'mcp-server.mjs')) ? 'WorkBuddy' : '';
+    : existsSync(join(codeartsPluginDir, 'src', 'mcp-server.mjs')) ? 'CodeArts'
+    : existsSync(join(workbuddyPluginDir, 'src', 'mcp-server.mjs')) ? 'WorkBuddy'
+    : existsSync(join(dshPluginDir, 'src', 'mcp-server.mjs')) ? 'DSH' : '';
   check('MCP server installed', mcpOk, 'Run: npx huaweicloud-devkit install');
 
   if (mcpOk) {
@@ -990,10 +1273,12 @@ async function cmdDoctor() {
 
   const safetyOk = existsSync(join(opencodePluginDir, 'safety', 'policy.json'))
     || existsSync(join(codexPluginDir, 'safety', 'policy.json'))
-    || existsSync(join(workbuddyPluginDir, 'safety', 'policy.json'));
+    || existsSync(join(codeartsPluginDir, 'safety', 'policy.json'))
+    || existsSync(join(workbuddyPluginDir, 'safety', 'policy.json'))
+    || existsSync(join(dshPluginDir, 'safety', 'policy.json'));
   check('Safety policy installed', safetyOk, 'Run: npx huaweicloud-devkit install');
 
-  // MCP config — check OpenCode, Codex Desktop, and WorkBuddy
+  // MCP config — check OpenCode, Codex Desktop, CodeArts, WorkBuddy, and DSH
   let mcpConfigured = false;
   let mcpCfgTarget = '';
   const opencodeCfg = opencodeConfigFile();
@@ -1010,12 +1295,23 @@ async function cmdDoctor() {
       if (cfg.includes('[mcp_servers.huaweicloud-devkit]')) { mcpConfigured = true; mcpCfgTarget = 'Codex Desktop'; }
     } catch {}
   }
+  const codeartsCfg = codeartsMcpSettingsFile();
+  if (!mcpConfigured && existsSync(codeartsCfg)) {
+    try {
+      const cfg = JSON.parse(readFileSync(codeartsCfg, 'utf8'));
+      if (cfg.mcpServers && cfg.mcpServers['huaweicloud-devkit']) { mcpConfigured = true; mcpCfgTarget = 'CodeArts'; }
+    } catch {}
+  }
   const workbuddyCfg = workbuddyMcpConfigFile();
   if (!mcpConfigured && existsSync(workbuddyCfg)) {
     try {
       const cfg = JSON.parse(readFileSync(workbuddyCfg, 'utf8'));
       if (cfg.mcpServers && cfg.mcpServers['huaweicloud-devkit']) { mcpConfigured = true; mcpCfgTarget = 'WorkBuddy'; }
     } catch {}
+  }
+  if (!mcpConfigured && dshPatchConfigured()) {
+    mcpConfigured = true;
+    mcpCfgTarget = 'DSH';
   }
   check('MCP configured', mcpConfigured, mcpCfgTarget ? `Found in ${mcpCfgTarget} config` : 'Run: npx huaweicloud-devkit install');
 
@@ -1046,7 +1342,7 @@ async function cmdDoctor() {
   }
 
   // Skills
-  const skillsOptions = [opencodeSkillsDir(), codexDesktopSkillsDir(), codeartsSkillsDir(), workbuddySkillsDir()];
+  const skillsOptions = [opencodeSkillsDir(), codexDesktopSkillsDir(), codeartsSkillsDir(), workbuddySkillsDir(), dshSkillsDir()];
   let skillCount = 0, skillsDir = '', missingSkills = [];
   for (const dir of skillsOptions) {
     if (!existsSync(dir)) continue;
@@ -1091,6 +1387,7 @@ async function cmdDoctor() {
     { path: join(codexDesktopPluginsDir(), '.installed'), name: 'Codex Desktop' },
     { path: join(workbuddyPluginsDir(), '.installed'), name: 'WorkBuddy' },
     { path: join(codeartsPluginsDir(), '.installed'), name: 'CodeArts' },
+    { path: join(dshPluginsDir(), '.installed'), name: 'DSH' },
   ];
   for (const marker of installedMarkers) {
     if (existsSync(marker.path)) {
@@ -1172,6 +1469,18 @@ async function cmdUpdate() {
     return;
   }
 
+  if (target === 'dsh') {
+    if (!existsSync(join(dshPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
+      return;
+    }
+    console.log('[DSH]');
+    await updateDsh();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mRestart the DSH session for changes to take effect.\x1b[0m`);
+    return;
+  }
+
   if (target === 'all') {
     let updatedAny = false;
     if (existsSync(join(opencodePluginsDir(), 'src', 'mcp-server.mjs'))) {
@@ -1192,6 +1501,11 @@ async function cmdUpdate() {
     if (existsSync(join(workbuddyPluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\n[WorkBuddy]');
       await updateWorkBuddy();
+      updatedAny = true;
+    }
+    if (existsSync(join(dshPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\n[DSH]');
+      await updateDsh();
       updatedAny = true;
     }
     if (codexStatus()) {
@@ -1661,7 +1975,7 @@ async function main() {
     case '-h':
     default:
       console.log(BANNER);
-      console.log('Usage: npx huaweicloud-devkit <command> [--target <opencode|codex|codearts|workbuddy|all>]\n');
+      console.log('Usage: npx huaweicloud-devkit <command> [--target <opencode|codex|codearts|workbuddy|dsh|all>]\n');
       console.log('Commands:');
       console.log('  install      Install skills, MCP server, safety policy');
       console.log('  uninstall    Remove installed files');
@@ -1674,12 +1988,13 @@ async function main() {
       console.log('  proxy        Manage proxy config: init | show | clear');
       console.log('  help         Show this help');
       console.log('\nOptions:');
-      console.log('  --target     Target agent: opencode (default), codex, codearts, workbuddy, all');
+      console.log('  --target     Target agent: opencode (default), codex, codearts, workbuddy, dsh, all');
       console.log('\nExamples:');
       console.log('  npx huaweicloud-devkit install');
       console.log('  npx huaweicloud-devkit install --target codex');
       console.log('  npx huaweicloud-devkit install --target codearts');
       console.log('  npx huaweicloud-devkit install --target workbuddy');
+      console.log('  npx huaweicloud-devkit install --target dsh');
       console.log('  npx huaweicloud-devkit install --target all');
       console.log('  npx huaweicloud-devkit auth init');
       console.log('  npx huaweicloud-devkit auth sync --target all');

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -25,8 +25,13 @@ function workbuddySkillsDir() {
   const home = homedir();
   return join(home, '.workbuddy', 'skills');
 }
+function dshSkillsDir() {
+  const home = process.env.DSH_HOME || join(homedir(), '.dsh');
+  return join(home, 'skills');
+}
 function resolveSkillsRoot() {
   if (existsSync(SKILLS_ROOT_DEV)) return SKILLS_ROOT_DEV;
+  if (existsSync(dshSkillsDir())) return dshSkillsDir();
   if (existsSync(codeartsSkillsDir())) return codeartsSkillsDir();
   if (existsSync(opencodeSkillsDir())) return opencodeSkillsDir();
   if (existsSync(workbuddySkillsDir())) return workbuddySkillsDir();
@@ -295,7 +300,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        target: { type: 'string', description: 'Agent target to check: opencode, codex, codex-desktop, codearts, workbuddy, or all (default).' },
+        target: { type: 'string', description: 'Agent target to check: opencode, codex, codex-desktop, codearts, workbuddy, dsh, or all (default).' },
       },
     },
   },
@@ -305,7 +310,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        target: { type: 'string', description: 'Agent target to report after sync: opencode, codex, codex-desktop, codearts, workbuddy, or all (default).' },
+        target: { type: 'string', description: 'Agent target to report after sync: opencode, codex, codex-desktop, codearts, workbuddy, dsh, or all (default).' },
       },
     },
   },

--- a/test/auth-credentials.test.mjs
+++ b/test/auth-credentials.test.mjs
@@ -23,6 +23,7 @@ function withTempHome(fn) {
     HW_SECURITY_TOKEN: process.env.HW_SECURITY_TOKEN,
     HW_REGION: process.env.HW_REGION,
     HUAWEICLOUD_REGION: process.env.HUAWEICLOUD_REGION,
+    DSH_HOME: process.env.DSH_HOME,
   };
   process.env.HUAWEICLOUD_HOME = dir;
   delete process.env.HW_ACCESS_KEY;
@@ -30,6 +31,7 @@ function withTempHome(fn) {
   delete process.env.HW_SECURITY_TOKEN;
   delete process.env.HW_REGION;
   delete process.env.HUAWEICLOUD_REGION;
+  delete process.env.DSH_HOME;
   try {
     return fn(dir);
   } finally {

--- a/test/auth-credentials.test.mjs
+++ b/test/auth-credentials.test.mjs
@@ -96,6 +96,7 @@ test('auth sync writes OBS and reports all agent registration targets', () => {
     assert.ok(sync.agents['codex-desktop'] !== undefined);
     assert.ok(sync.agents.codearts !== undefined);
     assert.ok(sync.agents.workbuddy !== undefined);
+    assert.ok(sync.agents.dsh !== undefined);
   });
 });
 
@@ -113,6 +114,49 @@ test('agent registration detects OpenCode MCP config', () => {
   });
 });
 
+test('agent registration detects DSH cordis patch config', () => {
+  withTempHome((home) => {
+    const profileDir = join(home, '.dsh', 'profiles', 'web');
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(
+      join(profileDir, 'cordis.patch.yml'),
+      [
+        '- insert:',
+        '    - id: mcp-huaweicloud',
+        "      name: '@deepseek-ai/dsh-mcp-client'",
+        '      config:',
+        '        serverName: huaweicloud',
+        '',
+      ].join('\n'),
+      'utf8',
+    );
+    const status = getAgentRegistrationStatuses('dsh');
+    assert.equal(status.agents.dsh.configured, true);
+  });
+});
+
+test('agent registration detects DSH_HOME cordis patch config', () => {
+  withTempHome((home) => {
+    const previousDshHome = process.env.DSH_HOME;
+    const dshHome = join(home, 'custom-dsh');
+    try {
+      process.env.DSH_HOME = dshHome;
+      const profileDir = join(dshHome, 'profiles', 'web');
+      mkdirSync(profileDir, { recursive: true });
+      writeFileSync(
+        join(profileDir, 'cordis.patch.yml'),
+        "id: mcp-huaweicloud\nname: '@deepseek-ai/dsh-mcp-client'\nserverName: huaweicloud\n",
+        'utf8',
+      );
+      const status = getAgentRegistrationStatuses('dsh');
+      assert.equal(status.agents.dsh.configured, true);
+    } finally {
+      if (previousDshHome === undefined) delete process.env.DSH_HOME;
+      else process.env.DSH_HOME = previousDshHome;
+    }
+  });
+});
+
 test('auth status is redacted and reflects vault/OBS state', () => {
   withTempHome(() => {
     writeGlobalCredentials({ ak: 'STATUS_AK', sk: 'STATUS_SK', region: 'cn-north-4' });
@@ -121,6 +165,7 @@ test('auth status is redacted and reflects vault/OBS state', () => {
     assert.equal(status.credentialsConfigured, true);
     assert.equal(status.obsConfigured, true);
     assert.ok(status.agents.opencode !== undefined);
+    assert.ok(status.agents.dsh !== undefined);
     assert.doesNotMatch(JSON.stringify(status), /STATUS_AK|STATUS_SK/);
   });
 });

--- a/test/codearts-adaptation.test.mjs
+++ b/test/codearts-adaptation.test.mjs
@@ -182,7 +182,7 @@ test('cli help documents the codearts target', () => {
   try {
     const res = runCli(home, cwd, ['help']);
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|all>/);
+    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|all>/);
     assert.match(res.stdout, /install --target codearts/);
   } finally {
     rmSync(home, { recursive: true, force: true });

--- a/test/dsh-adaptation.test.mjs
+++ b/test/dsh-adaptation.test.mjs
@@ -165,10 +165,34 @@ test('dsh uninstall removes installed files and only the managed patch row', () 
     assert.match(uninstall.stdout, /Uninstall complete\./);
 
     assert.equal(countSkills(join(dshHome, 'skills')), 0, 'DSH skills removed');
+    assert.ok(!existsSync(join(dshHome, 'skills')), 'empty DSH skills dir removed');
     assert.ok(!existsSync(join(dshHome, 'huaweicloud-plugins')), 'DSH plugin dir removed');
     const patch = readPatch(dshHome);
     assert.equal(countMcpRows(patch), 0, patch);
     assert.doesNotMatch(patch, /@deepseek-ai\/dsh-mcp-client/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('dsh uninstall preserves non-Huawei skills directory entries', () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh-proj-'));
+  try {
+    const dshHome = join(home, '.dsh');
+    const customSkillDir = join(dshHome, 'skills', 'custom-skill');
+    mkdirSync(customSkillDir, { recursive: true });
+    writeFileSync(join(customSkillDir, 'SKILL.md'), 'name: custom-skill\n');
+
+    const install = runCli(home, cwd, ['install', '--target', 'dsh'], dshHome);
+    assert.equal(install.status, 0, install.stderr);
+
+    const uninstall = runCli(home, cwd, ['uninstall', '--target', 'dsh'], dshHome);
+    assert.equal(uninstall.status, 0, uninstall.stderr);
+
+    assert.ok(existsSync(customSkillDir), 'custom skill preserved');
+    assert.equal(countSkills(join(dshHome, 'skills')), 0, 'Huawei skills removed');
   } finally {
     rmSync(home, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });

--- a/test/dsh-adaptation.test.mjs
+++ b/test/dsh-adaptation.test.mjs
@@ -1,0 +1,190 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const setupCli = join(root, 'bin', 'setup.cjs');
+
+function makeEnv(home, dshHome) {
+  return {
+    ...process.env,
+    USERPROFILE: home,
+    HOME: home,
+    HOMEDRIVE: home.slice(0, 2),
+    HOMEPATH: home.slice(2),
+    DSH_HOME: dshHome,
+    HUAWEICLOUD_DEVKIT_SKIP_DSH_PLUGIN_INSTALL: '1',
+  };
+}
+
+function runCli(home, cwd, args, dshHome = join(home, '.dsh')) {
+  return spawnSync(process.execPath, [setupCli, ...args], {
+    cwd,
+    env: makeEnv(home, dshHome),
+    encoding: 'utf8',
+    timeout: 60000,
+  });
+}
+
+function countSkills(dir) {
+  if (!existsSync(dir)) return 0;
+  return readdirSync(dir, { withFileTypes: true })
+    .filter((d) => d.isDirectory() && d.name.startsWith('huawei'))
+    .length;
+}
+
+function readPatch(dshHome) {
+  const patchFile = join(dshHome, 'profiles', 'web', 'cordis.patch.yml');
+  return existsSync(patchFile) ? readFileSync(patchFile, 'utf8') : '';
+}
+
+function countMcpRows(patch) {
+  return (patch.match(/id: mcp-huaweicloud/g) || []).length;
+}
+
+test('dsh install copies skills, MCP server, safety policy, and patch row', () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh-proj-'));
+  try {
+    const dshHome = join(home, '.dsh-custom');
+    const res = runCli(home, cwd, ['install', '--target', 'dsh'], dshHome);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /\[DSH\]/);
+    assert.match(res.stdout, /Installation complete!/);
+
+    assert.ok(countSkills(join(dshHome, 'skills')) >= 6, 'DSH skills installed');
+    const pluginDir = join(dshHome, 'huaweicloud-plugins');
+    assert.ok(existsSync(join(pluginDir, 'src', 'mcp-server.mjs')));
+    assert.ok(existsSync(join(pluginDir, 'src', 'tools.mjs')));
+    assert.ok(existsSync(join(pluginDir, 'safety', 'policy.json')));
+    assert.ok(existsSync(join(pluginDir, '.installed')));
+
+    const patch = readPatch(dshHome);
+    assert.match(patch, /id: mcp-huaweicloud/);
+    assert.match(patch, /name: '@deepseek-ai\/dsh-mcp-client'/);
+    assert.match(patch, /serverName: huaweicloud/);
+    assert.match(patch, /transport: stdio/);
+    assert.match(patch, /failOnStartupError: false/);
+    assert.match(patch, /HUAWEICLOUD_AGENT_TOOLKIT_MODE: local/);
+    assert.match(patch, /HDKITSERVICE_ENDPOINT: ''/);
+    assert.doesNotMatch(patch, /\\/);
+    assert.match(patch, /huaweicloud-plugins\/src\/mcp-server\.mjs/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('dsh install is idempotent and preserves unrelated patch entries', () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh-proj-'));
+  try {
+    const dshHome = join(home, '.dsh');
+    const profileDir = join(dshHome, 'profiles', 'web');
+    const patchFile = join(profileDir, 'cordis.patch.yml');
+    const existingPatch = [
+      '# user patch',
+      '- insert:',
+      '    - id: user-plugin',
+      "      name: '@example/user-plugin'",
+      '',
+    ].join('\n');
+    mkdirSync(profileDir, { recursive: true });
+    writeFileSync(patchFile, existingPatch);
+
+    const first = runCli(home, cwd, ['install', '--target', 'dsh'], dshHome);
+    assert.equal(first.status, 0, first.stderr);
+    const second = runCli(home, cwd, ['install', '--target', 'dsh'], dshHome);
+    assert.equal(second.status, 0, second.stderr);
+
+    const patch = readPatch(dshHome);
+    assert.equal(countMcpRows(patch), 1, patch);
+    assert.match(patch, /id: user-plugin/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('dsh update refreshes installed files and keeps one patch row', () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh-proj-'));
+  try {
+    const dshHome = join(home, '.dsh');
+    const install = runCli(home, cwd, ['install', '--target', 'dsh'], dshHome);
+    assert.equal(install.status, 0, install.stderr);
+
+    const update = runCli(home, cwd, ['update', '--target', 'dsh'], dshHome);
+    assert.equal(update.status, 0, update.stderr);
+    assert.match(update.stdout, /Update complete/);
+
+    assert.ok(existsSync(join(dshHome, 'huaweicloud-plugins', 'src', 'mcp-server.mjs')));
+    assert.ok(countSkills(join(dshHome, 'skills')) >= 6);
+    assert.equal(countMcpRows(readPatch(dshHome)), 1);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('dsh status reports installed files and patch configuration', () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh-proj-'));
+  try {
+    const dshHome = join(home, '.dsh');
+    const install = runCli(home, cwd, ['install', '--target', 'dsh'], dshHome);
+    assert.equal(install.status, 0, install.stderr);
+
+    const status = runCli(home, cwd, ['status', '--target', 'dsh'], dshHome);
+    assert.equal(status.status, 0, status.stderr);
+    assert.match(status.stdout, /\[DSH\]/);
+    assert.match(status.stdout, /MCP Server: .*Installed/);
+    assert.match(status.stdout, /Safety Policy: .*Installed/);
+    assert.match(status.stdout, /Skills: .*\d+ installed/);
+    assert.match(status.stdout, /DSH patch: .*Configured/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('dsh uninstall removes installed files and only the managed patch row', () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh-proj-'));
+  try {
+    const dshHome = join(home, '.dsh');
+    const install = runCli(home, cwd, ['install', '--target', 'dsh'], dshHome);
+    assert.equal(install.status, 0, install.stderr);
+
+    const uninstall = runCli(home, cwd, ['uninstall', '--target', 'dsh'], dshHome);
+    assert.equal(uninstall.status, 0, uninstall.stderr);
+    assert.match(uninstall.stdout, /Uninstall complete\./);
+
+    assert.equal(countSkills(join(dshHome, 'skills')), 0, 'DSH skills removed');
+    assert.ok(!existsSync(join(dshHome, 'huaweicloud-plugins')), 'DSH plugin dir removed');
+    const patch = readPatch(dshHome);
+    assert.equal(countMcpRows(patch), 0, patch);
+    assert.doesNotMatch(patch, /@deepseek-ai\/dsh-mcp-client/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('cli help documents the dsh target', () => {
+  const home = mkdtempSync(join(tmpdir(), 'dsh-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'dsh-proj-'));
+  try {
+    const res = runCli(home, cwd, ['help']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|all>/);
+    assert.match(res.stdout, /install --target dsh/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -244,11 +244,11 @@ test('setup-cli.mjs supports the codearts target end to end', () => {
   const branches = setup.match(/target === 'codearts' \|\| target === 'all'/g);
   assert.ok(branches && branches.length >= 3, `codearts dispatch branches: ${branches?.length}`);
   // .installed marker goes to the codearts plugins dir
-  assert.match(setup, /const markerDir = target === 'codearts' \? codeartsPluginsDir\(\)\s+: target === 'workbuddy' \? workbuddyPluginsDir\(\)\s+: target === 'codex-desktop' \? codexDesktopPluginsDir\(\)\s+: opencodePluginsDir\(\);/);
+  assert.match(setup, /const markerDir = target === 'dsh' \? dshPluginsDir\(\)\s+: target === 'codearts' \? codeartsPluginsDir\(\)\s+: target === 'workbuddy' \? workbuddyPluginsDir\(\)\s+: target === 'codex-desktop' \? codexDesktopPluginsDir\(\)\s+: opencodePluginsDir\(\);/);
   // doctor checks the codearts skills dir alongside opencode
-  assert.match(setup, /const skillsOptions = \[opencodeSkillsDir\(\), codexDesktopSkillsDir\(\), codeartsSkillsDir\(\), workbuddySkillsDir\(\)\];/);
+  assert.match(setup, /const skillsOptions = \[opencodeSkillsDir\(\), codexDesktopSkillsDir\(\), codeartsSkillsDir\(\), workbuddySkillsDir\(\), dshSkillsDir\(\)\];/);
   // help text documents the target
-  assert.match(setup, /--target <opencode\|codex\|codearts\|workbuddy\|all>/);
+  assert.match(setup, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|all>/);
   assert.match(setup, /install --target codearts/);
 });
 
@@ -280,4 +280,59 @@ test('setup-cli.mjs handles KooCLI sandbox blockers and privacy agreement', () =
   assert.match(setup, /if \(hcloudBin\) env\.HCLOUD_BIN = hcloudBin\.replace/);
   // doctor warns about sandbox mode
   assert.match(setup, /CodeArts sandbox mode active/);
+});
+
+test('setup-cli.mjs supports the dsh target end to end', () => {
+  const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
+  // parseTarget accepts dsh
+  assert.match(setup, /if \(val === 'dsh'\) return 'dsh';/);
+  // DSH path helpers and managed patch constants exist
+  assert.match(setup, /function dshRoot\(\)/);
+  assert.match(setup, /function dshSkillsDir\(\)/);
+  assert.match(setup, /function dshProfileDir\(\)/);
+  assert.match(setup, /function dshPatchFile\(\)/);
+  assert.match(setup, /function dshPluginsDir\(\)/);
+  assert.match(setup, /const DSH_MCP_PATCH_START = '# HuaweiCloud DevKit DSH integration start';/);
+  assert.match(setup, /const DSH_MCP_PATCH_END = '# HuaweiCloud DevKit DSH integration end';/);
+  // install / update / uninstall / status functions exist
+  assert.match(setup, /async function installDsh\(\)/);
+  assert.match(setup, /async function updateDsh\(\)/);
+  assert.match(setup, /function uninstallDsh\(\)/);
+  assert.match(setup, /function dshStatus\(\)/);
+  // install copies skills/server/safety and registers MCP through cordis.patch.yml
+  assert.match(setup, /copyDir\(skillsSrc, dshSkillsDir\(\)\)/);
+  assert.match(setup, /copyDir\(srcDir, join\(pluginDest, 'src'\)\)/);
+  assert.match(setup, /copyDir\(safetyDir, join\(pluginDest, 'safety'\)\)/);
+  assert.match(setup, /ensureDshMcpPatch\(\)/);
+  assert.match(setup, /tryInstallDshMcpClient\(\)/);
+  // DSH MCP patch uses dsh-mcp-client with stdio local server mode
+  assert.match(setup, /name: '@deepseek-ai\/dsh-mcp-client'/);
+  assert.match(setup, /serverName: huaweicloud/);
+  assert.match(setup, /transport: stdio/);
+  assert.match(setup, /failOnStartupError: false/);
+  assert.match(setup, /HUAWEICLOUD_AGENT_TOOLKIT_MODE: local/);
+  assert.match(setup, /HDKITSERVICE_ENDPOINT: ''/);
+  // uninstall removes only the managed patch block
+  assert.match(setup, /removeDshMcpPatch\(\)/);
+  // command dispatch covers dsh for install / uninstall / status / update
+  const branches = setup.match(/target === 'dsh' \|\| target === 'all'/g);
+  assert.ok(branches && branches.length >= 4, `dsh dispatch branches: ${branches?.length}`);
+  // .installed marker goes to the dsh plugins dir
+  assert.match(setup, /target === 'dsh' \? dshPluginsDir\(\)/);
+  // doctor checks DSH plugin dir, patch, and skills dir
+  assert.match(setup, /const dshPluginDir = dshPluginsDir\(\);/);
+  assert.match(setup, /dshPatchConfigured\(\)/);
+  assert.match(setup, /dshSkillsDir\(\)/);
+  // help text documents the target
+  assert.match(setup, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|all>/);
+  assert.match(setup, /install --target dsh/);
+});
+
+test('tools.mjs resolves skills from the dsh directory', () => {
+  const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
+  assert.match(tools, /function dshSkillsDir\(\)/);
+  assert.match(tools, /process\.env\.DSH_HOME \|\| join\(homedir\(\), '\.dsh'\)/);
+  assert.match(tools, /return join\(home, 'skills'\);/);
+  assert.match(tools, /if \(existsSync\(dshSkillsDir\(\)\)\) return dshSkillsDir\(\);/);
+  assert.match(tools, /opencode, codex, codex-desktop, codearts, workbuddy, dsh, or all/);
 });


### PR DESCRIPTION
## Summary

- Add `--target dsh` support for install/update/uninstall/status/doctor.
- Reuse the existing HuaweiCloud DevKit MCP server through `@deepseek-ai/dsh-mcp-client` and manage a marked block in `$DSH_HOME/profiles/web/cordis.patch.yml`.
- Copy Skills, MCP server, and safety policy into `$DSH_HOME`, add auth status detection, docs, and isolated DSH tests.

## Validation

- `npm test`
- `npm run validate`
- `npm run lint`
- `npm pack --dry-run`
- Temporary `DSH_HOME` smoke test for install/status and generated `cordis.patch.yml`

## Notes

V1 intentionally avoids a native Cordis tool implementation so DSH can share the existing MCP schemas, KooCLI wrapper, and safety policy with other agents.