### PR TITLE
fix(huaweicloud-core): strip echoed line via string search to avoid regex size limit

### DIFF
--- a/plugins/huaweicloud-core/src/ws-exec/ws-exec-client.js
+++ b/plugins/huaweicloud-core/src/ws-exec/ws-exec-client.js
@@ -43,10 +43,42 @@ function escapeRegExp(text) {
 }
 
 function stripEchoedLine(text, line, options = {}) {
-  const escaped = escapeRegExp(line);
-  const stripped = text.replace(new RegExp(`(^|\\r?\\n)${escaped}\\r?\\n?`), '$1');
-  if (!options.allowAttached || stripped !== text) return stripped;
-  return text.replace(new RegExp(`${escaped}(?:\\r?\\n){0,2}$`), '');
+  if (!line) return text;
+
+  // Strip the echoed line using string search instead of RegExp so that an
+  // arbitrarily long command cannot trip V8's "Regular expression too large"
+  // limit. First, drop the line when it starts the text or follows a newline.
+  let from = 0;
+  while (from <= text.length - line.length) {
+    const index = text.indexOf(line, from);
+    if (index === -1) break;
+    if (index === 0 || text[index - 1] === '\n') {
+      const trailing = text.startsWith('\r\n', index + line.length) ? 2
+        : text.startsWith('\n', index + line.length) ? 1 : 0;
+      return text.slice(0, index) + text.slice(index + line.length + trailing);
+    }
+    from = index + 1;
+  }
+
+  if (!options.allowAttached) return text;
+
+  // Fallback: drop the line when it sits at the very end, optionally followed
+  // by up to two newlines (terminal may append the echo without a separator).
+  from = 0;
+  while (from <= text.length - line.length) {
+    const index = text.indexOf(line, from);
+    if (index === -1) break;
+    let rest = text.slice(index + line.length);
+    let newlines = 0;
+    while (newlines < 2 && (rest.startsWith('\r\n') || rest.startsWith('\n'))) {
+      rest = rest.startsWith('\r\n') ? rest.slice(2) : rest.slice(1);
+      newlines += 1;
+    }
+    if (rest === '') return text.slice(0, index);
+    from = index + 1;
+  }
+
+  return text;
 }
 
 function buildMarkers(nonce = randomBytes(8).toString('hex')) {

--- a/test/ws-exec-client.test.mjs
+++ b/test/ws-exec-client.test.mjs
@@ -1,0 +1,34 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import {
+  cleanCommandOutput,
+  stripEchoedLine,
+} from '../plugins/huaweicloud-core/src/ws-exec/ws-exec-client.js';
+
+test('stripEchoedLine removes a newline-terminated echoed command', () => {
+  assert.equal(stripEchoedLine('cmd\nout', 'cmd'), 'out');
+  assert.equal(stripEchoedLine('cmd\r\nout', 'cmd'), 'out');
+  assert.equal(stripEchoedLine('out1\ncmd\nout2', 'cmd'), 'out1\nout2');
+});
+
+test('stripEchoedLine with allowAttached removes a trailing attached echo', () => {
+  assert.equal(stripEchoedLine('outcmd', 'cmd', { allowAttached: true }), 'out');
+  assert.equal(stripEchoedLine('cmd\n', 'cmd', { allowAttached: true }), '');
+});
+
+test('stripEchoedLine does not throw on a very long command (RangeError regression)', () => {
+  const command = `echo '${'A'.repeat(128 * 1024)}' | base64 -d > /workspace/test.bin`;
+  const output = `${command}\nsome output\n`;
+  assert.doesNotThrow(() => stripEchoedLine(output, command));
+  assert.equal(stripEchoedLine(output, command), 'some output\n');
+});
+
+test('cleanCommandOutput handles a long echoed command', () => {
+  const command = `echo '${'A'.repeat(128 * 1024)}' | base64 -d > /workspace/test.bin`;
+  const doneCommand = '__ws_exec_done__';
+  const output = `${command}\nhello\n`;
+  assert.equal(
+    cleanCommandOutput(output, { inputEchoed: true, command, doneCommand }),
+    'hello\n',
+  );
+});


### PR DESCRIPTION
## Summary

Fixes #85 — `ws-exec` crashed with `RangeError: Regular expression too large` when executing very long commands (e.g. ~1MB base64 file upload), because `stripEchoedLine()` built a `RegExp` from the entire command text. The regex source grows linearly with command length and V8 rejects it during `.replace()`.

## Change

`plugins/huaweicloud-core/src/ws-exec/ws-exec-client.js` — `stripEchoedLine()` now locates the echoed line with `String.prototype.indexOf` and trims it with `slice`, preserving the original behavior (leading/line-preceded echo, and `allowAttached` trailing echo with up to two newlines) but with no regex and therefore no length limit.

- Before: `text.replace(new RegExp(\`(^|\\r?\\n)\${escapeRegExp(line)}\\r?\\n?\`), '$1')`
- After: `indexOf` + `slice`, no `RegExp` construction from the command text.

## Tests

Added `test/ws-exec-client.test.mjs`:
- echo stripping for LF / CRLF and newline-preceded cases
- `allowAttached` trailing echo
- regression: 128KB command does not throw and strips correctly
- `cleanCommandOutput` integration with a long echoed command

`npm test` (94 pass) and `npm run validate` both pass.