### PR TITLE
fix(release): drop workflow_dispatch inputs, derive dist-tag from the tag version

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,13 +1,7 @@
-name: Publish
+name: Publish npm
 
 on:
   workflow_dispatch:
-    inputs:
-      dist-tag:
-        description: npm dist-tag to publish under (latest for stable, next for prerelease)
-        required: true
-        type: string
-        default: latest
 
 permissions:
   contents: read
@@ -21,11 +15,14 @@ jobs:
     name: Verify tag and package
     runs-on: ubuntu-24.04
     timeout-minutes: 10
+    outputs:
+      dist-tag: ${{ steps.gate.outputs.dist_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Gate: must run from a v* tag matching package.json
+        id: gate
         run: |
           set -euo pipefail
           [ "$GITHUB_REF_TYPE" = "tag" ] || { echo "::error::Publish must run from a v* tag, not a branch."; exit 1; }
@@ -36,15 +33,11 @@ jobs:
           VERSION=$(node -p "require('./package.json').version")
           [ "$GITHUB_REF_NAME" = "v$VERSION" ] || { echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $VERSION."; exit 1; }
           case "$VERSION" in
-            *-*)
-              [ "$DIST_TAG" = "next" ] || { echo "::error::Prerelease $VERSION must publish under dist-tag next, got $DIST_TAG."; exit 1; }
-              ;;
-            *)
-              [ "$DIST_TAG" = "latest" ] || { echo "::error::Stable $VERSION must publish under dist-tag latest, got $DIST_TAG."; exit 1; }
-              ;;
+            *-*) DIST_TAG=next ;;
+            *) DIST_TAG=latest ;;
           esac
-        env:
-          DIST_TAG: ${{ inputs.dist-tag }}
+          echo "dist-tag: $DIST_TAG"
+          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -77,4 +70,4 @@ jobs:
       - name: Publish tarball
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --tag ${{ inputs.dist-tag }}
+        run: npm publish --access public --tag ${{ needs.verify.outputs.dist-tag }}


### PR DESCRIPTION
workflow_dispatch with an inputs block is rejected by GitHub's indexer in this repo (dispatch returns 422 and the workflow name falls back to the file path). This removes the input; the dist-tag is derived from the tag's version (prerelease -> next, stable -> latest).