### PR TITLE
fix(release): pass RELEASE_PLEASE_TOKEN to release-please so its PR pushes trigger CI

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -19,6 +19,7 @@ jobs:
         id: release
         uses: googleapis/release-please-action@v4
         with:
+          token: ${{ secrets.RELEASE_PLEASE_TOKEN || secrets.GITHUB_TOKEN }}
           target-branch: ${{ github.ref_name }}
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json


### PR DESCRIPTION
Same token fix as dev (PR 117), applied to the next branch so prerelease PRs get CI automatically.