### PR TITLE
fix(skills): document CCE field-by-field errors and Flyway SQL dialect trap

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-cce/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-cce/SKILL.md
@@ -18,6 +18,7 @@ Domain expertise for CCE (Cloud Container Engine) and SWR (Software Repository f
 
 | Trap | Why |
 |------|-----|
+| **Huawei Cloud API returns errors one field at a time** | When creating clusters/services with multiple invalid fields, the API reports only the first error, not all errors at once. After fixing one field and resubmitting, the next call reveals the next error — iterating N times for N bad fields. This compounds with long cluster creation times (~10 min). To avoid this loop, run `hcloud CCE <Operation> --help` and validate every parameter with its constraints before the first call. Use `--cli-jsonInput` with a validated JSON file to reduce reformatting overhead between retries. |
 | **KooCLI 7.x: CreateCluster/CreateNodePool broken** | OPENAPI_ERROR in KooCLI 7.2.12. Use `CreateAutopilotCluster` for serverless, or Python SDK for VM clusters |
 | Cluster type immutable | Cannot change hybrid/traditional after creation |
 | Master managed by Huawei | No SSH to master. Use kubectl or kubectl-cce |
@@ -83,6 +84,7 @@ See `hcloud CCI --help` for full operation list.
 | SVCSTG.SWR.4030170 | Missing `sts::createServiceBearerToken` IAM permission. Grant SWR Admin role or add policy |
 | Addon install fails | Use `metadata.uid` from `ShowAddonInstance`, not name |
 | `kubectl cce` not found | Install plugin: `kubectl cce` uses AK/SK, no kubeconfig required |
+| Serial field-by-field API errors | The API reports errors one field at a time. Fix a field, retry, get the next error — each cycle ~10 min for cluster operations. Mitigation: validate all parameters against `--help` constraints before the first call; use `--cli-jsonInput` for faster retries. |
 
 ## Security Considerations
 

--- a/plugins/huaweicloud-core/skills/huawei-deployment/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-deployment/SKILL.md
@@ -18,6 +18,7 @@ Domain expertise for Huawei Cloud CloudDeploy. Covers application creation, depl
 
 | Trap | Why |
 |------|-----|
+| **Flyway SQL dialect mismatch (H2 dev → MySQL prod)** | Spring Boot apps commonly develop with H2 in-memory DB, then deploy to RDS MySQL. Flyway migrations using H2-specific syntax (e.g. `DATEADD`, `CHARACTER_LENGTH`, `BOOLEAN`) silently succeed on H2 but fail on MySQL. Before deploying, audit `V*__*.sql` migration files: replace `DATEADD` with `DATE_ADD`, `BOOLEAN` with `TINYINT(1)`, remove `characterEncoding=utf8mb4` from Spring Boot datasource URL (KooCLI RDS CreateInstance sets charset at the instance level). Use `Flyway.validate-on-migrate=true` in CI to catch dialect issues early. |
 | Service name may be `CodeArtsDeploy` | hcloud service name for deployment may be `CodeArtsDeploy` instead of `CloudDeploy`. Run `hcloud --help` to verify |
 | Deployment hosts need agent | Install CloudDeploy agent on target hosts first |
 | Task must reference application first | Create application before task |

--- a/scripts/pack-verify.mjs
+++ b/scripts/pack-verify.mjs
@@ -8,7 +8,7 @@ import { fileURLToPath } from 'node:url';
 const root = fileURLToPath(new URL('..', import.meta.url));
 const npm = process.platform === 'win32' ? 'npm.cmd' : 'npm';
 
-const quote = (arg) => `"${arg.replace(/"/g, '\\"')}"`;
+const quote = (arg) => `"${arg.replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"`;
 const runNpm = (args, options) =>
   execSync([npm, ...args.map(quote)].join(' '), { stdio: 'ignore', ...options });
 


### PR DESCRIPTION
## 背景

Issue #19 部署测试报告中遗留的 2 个待修复 P0/P1 问题。

## 修复

### P0: CCE 错误逐字段返回（#19 Bug 2）

Huawei Cloud API 创建 CCE 集群时，多字段错误只报第一个，修一个重试一次，每轮约10分钟。在 huawei-cce/SKILL.md 增加：
- Critical Warning：教导 agent 首次调用前用 --help 逐字段验证，用 --cli-jsonInput 减少重试开销
- Troubleshooting 条目：识别逐字段报错特征并给出缓解方案

### P1: Flyway H2 to MySQL SQL 方言不兼容（#19 Bug 6）

Spring Boot + H2 开发，部署到 RDS MySQL 时，Flyway 迁移文件中的 H2 专属语法（DATEADD / BOOLEAN / characterEncoding=utf8mb4）在 H2 上静默通过，MySQL 上失败。在 huawei-deployment/SKILL.md 增加：
- Critical Warning：列出常见不兼容项及替换方案，建议 CI 中启用 Flyway.validate-on-migrate

## 验证

- npm test 103/103 通过
- npm run validate 通过