### PR TITLE
fix: reset dev version to 1.0.1 (stable baseline, not a release branch)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "huaweicloud-devkit",
-    "version": "1.0.2-dev.10",
+    "version": "1.0.1",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "huaweicloud-devkit",
-            "version": "1.0.2-dev.10",
+            "version": "1.0.1",
             "hasInstallScript": true,
             "license": "Apache-2.0",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "huaweicloud-devkit",
-    "version": "1.0.2-dev.10",
+    "version": "1.0.1",
     "description": "Agent toolkit that helps coding agents use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities safely and accurately.",
     "type": "module",
     "files": [

--- a/plugins/huaweicloud-core/.claude-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.claude-plugin/plugin.json
@@ -20,7 +20,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "skills": "./skills/",
-  "version": "1.0.2-dev.10",
+  "version": "1.0.1",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"

--- a/plugins/huaweicloud-core/.codex-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.codex-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "huaweicloud-core",
-  "version": "1.0.2-dev.10",
+  "version": "1.0.1",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {
     "name": "HuaweiCloud Mate",

--- a/plugins/huaweicloud-core/.cursor-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.cursor-plugin/plugin.json
@@ -20,7 +20,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "skills": "./skills/",
-  "version": "1.0.2-dev.10",
+  "version": "1.0.1",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"

--- a/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "huaweicloud-core",
-  "version": "1.0.2-dev.10",
+  "version": "1.0.1",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {
     "name": "HuaweiCloud Mate",


### PR DESCRIPTION
dev is the integration branch, not a release branch. Its version was left at the orphaned 1.0.2-dev.10 from the old publish-dev workflow. Resetting to 1.0.1 (current npm stable baseline) so dev-to-next syncs don't pollute next's version line.