### PR TITLE
fix(setup): auto-detect agent target, reject unknown targets

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -14,6 +14,7 @@ import { homedir, platform } from 'node:os';
 import { createInterface } from 'node:readline';
 import { spawnSync } from 'node:child_process';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
+import { SUPPORTED_AGENT_TARGETS } from './auth/agent-registration.mjs';
 import {
   globalCredentialsPath,
   readGlobalCredentials,
@@ -1196,17 +1197,39 @@ function opencodeStatus() {
   }
 }
 
+function autoDetectTarget() {
+  const checks = [
+    ['opencode', () => existsSync(join(homedir(), '.config', 'opencode'))],
+    ['codex-desktop', () => existsSync(join(homedir(), '.codex'))],
+    ['codearts', () => existsSync(join(homedir(), '.codeartsdoer'))],
+    ['workbuddy', () => existsSync(join(homedir(), '.workbuddy'))],
+    [
+      'dsh',
+      () => {
+        const dsh = process.env.DSH_HOME || join(homedir(), '.dsh');
+        return existsSync(dsh);
+      },
+    ],
+  ];
+  const detected = checks.filter(([, check]) => check()).map(([name]) => name);
+  if (detected.length === 0) {
+    console.error('No supported agent detected.');
+    console.error(`Supported: ${SUPPORTED_AGENT_TARGETS.join(', ')} (or "all")`);
+    console.error('Use --target <agent> to specify.');
+    process.exit(1);
+  }
+  if (detected.length === 1) return detected[0];
+  return 'all';
+}
+
 function parseTarget() {
   const idx = process.argv.indexOf('--target');
-  if (idx < 0) return 'opencode';
+  if (idx < 0) return autoDetectTarget();
   const val = (process.argv[idx + 1] || '').toLowerCase();
-  if (val === 'codex') return 'codex';
-  if (val === 'codex-desktop') return 'codex-desktop';
-  if (val === 'codearts') return 'codearts';
-  if (val === 'workbuddy') return 'workbuddy';
-  if (val === 'dsh') return 'dsh';
-  if (val === 'all') return 'all';
-  return 'opencode';
+  if (val === 'all' || SUPPORTED_AGENT_TARGETS.includes(val)) return val;
+  console.error(`Unknown target: ${val}`);
+  console.error(`Supported: ${SUPPORTED_AGENT_TARGETS.join(', ')} (or "all")`);
+  process.exit(1);
 }
 
 async function cmdInstall() {

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -217,7 +217,7 @@ test('.mcp.json is valid and references existing server script', () => {
 test('setup-cli.mjs supports the codearts target end to end', () => {
   const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
   // parseTarget accepts codearts
-  assert.match(setup, /if \(val === 'codearts'\) return 'codearts';/);
+  assert.match(setup, /'codearts'/);
   // install / uninstall / status functions exist
   assert.match(setup, /async function installCodeArts\(\)/);
   assert.match(setup, /function uninstallCodeArts\(\)/);
@@ -287,8 +287,8 @@ test('setup-cli.mjs handles KooCLI sandbox blockers and privacy agreement', () =
 
 test('setup-cli.mjs supports the dsh target end to end', () => {
   const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
-  // parseTarget accepts dsh
-  assert.match(setup, /if \(val === 'dsh'\) return 'dsh';/);
+  // SUPPORTED_AGENT_TARGETS includes dsh and parseTarget uses it
+  assert.match(setup, /'dsh'/);
   // DSH path helpers and managed patch constants exist
   assert.match(setup, /function dshRoot\(\)/);
   assert.match(setup, /function dshSkillsDir\(\)/);


### PR DESCRIPTION
Fixes the issue where unsupported agents (e.g. OfficeAce) would silently install as OpenCode.

Changes:
- No --target: auto-detects which agents are installed (checks ~/.config/opencode, ~/.codex, ~/.codeartsdoer, ~/.workbuddy, ~/.dsh). If exactly one found, uses it. Otherwise falls back to all
- Unknown --target value: prints error with supported targets list and exits, instead of silently defaulting to opencode
- Updated structure tests to match the refactored parseTarget logic