### PR TITLE
fix(release): npm-publish without job outputs wiring

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -3,8 +3,7 @@ name: Publish npm
 on:
   workflow_dispatch:
 
-permissions:
-  contents: read
+permissions: {}
 
 concurrency:
   group: Publish
@@ -15,14 +14,11 @@ jobs:
     name: Verify tag and package
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    outputs:
-      dist-tag: ${{ steps.gate.outputs.dist_tag }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
       - name: Gate: must run from a v* tag matching package.json
-        id: gate
         run: |
           set -euo pipefail
           [ "$GITHUB_REF_TYPE" = "tag" ] || { echo "::error::Publish must run from a v* tag, not a branch."; exit 1; }
@@ -32,12 +28,6 @@ jobs:
           esac
           VERSION=$(node -p "require('./package.json').version")
           [ "$GITHUB_REF_NAME" = "v$VERSION" ] || { echo "::error::Tag $GITHUB_REF_NAME does not match package.json version $VERSION."; exit 1; }
-          case "$VERSION" in
-            *-*) DIST_TAG=next ;;
-            *) DIST_TAG=latest ;;
-          esac
-          echo "dist-tag: $DIST_TAG"
-          echo "dist_tag=$DIST_TAG" >> "$GITHUB_OUTPUT"
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -70,4 +60,9 @@ jobs:
       - name: Publish tarball
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish --access public --tag ${{ needs.verify.outputs.dist-tag }}
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          case "$VERSION" in
+            *-*) npm publish --access public --tag next ;;
+            *) npm publish --access public --tag latest ;;
+          esac


### PR DESCRIPTION
Bisection probe: removes job-level outputs, step id, and needs.outputs reference; the publish job derives the dist-tag itself.