### PR TITLE
fix(release): pass RELEASE_PLEASE_TOKEN to release-please so its PR pushes trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
When release-please pushes with GITHUB_TOKEN, its PR updates do not trigger CI and branch protection blocks the merge. Passing a PAT secret makes those pushes trigger CI automatically. Falls back to GITHUB_TOKEN until the secret is configured.