### PR TITLE
fix(proxy): resolve proxy issues - case sensitivity, undici, TLS, WebSocket constructor

### DIFF
--- a/plugins/huaweicloud-core/src/proxy/proxy-agent.mjs
+++ b/plugins/huaweicloud-core/src/proxy/proxy-agent.mjs
@@ -48,113 +48,22 @@ export async function createProxyWebSocket(url, protocols) {
   return new UndiciWebSocket(url, wsOptions);
 }
 
-export function getWebSocketImpl(targetUrl) {
+export async function getWebSocketImpl(targetUrl) {
   const proxyUrl = getProxyUrlForTarget(targetUrl);
   if (!proxyUrl) return globalThis.WebSocket;
 
-  return (url, protocols) => {
-    const proxyUrlForTarget = getProxyUrlForTarget(url);
-    if (!proxyUrlForTarget) {
-      return new globalThis.WebSocket(url, protocols);
-    }
+  const dispatcher = await getProxyDispatcher(targetUrl);
+  const { WebSocket: UndiciWebSocket } = await importUndici();
 
-    const wsPromise = (async () => {
-      const dispatcher = await getProxyDispatcher(url);
-      const { WebSocket: UndiciWebSocket } = await importUndici();
-
-      const wsOptions = { dispatcher };
+  class ProxyWebSocket extends UndiciWebSocket {
+    constructor(url, protocols) {
+      const options = { dispatcher };
       if (protocols) {
-        if (Array.isArray(protocols)) {
-          wsOptions.protocols = protocols;
-        } else {
-          wsOptions.protocols = [protocols];
-        }
+        options.protocols = Array.isArray(protocols) ? protocols : [protocols];
       }
-
-      return new UndiciWebSocket(url, wsOptions);
-    })();
-
-    return createSyncProxyWebSocketWrapper(wsPromise);
-  };
-}
-
-function createSyncProxyWebSocketWrapper(wsPromise) {
-  const pendingEvents = [];
-  const eventHandlers = new Map();
-  let ws = null;
-  let settled = false;
-  let readyState = 0;
-  let binaryType = 'arraybuffer';
-
-  const wrapper = {
-    get readyState() { return ws ? ws.readyState : readyState; },
-    get url() { return ws ? ws.url : ''; },
-    get protocol() { return ws ? ws.protocol : ''; },
-    get binaryType() { return ws ? ws.binaryType : binaryType; },
-    set binaryType(v) {
-      binaryType = v;
-      if (ws) ws.binaryType = v;
-    },
-
-    send(data, callback) {
-      if (ws) {
-        if (ws.send.length >= 2) return ws.send(data, callback);
-        try { ws.send(data); if (callback) callback(null); } catch (e) { if (callback) callback(e); }
-        return;
-      }
-      pendingEvents.push({ type: 'send', data, callback });
-    },
-
-    close(code, reason) {
-      if (ws) { ws.close(code, reason); return; }
-      readyState = 3;
-      pendingEvents.push({ type: 'close', code, reason });
-    },
-
-    addEventListener(type, handler) {
-      if (!eventHandlers.has(type)) eventHandlers.set(type, new Set());
-      eventHandlers.get(type).add(handler);
-      if (ws) ws.addEventListener(type, handler);
-    },
-
-    removeEventListener(type, handler) {
-      const handlers = eventHandlers.get(type);
-      if (handlers) handlers.delete(handler);
-      if (ws) ws.removeEventListener(type, handler);
-    },
-
-    on(type, handler) { wrapper.addEventListener(type, handler); },
-    off(type, handler) { wrapper.removeEventListener(type, handler); },
-  };
-
-  function flushPendingEvents() {
-    for (const evt of pendingEvents) {
-      if (evt.type === 'send') {
-        if (ws.send.length >= 2) ws.send(evt.data, evt.callback);
-        else { try { ws.send(evt.data); if (evt.callback) evt.callback(null); } catch (e) { if (evt.callback) evt.callback(e); } }
-      } else if (evt.type === 'close') {
-        ws.close(evt.code, evt.reason);
-      }
+      super(url, options);
     }
-    pendingEvents.length = 0;
   }
 
-  wsPromise.then((resolvedWs) => {
-    ws = resolvedWs;
-    if ('binaryType' in ws) ws.binaryType = binaryType;
-    for (const [type, handlers] of eventHandlers) {
-      for (const handler of handlers) {
-        ws.addEventListener(type, handler);
-      }
-    }
-    flushPendingEvents();
-  }).catch((err) => {
-    readyState = 3;
-    const handlers = eventHandlers.get('error');
-    if (handlers) for (const h of handlers) h(err instanceof Error ? err : new Error(String(err)));
-    const closeHandlers = eventHandlers.get('close');
-    if (closeHandlers) for (const h of closeHandlers) h({ code: 1006, reason: err.message || String(err) });
-  });
-
-  return wrapper;
+  return ProxyWebSocket;
 }

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -58,7 +58,7 @@ async function getSession(workspaceId, username, timeoutMs) {
   const { ak, sk, securitytoken } = getCredentials();
   const { wsUrl, source } = await createConnection(workspaceId, ak, sk, securitytoken);
 
-  const WebSocketImpl = getWebSocketImpl(wsUrl);
+  const WebSocketImpl = await getWebSocketImpl(wsUrl);
 
   const { connectHwlinkTerminalSession } = await import(WS_EXEC_INDEX_URL);
   const session = await connectHwlinkTerminalSession({
@@ -77,7 +77,7 @@ export async function execOneShot(workspaceId, command, username, timeoutMs) {
   const { ak, sk, securitytoken } = getCredentials();
   const { wsUrl, source } = await createConnection(workspaceId, ak, sk, securitytoken);
 
-  const WebSocketImpl = getWebSocketImpl(wsUrl);
+  const WebSocketImpl = await getWebSocketImpl(wsUrl);
 
   const { executeHwlinkCommand } = await import(WS_EXEC_INDEX_URL);
   return await executeHwlinkCommand({


### PR DESCRIPTION
## Summary

Fix proxy-related issues identified in enterprise network testing (devkittest18.md + devkittest19.md).

### Batch 1: devkittest18.md

| Issue | Priority | Fix |
|-------|----------|-----|
| #1 proxy.json field name case sensitivity | P0 | Read both `http_proxy` and `HTTP_PROXY` from file config |
| #2 undici dependency missing | P0 | Add `undici: ^6.21.0` to dependencies; prefer `node:undici` fallback to `undici` |
| #3 SSL certificate verification failure | P1 | Default `NODE_TLS_REJECT_UNAUTHORIZED=0` in mcp-server.mjs |
| #4 no_proxy wildcard format unsupported | P2 | Support `*.domain` pattern in `shouldBypassProxy` |
| #6 proxy init default no_proxy | P1 | Update default to `127.0.0.1,localhost,.huawei.com` |
| New: install guide missing proxy step | P1 | Add `proxy init` to install next steps |
| New: hcloud proxy sync | P1 | Inject proxy env vars into hcloud child process only (not global process.env) |

### Batch 2: devkittest19.md (P0)

| Issue | Fix |
|-------|-----|
| `WebSocketImpl is not a constructor` | `getWebSocketImpl()` changed to async, returns `ProxyWebSocket` class extending `UndiciWebSocket` instead of arrow function |
| Sync wrapper unnecessary | Deleted `createSyncProxyWebSocketWrapper` (~80 lines) |
| `session-manager.mjs` missing await | Added `await` to both `getWebSocketImpl()` calls |

### Key Design Decisions

- **undici auto-install**: Added as npm dependency; code still tries `node:undici` first
- **TLS default off**: `NODE_TLS_REJECT_UNAUTHORIZED=0` set by default for enterprise self-signed certs
- **hcloud proxy scope**: Proxy env vars injected ONLY into hcloud child process env, never to `process.env`
- **WebSocket class vs function**: Arrow functions cannot be called with `new`; class constructors can

### Test Results

```
103 tests passed, 0 failed
npm run validate: OK (28 skills)
```