### PR TITLE
fix(sandbox): validate local_path before upload, register tool in safety policy

### DIFF
--- a/plugins/huaweicloud-core/safety/policy.json
+++ b/plugins/huaweicloud-core/safety/policy.json
@@ -95,6 +95,7 @@
                               ],
     "sandboxWriteTools":  [
                                "huaweicloud_sandbox_connect",
-                               "huaweicloud_sandbox_credentials"
+                               "huaweicloud_sandbox_credentials",
+                               "huaweicloud_sandbox_upload_file"
                            ]
 }

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { readFileSync } from 'node:fs';
+import { existsSync, readFileSync, statSync } from 'node:fs';
 import { createHash } from 'node:crypto';
 import { join, dirname } from 'node:path';
 import { fileURLToPath, pathToFileURL } from 'node:url';
@@ -106,6 +106,12 @@ export function splitBase64Chunks(base64, chunkSize = UPLOAD_CHUNK_SIZE) {
 }
 
 export async function uploadFileWithSession(workspaceId, localPath, remotePath, username = 'root', timeoutMs = 30000) {
+  if (!existsSync(localPath)) {
+    throw new Error(`sandbox upload: local file not found: ${localPath}`);
+  }
+  if (!statSync(localPath).isFile()) {
+    throw new Error(`sandbox upload: path is not a regular file: ${localPath}`);
+  }
   const content = readFileSync(localPath);
   const base64 = content.toString('base64');
   const expectedMd5 = createHash('md5').update(content).digest('hex');


### PR DESCRIPTION
## 背景

PR #120 (#93) 合入后遗留 2 个小瑕疵。

## 修复

1. **session-manager.mjs** — uploadFileWithSession 增加 local_path 前置验证：
   - existsSync 检查文件是否存在，不存在时抛出 "local file not found" 而非让 Node.js readFileSync 抛出原始错误
   - statSync().isFile() 检查路径是否普通文件，目录等非文件路径抛出 "not a regular file"

2. **policy.json** — sandboxWriteTools 注册新工具 huaweicloud_sandbox_upload_file（与已有的 sandbox_connect/sandbox_credentials 并列）

## 验证

- npm test 103/103 通过
- npm run validate 通过