### PR TITLE
fix(release): add checkout steps to prerelease publish job, disable component-in-tag

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -2,6 +2,7 @@
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "node",
   "include-v-in-tag": true,
+  "include-component-in-tag": false,
   "changelog-sections": [
     { "type": "feat", "section": "Features", "hidden": false },
     { "type": "fix", "section": "Bug Fixes", "hidden": false },


### PR DESCRIPTION
The publish step ran without a repo checkout (npm ci had no lockfile). Add checkout/setup-node before publishing, and disable component-name prefix in tags so they match the existing v* convention.