### PR TITLE
fix(tools): skip stale skills dirs in SKILLS_ROOT fallback, support symlinked skills

### DIFF
--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -35,13 +35,34 @@ function dshSkillsDir() {
   const home = process.env.DSH_HOME || join(homedir(), '.dsh');
   return join(home, 'skills');
 }
+export function listSkillDirs(root) {
+  if (!existsSync(root)) return [];
+  try {
+    return readdirSync(root, { withFileTypes: true })
+      .filter((d) => (d.isDirectory() || d.isSymbolicLink()) && existsSync(join(root, d.name, 'SKILL.md')))
+      .map((d) => d.name);
+  } catch {
+    return [];
+  }
+}
+
+export function findSkillsRoot(candidates) {
+  for (const dir of candidates) {
+    if (listSkillDirs(dir).length > 0) return dir;
+  }
+  return null;
+}
+
 function resolveSkillsRoot() {
-  if (existsSync(SKILLS_ROOT_DEV)) return SKILLS_ROOT_DEV;
-  if (existsSync(dshSkillsDir())) return dshSkillsDir();
-  if (existsSync(codeartsSkillsDir())) return codeartsSkillsDir();
-  if (existsSync(opencodeSkillsDir())) return opencodeSkillsDir();
-  if (existsSync(workbuddySkillsDir())) return workbuddySkillsDir();
-  return SKILLS_ROOT_DEV;
+  return (
+    findSkillsRoot([
+      SKILLS_ROOT_DEV,
+      dshSkillsDir(),
+      codeartsSkillsDir(),
+      opencodeSkillsDir(),
+      workbuddySkillsDir(),
+    ]) || SKILLS_ROOT_DEV
+  );
 }
 const SKILLS_ROOT = resolveSkillsRoot();
 
@@ -1060,9 +1081,7 @@ async function searchDocs(query, topic = 'all') {
   const results = [];
   try {
     if (existsSync(SKILLS_ROOT)) {
-      const dirs = readdirSync(SKILLS_ROOT, { withFileTypes: true })
-        .filter((d) => d.isDirectory())
-        .map((d) => d.name);
+      const dirs = listSkillDirs(SKILLS_ROOT);
       for (const dir of dirs) {
         const skillPath = join(SKILLS_ROOT, dir, 'SKILL.md');
         if (!existsSync(skillPath)) continue;
@@ -1114,11 +1133,7 @@ async function retrieveSkill(name) {
   if (!skillName) return { ok: false, error: 'Skill name is required.' };
   const skillPath = join(SKILLS_ROOT, skillName, 'SKILL.md');
   if (!existsSync(skillPath)) {
-    const dirs = existsSync(SKILLS_ROOT)
-      ? readdirSync(SKILLS_ROOT, { withFileTypes: true })
-          .filter((d) => d.isDirectory())
-          .map((d) => d.name)
-      : [];
+    const dirs = listSkillDirs(SKILLS_ROOT);
     return { ok: false, error: 'Skill "' + skillName + '" not found. Available: ' + dirs.join(', ') };
   }
   const content = readFileSync(skillPath, 'utf8');

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -55,13 +55,8 @@ export function findSkillsRoot(candidates) {
 
 function resolveSkillsRoot() {
   return (
-    findSkillsRoot([
-      SKILLS_ROOT_DEV,
-      dshSkillsDir(),
-      codeartsSkillsDir(),
-      opencodeSkillsDir(),
-      workbuddySkillsDir(),
-    ]) || SKILLS_ROOT_DEV
+    findSkillsRoot([SKILLS_ROOT_DEV, dshSkillsDir(), codeartsSkillsDir(), opencodeSkillsDir(), workbuddySkillsDir()]) ||
+    SKILLS_ROOT_DEV
   );
 }
 const SKILLS_ROOT = resolveSkillsRoot();

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -259,7 +259,11 @@ test('tools.mjs resolves skills from the codearts directory', () => {
   const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
   assert.match(tools, /function codeartsSkillsDir\(\)/);
   assert.match(tools, /return join\(home, '\.codeartsdoer', 'skills'\);/);
-  assert.match(tools, /if \(existsSync\(codeartsSkillsDir\(\)\)\) return codeartsSkillsDir\(\);/);
+  // candidates only count when they contain at least one skill with SKILL.md
+  assert.match(tools, /export function findSkillsRoot/);
+  assert.match(tools, /export function listSkillDirs/);
+  assert.match(tools, /existsSync\(join\(root, d\.name, 'SKILL\.md'\)\)/);
+  assert.match(tools, /findSkillsRoot\(\[[\s\S]*?SKILLS_ROOT_DEV[\s\S]*?dshSkillsDir\(\)[\s\S]*?codeartsSkillsDir\(\)[\s\S]*?opencodeSkillsDir\(\)[\s\S]*?workbuddySkillsDir\(\)[\s\S]*?\]\)/);
 });
 
 test('setup-cli.mjs handles KooCLI sandbox blockers and privacy agreement', () => {
@@ -336,7 +340,9 @@ test('tools.mjs resolves skills from the dsh directory', () => {
   assert.match(tools, /function dshSkillsDir\(\)/);
   assert.match(tools, /process\.env\.DSH_HOME \|\| join\(homedir\(\), '\.dsh'\)/);
   assert.match(tools, /return join\(home, 'skills'\);/);
-  assert.match(tools, /if \(existsSync\(dshSkillsDir\(\)\)\) return dshSkillsDir\(\);/);
+  // stale or empty dirs must not short-circuit the fallback chain
+  assert.match(tools, /resolveSkillsRoot[\s\S]*?findSkillsRoot\(\[/);
+  assert.match(tools, /\|\| SKILLS_ROOT_DEV/);
   assert.match(tools, /opencode, codex, codex-desktop, codearts, workbuddy, dsh, or all/);
 });
 

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -263,7 +263,10 @@ test('tools.mjs resolves skills from the codearts directory', () => {
   assert.match(tools, /export function findSkillsRoot/);
   assert.match(tools, /export function listSkillDirs/);
   assert.match(tools, /existsSync\(join\(root, d\.name, 'SKILL\.md'\)\)/);
-  assert.match(tools, /findSkillsRoot\(\[[\s\S]*?SKILLS_ROOT_DEV[\s\S]*?dshSkillsDir\(\)[\s\S]*?codeartsSkillsDir\(\)[\s\S]*?opencodeSkillsDir\(\)[\s\S]*?workbuddySkillsDir\(\)[\s\S]*?\]\)/);
+  assert.match(
+    tools,
+    /findSkillsRoot\(\[[\s\S]*?SKILLS_ROOT_DEV[\s\S]*?dshSkillsDir\(\)[\s\S]*?codeartsSkillsDir\(\)[\s\S]*?opencodeSkillsDir\(\)[\s\S]*?workbuddySkillsDir\(\)[\s\S]*?\]\)/,
+  );
 });
 
 test('setup-cli.mjs handles KooCLI sandbox blockers and privacy agreement', () => {
@@ -342,7 +345,7 @@ test('tools.mjs resolves skills from the dsh directory', () => {
   assert.match(tools, /return join\(home, 'skills'\);/);
   // stale or empty dirs must not short-circuit the fallback chain
   assert.match(tools, /resolveSkillsRoot[\s\S]*?findSkillsRoot\(\[/);
-  assert.match(tools, /\|\| SKILLS_ROOT_DEV/);
+  assert.match(tools, /\|\|\s*SKILLS_ROOT_DEV/);
   assert.match(tools, /opencode, codex, codex-desktop, codearts, workbuddy, dsh, or all/);
 });
 

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -1,9 +1,15 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
-import { callTool, runVersionCheck, TOOL_DEFINITIONS } from '../plugins/huaweicloud-core/src/tools.mjs';
+import {
+  callTool,
+  runVersionCheck,
+  TOOL_DEFINITIONS,
+  findSkillsRoot,
+  listSkillDirs,
+} from '../plugins/huaweicloud-core/src/tools.mjs';
 
 test('runVersionCheck uses hcloud version instead of --version', async () => {
   const dir = mkdtempSync(join(tmpdir(), 'huaweicloud-toolkit-version-'));
@@ -130,4 +136,43 @@ test('service_catalog keeps storage routing for pure storage intent', async () =
   const result = await callTool('huaweicloud_service_catalog', { intent: 'store files in an obs bucket' });
   assert.ok(result.recommendedSkills.includes('huawei-obs'));
   assert.notEqual(result.recommendedSkills[0], 'huawei-sandbox');
+});
+
+test('findSkillsRoot skips stale dirs without SKILL.md and picks the first real skills root', () => {
+  const base = mkdtempSync(join(tmpdir(), 'huaweicloud-skills-root-'));
+  try {
+    const empty = join(base, 'empty');
+    const stale = join(base, 'stale');
+    const real = join(base, 'real');
+    mkdirSync(empty);
+    mkdirSync(stale);
+    mkdirSync(join(stale, 'leftover'), { recursive: true });
+    mkdirSync(join(real, 'huawei-ecs'), { recursive: true });
+    writeFileSync(join(real, 'huawei-ecs', 'SKILL.md'), '---\nname: huawei-ecs\n---\n', 'utf8');
+
+    assert.equal(findSkillsRoot([empty, stale, real]), real);
+    assert.equal(findSkillsRoot([empty, stale]), null);
+    assert.equal(findSkillsRoot([]), null);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
+});
+
+test('listSkillDirs ignores files, subdirs without SKILL.md, and counts symlinked skill dirs', () => {
+  const base = mkdtempSync(join(tmpdir(), 'huaweicloud-list-skills-'));
+  try {
+    const root = join(base, 'root');
+    const external = join(base, 'external');
+    mkdirSync(root, { recursive: true });
+    mkdirSync(join(external, 'huawei-vpc'), { recursive: true });
+    writeFileSync(join(external, 'huawei-vpc', 'SKILL.md'), '---\nname: huawei-vpc\n---\n', 'utf8');
+    symlinkSync(join(external, 'huawei-vpc'), join(root, 'huawei-vpc'));
+    mkdirSync(join(root, 'no-skill'));
+    writeFileSync(join(root, 'stray.md'), 'x');
+
+    assert.deepEqual(listSkillDirs(root).sort(), ['huawei-vpc']);
+    assert.deepEqual(listSkillDirs(join(base, 'missing')), []);
+  } finally {
+    rmSync(base, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## Problem

`huaweicloud_retrieve_skill` / `huaweicloud_search_docs` returned an empty skill list (`Available: `) on a machine where `~/.codeartsdoer/skills` existed as a leftover directory containing only a symlink (no `SKILL.md` entries). The fallback chain in `resolveSkillsRoot()` stopped at the first *existing* directory, so a stale dir short-circuited resolution and the tools never reached `~/.config/opencode/skills`.

## Changes

- `resolveSkillsRoot()` now selects a candidate only when it contains at least one skill directory with a `SKILL.md` (exported `findSkillsRoot` / `listSkillDirs` helpers)
- `retrieveSkill` and `searchDocs` reuse `listSkillDirs` and count symlinked skill directories (previously symlinks were invisible, producing empty `Available:` listings)
- New unit tests in `test/tools.test.mjs`; structure assertions updated in `test/structure.test.mjs`

## Verification

- `npm test`: 111/111 pass
- `npm run lint`: clean
- `npm run validate`: clean

## Notes

For properly installed agents the selected skills root is identical to before (all candidates receive real skill directories from the installer); behavior only changes for stale/empty directories, where resolution now falls through instead of dead-ending.