### PR TITLE
feat(release): sync verification/publication separation to next branch

### DIFF
--- a/.github/workflows/cd-production.yml
+++ b/.github/workflows/cd-production.yml
@@ -9,30 +9,10 @@ on:
 permissions: {}
 
 jobs:
-  npm-publish:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 15
-    environment: production
-    permissions:
-      contents: read
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-      - run: npm ci
-      - run: npm test
-      - run: npm run validate
-      - name: Publish to npm
-        run: npm publish --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-
   remote-deploy:
-    needs: npm-publish
     runs-on: ubuntu-24.04
     timeout-minutes: 30
+    environment: production
     permissions:
       contents: read
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,20 @@ jobs:
       - run: npm test
       - run: npm run validate
 
+  pack:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: node ./scripts/pack-verify.mjs
+
   security:
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,80 @@
-name: Publish Release (retired)
+name: Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      dist-tag:
+        description: npm dist-tag to publish under (latest for stable, next for prerelease)
+        required: true
+        type: string
+        default: latest
 
-permissions: {}
+permissions:
+  contents: read
+
+concurrency:
+  group: Publish
+  cancel-in-progress: false
 
 jobs:
-  publish:
+  verify:
+    name: Verify tag and package
     runs-on: ubuntu-24.04
-    timeout-minutes: 5
+    timeout-minutes: 10
     steps:
-      - name: Retired workflow
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+      - name: Gate: must run from a v* tag matching package.json
         run: |
-          echo "This workflow is retired. Releases are now managed by release-please."
-          echo "See docs/RELEASING.md."
-          exit 0
+          set -euo pipefail
+          [ "$GITHUB_REF_TYPE" = "tag" ] || { echo "::error::Publish must run from a v* tag, not a branch."; exit 1; }
+          case "$GITHUB_REF_NAME" in
+            v*) ;;
+            *) echo "::error::Tag must start with v (got $GITHUB_REF_NAME)."; exit 1 ;;
+          esac
+          VERSION=$(node -p "require('./package.json').version")
+          [ "$GITHUB_REF_NAME" = "v$VERSION" ] || { echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $VERSION."; exit 1; }
+          case "$VERSION" in
+            *-*)
+              [ "$DIST_TAG" = "next" ] || { echo "::error::Prerelease $VERSION must publish under dist-tag next, got $DIST_TAG."; exit 1; }
+              ;;
+            *)
+              [ "$DIST_TAG" = "latest" ] || { echo "::error::Stable $VERSION must publish under dist-tag latest, got $DIST_TAG."; exit 1; }
+              ;;
+          esac
+        env:
+          DIST_TAG: ${{ inputs.dist-tag }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+      - run: npm ci
+      - run: npm test
+      - run: npm run validate
+      - run: node ./scripts/pack-verify.mjs
+
+  publish:
+    name: Publish to npm
+    needs: verify
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - name: Guard: version must not exist on the registry
+        run: |
+          set -euo pipefail
+          VERSION=$(node -p "require('./package.json').version")
+          if npm view "huaweicloud-devkit@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::$VERSION already exists on npm; nothing to publish."
+            exit 1
+          fi
+      - name: Publish tarball
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag ${{ inputs.dist-tag }}

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -22,22 +22,3 @@ jobs:
           target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
-
-      - name: Checkout
-        if: ${{ steps.release.outputs.release_created && github.ref_name != 'main' }}
-        uses: actions/checkout@v4
-
-      - name: Setup Node
-        if: ${{ steps.release.outputs.release_created && github.ref_name != 'main' }}
-        uses: actions/setup-node@v4
-        with:
-          node-version: 20
-          registry-url: https://registry.npmjs.org
-
-      - name: Publish prerelease to npm
-        if: ${{ steps.release.outputs.release_created && github.ref_name != 'main' }}
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: |
-          npm ci
-          npm publish --access public --tag next

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -159,8 +159,14 @@ Prerelease cadence: at most 1–2 `next` publishes per week, only after
 - Add `release-please.yml` on the `main` branch: computes the next version
   from conventional commits, opens a release PR that bumps `package.json`,
   all plugin manifests, and `CHANGELOG.md`; merging the PR creates the git
-  tag and the GitHub Release.
-- Keep `cd-production.yml` (tag-triggered `npm publish` to `latest`).
+  tag and the GitHub Release. **release-please versions and tags only; it
+  never publishes to npm.**
+- Add `publish.yml` (manual dispatch): the only npm publish path. It must be
+  triggered from a `v*` tag and passes the `npm-publish` environment approval
+  before publishing. `ci.yml` gains a `pack` verification job (tarball file
+  list + real install) on every PR.
+- `cd-production.yml` no longer publishes npm; it keeps only the production
+  deploy placeholder.
 - Retire the manual `Publish Release` and `Publish Dev` workflows.
 
 Release flow after Phase 1:
@@ -169,9 +175,17 @@ Release flow after Phase 1:
 feat/fix commits → PR → merge to main
   → release-please opens/updates a release PR (version + changelog)
   → a maintainer merges it
-  → git tag vX.Y.Z + GitHub Release
-  → cd-production publishes to npm `latest`
+  → git tag vX.Y.Z + GitHub Release (npm is untouched)
+  → a maintainer manually dispatches Publish on the vX.Y.Z tag (dist-tag=latest)
+  → npm-publish environment approval (reviewer + v* tag allowlist)
+  → npm publish → latest
 ```
+
+**Verification is separated from publication.** Every PR runs
+`scripts/pack-verify.mjs` in CI (required files in the tarball + a real
+install into a temp project). The Publish workflow re-runs the same
+verification before publishing, so the bytes that reach npm are the bytes
+that were verified.
 
 **The team decides the version (title override rule).** The version computed by
 release-please is only a proposal, expressed in the release PR title (e.g.
@@ -188,11 +202,12 @@ When fix + feat + feat! commits are mixed, the proposal takes the highest
 priority (feat! > feat > fix); if the team judges the real impact lower than
 the proposal, use the title override to downgrade.
 
-### Phase 2 — Automate the `next` channel
+### Phase 2 — The `next` channel (prereleases)
 
-- Maintain a `next` branch; release-please runs there with `prerelease: true`,
-  producing `X.Y.Z-next.N` automatically.
-- Manual prerelease steps (Section 4) are retired.
+- Maintain a `next` branch; release-please runs there, producing
+  `X.Y.Z-next.N` release PRs; merging only tags, never publishes.
+- Prereleases use the same manual Publish: dispatch from the
+  `vX.Y.Z-next.N` tag with `dist-tag=next`.
 - The `next` line stays tied to the upcoming stable: after `1.1.0` ships,
   `next` resets toward the following release.
 
@@ -218,3 +233,6 @@ the proposal, use the title override to downgrade.
    same version as `package.json`.
 6. The repo `package.json` always reflects the latest **stable** version;
    prerelease numbers exist only transiently during a publish.
+7. **npm publishing happens only through `publish.yml`, manually dispatched
+   from a `v*` tag and approved via the `npm-publish` environment.** No other
+   automated publish path is allowed.

--- a/docs/RELEASING.zh-CN.md
+++ b/docs/RELEASING.zh-CN.md
@@ -149,7 +149,11 @@ SemVer 排序规则：同数字下，稳定版大于任何预发布版。
 - 新增 `release-please.yml`（`main` 分支）：根据 conventional commits 计算
   下一个版本号，开启发布 PR，自动更新 `package.json`、四个插件清单和
   `CHANGELOG.md`；合并该 PR 即自动创建 git tag 和 GitHub Release。
-- 保留 `cd-production.yml`（tag 触发的 `npm publish` 到 `latest`）。
+  **release-please 只负责定版本和打 tag，不发布 npm。**
+- 新增 `publish.yml`（手动触发）：npm 发布的唯一入口，必须从 `v*` tag 上
+  手动 dispatch，通过 `npm-publish` environment 审批后发布；`ci.yml` 增加
+  `pack` 校验（每个 PR 验证 tarball 完整性 + 真实安装）。
+- `cd-production.yml` 不再发布 npm，仅保留生产部署占位。
 - 退役手动的 `Publish Release` 与 `Publish Dev` 工作流。
 
 阶段 1 完成后的发布流程：
@@ -158,9 +162,15 @@ SemVer 排序规则：同数字下，稳定版大于任何预发布版。
 feat/fix 提交 → PR → 合并到 main
   → release-please 开启/更新发布 PR（版本号 + changelog）
   → 维护者合并该 PR
-  → 自动打 git tag vX.Y.Z + 创建 GitHub Release
-  → cd-production 发布到 npm 的 latest
+  → 自动打 git tag vX.Y.Z + 创建 GitHub Release（此时 npm 未变）
+  → 维护者在 Actions 里对 vX.Y.Z tag 手动触发 Publish（dist-tag=latest）
+  → npm-publish environment 审批（审批人 + tag 白名单 v*）
+  → npm publish → latest
 ```
+
+**发布与验证分离。** 每个 PR 的 CI 都执行 `npm pack` 验证（`scripts/pack-verify.mjs`：
+检查 tarball 必备文件清单 + 在临时目录真实安装验证），发布前 Publish 工作流
+再跑一遍同样的验证，保证"发到 npm 的字节 = 验证过的字节"。
 
 **版本号由团队决定（标题覆盖规则）。** release-please 计算的版本号只是提案，
 出现在发布 PR 的标题里（如 `chore: release 1.0.2`）。合并前维护者可以修改
@@ -175,11 +185,11 @@ PR 标题来强制指定版本号，合并后即按标题中的版本发布：
 多类 commit 混在时（fix + feat + feat!），提案取最高优先级
 （feat! > feat > fix）；如果团队判断实际影响低于提案，用标题覆盖降级即可。
 
-### 阶段 2 —— 自动化 `next` 频道
+### 阶段 2 —— `next` 频道（预发布）
 
-- 维护一条 `next` 分支；release-please 在该分支以 `prerelease: true` 运行，
-  自动产出 `X.Y.Z-next.N`。
-- 第 4 节的手动预发布步骤随之退役。
+- 维护一条 `next` 分支；release-please 在该分支运行，自动产出
+  `X.Y.Z-next.N` 的发布 PR；合并后只打 tag，不发布。
+- 预发布同样走手动 Publish：从 `vX.Y.Z-next.N` tag 触发，`dist-tag=next`。
 - `next` 线与即将到来的稳定版保持挂钩：`1.1.0` 发布后，`next` 重置并指向
   下一个版本。
 
@@ -202,3 +212,5 @@ PR 标题来强制指定版本号，合并后即按标题中的版本发布：
    保持一致。
 6. 仓库中的 `package.json` 永远反映最新**稳定版**；预发布版本号只存在于
    发布过程中的瞬时状态。
+7. **npm 发布只允许通过 `publish.yml` 从 `v*` tag 手动触发**，且必须经过
+   `npm-publish` environment 审批；禁止任何其他自动发布路径。

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.git\" \"#test/**\" \"#docs/**\"",
         "lint": "npm run lint:md",
         "validate": "node ./scripts/validate-package.mjs",
+        "pack:verify": "node ./scripts/pack-verify.mjs",
         "postinstall": "node -e \"console.log('\\nHuaweiCloud DevKit installed. Run: npx huaweicloud-devkit install\\n')\""
     },
     "devDependencies": {

--- a/scripts/pack-verify.mjs
+++ b/scripts/pack-verify.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const quote = (arg) => `"${arg.replace(/"/g, '\\"')}"`;
+const runNpm = (args, options) =>
+  execSync([npm, ...args.map(quote)].join(' '), { stdio: 'ignore', ...options });
+
+const packed = JSON.parse(
+  runNpm(['pack', '--json'], { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }),
+);
+assert.equal(packed.length, 1, 'npm pack should produce exactly one tarball');
+const { filename, files } = packed[0];
+const paths = new Set(files.map((f) => f.path.replace(/^package\//, '')));
+
+const requiredFiles = [
+  'package.json',
+  'bin/setup.cjs',
+  '.agents/plugins/marketplace.json',
+  'integrations/opencode/opencode.json',
+  'plugins/huaweicloud-core/.mcp.json',
+  'plugins/huaweicloud-core/.codex-plugin/plugin.json',
+  'plugins/huaweicloud-core/.claude-plugin/plugin.json',
+  'plugins/huaweicloud-core/.cursor-plugin/plugin.json',
+  'plugins/huaweicloud-core/.workbuddy-plugin/plugin.json',
+  'plugins/huaweicloud-core/hooks/hooks.json',
+  'plugins/huaweicloud-core/hooks/huaweicloud-safety.py',
+  'plugins/huaweicloud-core/safety/policy.json',
+  'plugins/huaweicloud-core/safety/rules/cloud-risk-rules.json',
+  'plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md',
+];
+for (const file of requiredFiles) {
+  assert.ok(paths.has(file), `Tarball is missing ${file}`);
+}
+
+const tarballPath = join(root, filename);
+assert.ok(existsSync(tarballPath), 'Tarball was not created');
+
+const installDir = mkdtempSync(join(tmpdir(), 'hwc-pack-verify-'));
+try {
+  runNpm(['init', '-y'], { cwd: installDir });
+  runNpm(['install', tarballPath], { cwd: installDir });
+  const installed = join(installDir, 'node_modules', 'huaweicloud-devkit');
+  assert.ok(existsSync(join(installed, 'bin', 'setup.cjs')), 'Installed package is missing bin/setup.cjs');
+  assert.ok(
+    existsSync(join(installed, 'plugins', 'huaweicloud-core', 'skills', 'huaweicloud-core', 'SKILL.md')),
+    'Installed package is missing the core skill',
+  );
+} finally {
+  rmSync(installDir, { recursive: true, force: true });
+  rmSync(tarballPath, { force: true });
+}
+
+console.log(`Verified pack of ${filename}: ${files.length} files, install OK.`);


### PR DESCRIPTION
Syncs the DeepSeek-style release flow (merged to dev via #100) to the next branch. Excludes next's own release-please config and manifest (next keeps prerelease config).

- ci.yml: add pack verification job
- publish.yml: the only npm publish path (tag-gated manual dispatch + environment approval)
- release-please.yml: drop auto npm publish (tags only)
- cd-production.yml: drop npm publish
- scripts/pack-verify.mjs: new tarball verification
- package.json: add pack:verify script (version untouched)
- docs/RELEASING: updated flow

After this merges, prereleases are published by manually dispatching Publish on the vX.Y.Z-next.N tag with dist-tag=next.