### PR TITLE
fix: escape backslashes in pack-verify.mjs quote helper

### DIFF
--- a/scripts/pack-verify.mjs
+++ b/scripts/pack-verify.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 const root = fileURLToPath(new URL('..', import.meta.url));
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
-const quote = (arg) => `"${arg.replace(/"/g, '\\"')}"`;
+const quote = (arg) => `"${arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 const runNpm = (args, options) =>
   execSync([npm, ...args.map(quote)].join(' '), { stdio: 'ignore', ...options });
 


### PR DESCRIPTION
CodeQL warning: Incomplete string escaping or encoding. The quote helper only escaped double quotes but not backslashes, which could allow crafted paths to break out of the quoted string boundary. Fix: escape backslashes before escaping double quotes.