### PR TITLE
fix(release): add tag-gated Publish workflow to main so workflow_dispatch works from tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    branches: [main, dev, next]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
@@ -44,6 +44,20 @@ jobs:
       - run: npm ci
       - run: npm test
       - run: npm run validate
+
+  pack:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 10
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+      - run: npm ci
+      - run: node ./scripts/pack-verify.mjs
 
   security:
     runs-on: ubuntu-24.04

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,37 +1,80 @@
-name: Publish Release
+name: Publish
 
 on:
   workflow_dispatch:
+    inputs:
+      dist-tag:
+        description: npm dist-tag to publish under (latest for stable, next for prerelease)
+        required: true
+        type: string
+        default: latest
 
-permissions: {}
+permissions:
+  contents: read
+
+concurrency:
+  group: Publish
+  cancel-in-progress: false
 
 jobs:
-  publish:
+  verify:
+    name: Verify tag and package
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    permissions:
-      contents: write
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
+      - name: Gate: must run from a v* tag matching package.json
+        run: |
+          set -euo pipefail
+          [ "$GITHUB_REF_TYPE" = "tag" ] || { echo "::error::Publish must run from a v* tag, not a branch."; exit 1; }
+          case "$GITHUB_REF_NAME" in
+            v*) ;;
+            *) echo "::error::Tag must start with v (got $GITHUB_REF_NAME)."; exit 1 ;;
+          esac
+          VERSION=$(node -p "require('./package.json').version")
+          [ "$GITHUB_REF_NAME" = "v$VERSION" ] || { echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $VERSION."; exit 1; }
+          case "$VERSION" in
+            *-*)
+              [ "$DIST_TAG" = "next" ] || { echo "::error::Prerelease $VERSION must publish under dist-tag next, got $DIST_TAG."; exit 1; }
+              ;;
+            *)
+              [ "$DIST_TAG" = "latest" ] || { echo "::error::Stable $VERSION must publish under dist-tag latest, got $DIST_TAG."; exit 1; }
+              ;;
+          esac
+        env:
+          DIST_TAG: ${{ inputs.dist-tag }}
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - run: npm ci
+      - run: npm test
+      - run: npm run validate
+      - run: node ./scripts/pack-verify.mjs
 
-      - name: Sync plugin manifest versions and validate
+  publish:
+    name: Publish to npm
+    needs: verify
+    runs-on: ubuntu-24.04
+    timeout-minutes: 15
+    environment: npm-publish
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+      - run: npm ci
+      - name: Guard: version must not exist on the registry
         run: |
-          node ./scripts/sync-version.mjs
-          npm run validate
-
-      - name: Tag and create GitHub Release
-        env:
-          GH_TOKEN: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
-        run: |
+          set -euo pipefail
           VERSION=$(node -p "require('./package.json').version")
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag "v${VERSION}"
-          git push origin "v${VERSION}"
-          gh release create "v${VERSION}" --title "v${VERSION}" --generate-notes || echo "Release already exists"
+          if npm view "huaweicloud-devkit@$VERSION" version >/dev/null 2>&1; then
+            echo "::error::$VERSION already exists on npm; nothing to publish."
+            exit 1
+          fi
+      - name: Publish tarball
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --access public --tag ${{ inputs.dist-tag }}

--- a/scripts/pack-verify.mjs
+++ b/scripts/pack-verify.mjs
@@ -1,0 +1,60 @@
+import assert from 'node:assert/strict';
+import { execSync } from 'node:child_process';
+import { existsSync, mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+
+const quote = (arg) => `"${arg.replace(/"/g, '\\"')}"`;
+const runNpm = (args, options) =>
+  execSync([npm, ...args.map(quote)].join(' '), { stdio: 'ignore', ...options });
+
+const packed = JSON.parse(
+  runNpm(['pack', '--json'], { cwd: root, encoding: 'utf8', stdio: ['ignore', 'pipe', 'ignore'] }),
+);
+assert.equal(packed.length, 1, 'npm pack should produce exactly one tarball');
+const { filename, files } = packed[0];
+const paths = new Set(files.map((f) => f.path.replace(/^package\//, '')));
+
+const requiredFiles = [
+  'package.json',
+  'bin/setup.cjs',
+  '.agents/plugins/marketplace.json',
+  'integrations/opencode/opencode.json',
+  'plugins/huaweicloud-core/.mcp.json',
+  'plugins/huaweicloud-core/.codex-plugin/plugin.json',
+  'plugins/huaweicloud-core/.claude-plugin/plugin.json',
+  'plugins/huaweicloud-core/.cursor-plugin/plugin.json',
+  'plugins/huaweicloud-core/.workbuddy-plugin/plugin.json',
+  'plugins/huaweicloud-core/hooks/hooks.json',
+  'plugins/huaweicloud-core/hooks/huaweicloud-safety.py',
+  'plugins/huaweicloud-core/safety/policy.json',
+  'plugins/huaweicloud-core/safety/rules/cloud-risk-rules.json',
+  'plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md',
+];
+for (const file of requiredFiles) {
+  assert.ok(paths.has(file), `Tarball is missing ${file}`);
+}
+
+const tarballPath = join(root, filename);
+assert.ok(existsSync(tarballPath), 'Tarball was not created');
+
+const installDir = mkdtempSync(join(tmpdir(), 'hwc-pack-verify-'));
+try {
+  runNpm(['init', '-y'], { cwd: installDir });
+  runNpm(['install', tarballPath], { cwd: installDir });
+  const installed = join(installDir, 'node_modules', 'huaweicloud-devkit');
+  assert.ok(existsSync(join(installed, 'bin', 'setup.cjs')), 'Installed package is missing bin/setup.cjs');
+  assert.ok(
+    existsSync(join(installed, 'plugins', 'huaweicloud-core', 'skills', 'huaweicloud-core', 'SKILL.md')),
+    'Installed package is missing the core skill',
+  );
+} finally {
+  rmSync(installDir, { recursive: true, force: true });
+  rmSync(tarballPath, { force: true });
+}
+
+console.log(`Verified pack of ${filename}: ${files.length} files, install OK.`);


### PR DESCRIPTION
GitHub only allows workflow_dispatch for workflows that exist on the default branch. This PR brings the new tag-gated Publish workflow (from dev/next) to main. Publishing remains impossible without the v* tag + environment approval gates.