### PR TITLE
fix(huaweicloud-core): add codex desktop skills dir to resolveSkillsRoot

### DIFF
--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -17,6 +17,10 @@ function opencodeSkillsDir() {
   const home = homedir();
   return join(home, '.config', 'opencode', 'skills');
 }
+function codexDesktopSkillsDir() {
+  const home = homedir();
+  return join(home, '.agents', 'skills');
+}
 function codeartsSkillsDir() {
   const home = homedir();
   return join(home, '.codeartsdoer', 'skills');
@@ -29,6 +33,7 @@ function resolveSkillsRoot() {
   if (existsSync(SKILLS_ROOT_DEV)) return SKILLS_ROOT_DEV;
   if (existsSync(codeartsSkillsDir())) return codeartsSkillsDir();
   if (existsSync(opencodeSkillsDir())) return opencodeSkillsDir();
+  if (existsSync(codexDesktopSkillsDir())) return codexDesktopSkillsDir();
   if (existsSync(workbuddySkillsDir())) return workbuddySkillsDir();
   return SKILLS_ROOT_DEV;
 }

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -239,6 +239,13 @@ test('tools.mjs resolves skills from the codearts directory', () => {
   assert.match(tools, /if \(existsSync\(codeartsSkillsDir\(\)\)\) return codeartsSkillsDir\(\);/);
 });
 
+test('tools.mjs resolves skills from the codex desktop directory', () => {
+  const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
+  assert.match(tools, /function codexDesktopSkillsDir\(\)/);
+  assert.match(tools, /return join\(home, '\.agents', 'skills'\);/);
+  assert.match(tools, /if \(existsSync\(codexDesktopSkillsDir\(\)\)\) return codexDesktopSkillsDir\(\);/);
+});
+
 test('setup-cli.mjs handles KooCLI sandbox blockers and privacy agreement', () => {
   const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
   // sandbox detection reads the CodeArts permission config


### PR DESCRIPTION
## Problem

For Codex Desktop, the installer copies skills to `~/.agents/skills` (`codexDesktopSkillsDir()` in `setup-cli.mjs`), but `resolveSkillsRoot()` in `plugins/huaweicloud-core/src/tools.mjs` never considers that directory. On a codex-only install, `huaweicloud_retrieve_skill` / `huaweicloud_search_docs` return empty results.

Fixes #170.

## Changes

- Added `codexDesktopSkillsDir()` (`~/.agents/skills`) to `plugins/huaweicloud-core/src/tools.mjs` and added it to the `resolveSkillsRoot()` fallback chain.
- Added a structural test in `test/structure.test.mjs` asserting the codex desktop candidate is resolved.

## Before / After

```diff
 function opencodeSkillsDir() {
   const home = homedir();
   return join(home, '.config', 'opencode', 'skills');
 }
+function codexDesktopSkillsDir() {
+  const home = homedir();
+  return join(home, '.agents', 'skills');
+}
 function codeartsSkillsDir() {
   ...
 }
   if (existsSync(codeartsSkillsDir())) return codeartsSkillsDir();
   if (existsSync(opencodeSkillsDir())) return opencodeSkillsDir();
+  if (existsSync(codexDesktopSkillsDir())) return codexDesktopSkillsDir();
   if (existsSync(workbuddySkillsDir())) return workbuddySkillsDir();
```

## Verification

- `npm test` — 87 pass
- `npm run validate` — pass