### PR TITLE
feat(officeace): write MCP config directly to mcp-connectors.sqlite

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "better-sqlite3": "^13.0.3",
+        "sql.js": "^1.14.2",
         "undici": "^8.10.0"
       },
       "bin": {
@@ -395,18 +395,6 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
-      }
-    },
-    "node_modules/better-sqlite3": {
-      "version": "13.0.3",
-      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
-      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
-      "license": "MIT",
-      "dependencies": {
-        "node-addon-api": "^8.0.0"
-      },
-      "engines": {
-        "node": ">=22"
       }
     },
     "node_modules/brace-expansion": {
@@ -2034,15 +2022,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/node-addon-api": {
-      "version": "8.9.2",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
-      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
-      "license": "MIT",
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -2319,6 +2298,12 @@
       "funding": {
         "url": "https://github.com/sponsors/cyyynthia"
       }
+    },
+    "node_modules/sql.js": {
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sql.js/-/sql.js-1.14.2.tgz",
+      "integrity": "sha512-3ZGPovObMFrdw79zrUHbfdE/DLIsy8jdNdssmMSQuRAymedU6q84asPt0kgiqrdMYlPegDItiIMfmIXzZnYFcw==",
+      "license": "MIT"
     },
     "node_modules/string-width": {
       "version": "8.2.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
+        "better-sqlite3": "^13.0.3",
         "undici": "^8.10.0"
       },
       "bin": {
-        "huaweicloud-devkit": "bin/setup.cjs"
+        "huaweicloud-devkit": "bin/setup.cjs",
+        "huaweicloud-devkit-mcp": "plugins/huaweicloud-core/src/mcp-server.mjs"
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
@@ -393,6 +395,18 @@
       "license": "MIT",
       "engines": {
         "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/better-sqlite3": {
+      "version": "13.0.3",
+      "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
+      "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "license": "MIT",
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=22"
       }
     },
     "node_modules/brace-expansion": {
@@ -2019,6 +2033,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "postinstall": "node -e \"console.log('\\nHuaweiCloud DevKit installed. Run: npx huaweicloud-devkit install\\n')\""
   },
   "dependencies": {
-    "better-sqlite3": "^13.0.3",
+    "sql.js": "^1.14.2",
     "undici": "^8.10.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "postinstall": "node -e \"console.log('\\nHuaweiCloud DevKit installed. Run: npx huaweicloud-devkit install\\n')\""
   },
   "dependencies": {
+    "better-sqlite3": "^13.0.3",
     "undici": "^8.10.0"
   },
   "devDependencies": {

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -1,7 +1,8 @@
 import { existsSync, readFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
+import { createRequire } from 'node:module';
 
 export const SUPPORTED_AGENT_TARGETS = [
   'opencode',
@@ -113,12 +114,28 @@ function officeaceCapabilitiesDir() {
   return dotDir;
 }
 
+function officeaceSqlitePath() {
+  const capDir = officeaceCapabilitiesDir();
+  return join(resolve(capDir, '..'), 'data', 'mcp-connectors.sqlite');
+}
+
 function officeaceRegistered() {
+  let hasMcp = false;
+  const dbPath = officeaceSqlitePath();
+  if (existsSync(dbPath)) {
+    try {
+      const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite');
+      const db = new DatabaseSync(dbPath, { readonly: true });
+      const row = db.prepare("SELECT enabled FROM mcp_connectors WHERE name = 'huaweicloud-devkit'").get();
+      db.close();
+      hasMcp = Boolean(row?.enabled);
+    } catch {}
+  }
+
   const capFile = join(officeaceCapabilitiesDir(), 'capabilities.json');
   const cfg = readJsonSafe(capFile);
-  if (!cfg?.capabilities) return false;
-  const hasMcp = cfg.capabilities.some((c) => c.id === 'huaweicloud-devkit' && c.type === 'mcp');
-  const hasSkills = cfg.capabilities.some((c) => c.id === 'huaweicloud-core' && c.type === 'skill');
+  const hasSkills = cfg?.capabilities?.some((c) => c.id === 'huaweicloud-core' && c.type === 'skill') ?? false;
+
   return hasMcp || hasSkills;
 }
 

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -14,7 +14,7 @@ import { homedir, platform } from 'node:os';
 import { createInterface } from 'node:readline';
 import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { createRequire } from 'node:module';
+import Database from 'better-sqlite3';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { SUPPORTED_AGENT_TARGETS } from './auth/agent-registration.mjs';
 import {
@@ -158,15 +158,14 @@ function officeaceSqlitePath() {
 }
 
 function openOfficeaceDb() {
-  const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite');
-  return new DatabaseSync(officeaceSqlitePath());
+  return new Database(officeaceSqlitePath());
 }
 
 function officeaceGetOwnerUserId() {
   if (!existsSync(officeaceSqlitePath())) return null;
   try {
     const db = openOfficeaceDb();
-    const row = db.prepare("SELECT owner_user_id FROM mcp_connectors WHERE owner_user_id IS NOT NULL LIMIT 1").get();
+    const row = db.prepare('SELECT owner_user_id FROM mcp_connectors WHERE owner_user_id IS NOT NULL LIMIT 1').get();
     db.close();
     return row?.owner_user_id || null;
   } catch {
@@ -226,7 +225,9 @@ function ensureOfficeaceMcpInSqlite() {
     return true;
   } catch (err) {
     if (db) {
-      try { db.close(); } catch {}
+      try {
+        db.close();
+      } catch {}
     }
     console.log(`  \x1b[31mFailed to write MCP config: ${err.message}\x1b[0m`);
     return false;
@@ -239,7 +240,9 @@ function removeOfficeaceMcpFromSqlite() {
   let db;
   try {
     db = openOfficeaceDb();
-    db.prepare("DELETE FROM mcp_connector_tools WHERE connector_id IN (SELECT id FROM mcp_connectors WHERE name = 'huaweicloud-devkit')").run();
+    db.prepare(
+      "DELETE FROM mcp_connector_tools WHERE connector_id IN (SELECT id FROM mcp_connectors WHERE name = 'huaweicloud-devkit')",
+    ).run();
     const result2 = db.prepare("DELETE FROM mcp_connectors WHERE name = 'huaweicloud-devkit'").run();
     if (result2.changes > 0) {
       console.log(`  MCP config removed: ${dbPath}`);
@@ -247,7 +250,9 @@ function removeOfficeaceMcpFromSqlite() {
     db.close();
   } catch (err) {
     if (db) {
-      try { db.close(); } catch {}
+      try {
+        db.close();
+      } catch {}
     }
     console.log(`  \x1b[31mFailed to remove MCP config: ${err.message}\x1b[0m`);
   }

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -13,6 +13,8 @@ import { fileURLToPath } from 'node:url';
 import { homedir, platform } from 'node:os';
 import { createInterface } from 'node:readline';
 import { spawnSync } from 'node:child_process';
+import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { SUPPORTED_AGENT_TARGETS } from './auth/agent-registration.mjs';
 import {
@@ -150,6 +152,107 @@ function officeacePluginsDir() {
   return join(officeaceCapabilitiesDir(), 'huaweicloud-plugins');
 }
 
+function officeaceSqlitePath() {
+  const capDir = officeaceCapabilitiesDir();
+  return join(resolve(capDir, '..'), 'data', 'mcp-connectors.sqlite');
+}
+
+function openOfficeaceDb() {
+  const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite');
+  return new DatabaseSync(officeaceSqlitePath());
+}
+
+function officeaceGetOwnerUserId() {
+  if (!existsSync(officeaceSqlitePath())) return null;
+  try {
+    const db = openOfficeaceDb();
+    const row = db.prepare("SELECT owner_user_id FROM mcp_connectors WHERE owner_user_id IS NOT NULL LIMIT 1").get();
+    db.close();
+    return row?.owner_user_id || null;
+  } catch {
+    return null;
+  }
+}
+
+function ensureOfficeaceMcpInSqlite() {
+  const dbPath = officeaceSqlitePath();
+  if (!existsSync(dbPath)) {
+    console.log(`  \x1b[31mOfficeAce database not found: ${dbPath}\x1b[0m`);
+    console.log(`  \x1b[33mPlease ensure OfficeAce is installed and has been launched at least once.\x1b[0m`);
+    return false;
+  }
+
+  const mcpPath = join(officeacePluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
+  const env = [{ key: 'HUAWEICLOUD_AGENT_TOOLKIT_MODE', value: 'local', sensitive: false }];
+  const hcloudBin = findHcloudBin();
+  if (hcloudBin) env.push({ key: 'HCLOUD_BIN', value: hcloudBin.replace(/\\/g, '/'), sensitive: false });
+
+  const now = Date.now();
+  let db;
+  try {
+    db = openOfficeaceDb();
+
+    const existing = db
+      .prepare("SELECT id, command, args_json FROM mcp_connectors WHERE name = 'huaweicloud-devkit'")
+      .get();
+
+    const argsJson = JSON.stringify([mcpPath]);
+    const envJson = JSON.stringify(env);
+
+    if (existing) {
+      if (existing.command === 'node' && existing.args_json === argsJson) {
+        console.log(`  MCP config unchanged: ${dbPath}`);
+        db.close();
+        return true;
+      }
+      db.prepare(
+        'UPDATE mcp_connectors SET command = ?, args_json = ?, env_json = ?, updated_at = ?, status = ?, enabled = 1 WHERE id = ?',
+      ).run('node', argsJson, envJson, now, 'disconnected', existing.id);
+      console.log(`  MCP config updated: ${dbPath}`);
+    } else {
+      const ownerUserId = officeaceGetOwnerUserId();
+      if (!ownerUserId) {
+        console.log(`  \x1b[31mCannot determine owner_user_id from database\x1b[0m`);
+        db.close();
+        return false;
+      }
+      db.prepare(
+        `INSERT INTO mcp_connectors (id, owner_user_id, type, name, normalized_name, transport, timeout_ms, command, args_json, env_json, enabled, status, created_at, updated_at, version, seeded)
+         VALUES (?, ?, 'custom', 'huaweicloud-devkit', 'huaweicloud-devkit', 'stdio', 60000, 'node', ?, ?, 1, 'disconnected', ?, ?, 1, 0)`,
+      ).run(randomUUID(), ownerUserId, argsJson, envJson, now, now);
+      console.log(`  MCP config created: ${dbPath}`);
+    }
+    db.close();
+    return true;
+  } catch (err) {
+    if (db) {
+      try { db.close(); } catch {}
+    }
+    console.log(`  \x1b[31mFailed to write MCP config: ${err.message}\x1b[0m`);
+    return false;
+  }
+}
+
+function removeOfficeaceMcpFromSqlite() {
+  const dbPath = officeaceSqlitePath();
+  if (!existsSync(dbPath)) return;
+  let db;
+  try {
+    db = openOfficeaceDb();
+    db.prepare("DELETE FROM mcp_connector_tools WHERE connector_id IN (SELECT id FROM mcp_connectors WHERE name = 'huaweicloud-devkit')").run();
+    const result2 = db.prepare("DELETE FROM mcp_connectors WHERE name = 'huaweicloud-devkit'").run();
+    if (result2.changes > 0) {
+      console.log(`  MCP config removed: ${dbPath}`);
+    }
+    db.close();
+  } catch (err) {
+    if (db) {
+      try { db.close(); } catch {}
+    }
+    console.log(`  \x1b[31mFailed to remove MCP config: ${err.message}\x1b[0m`);
+  }
+}
+
 function readCapabilitiesJson() {
   const capFile = officeaceCapabilitiesFile();
   if (!existsSync(capFile)) return { capabilities: [] };
@@ -165,54 +268,7 @@ function writeCapabilitiesJson(config) {
   writeFileSync(officeaceCapabilitiesFile(), JSON.stringify(config, null, 2));
 }
 
-function ensureOfficeaceCapabilities() {
-  const capFile = officeaceCapabilitiesFile();
-  const mcpPath = join(officeacePluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
-  const env = { HUAWEICLOUD_AGENT_TOOLKIT_MODE: 'local' };
-  const hcloudBin = findHcloudBin();
-  if (hcloudBin) env.HCLOUD_BIN = hcloudBin.replace(/\\/g, '/');
-
-  const config = readCapabilitiesJson();
-  let changed = false;
-
-  // Ensure MCP server entry
-  const mcpEntry = {
-    id: 'huaweicloud-devkit',
-    type: 'mcp',
-    enabled: true,
-    source: 'custom',
-    mcpServer: {
-      command: 'node',
-      args: [mcpPath],
-      env,
-    },
-  };
-  const existingMcpIdx = config.capabilities.findIndex((c) => c.id === 'huaweicloud-devkit' && c.type === 'mcp');
-  if (existingMcpIdx >= 0) {
-    const existing = config.capabilities[existingMcpIdx];
-    if (
-      existing.mcpServer?.command === 'node' &&
-      Array.isArray(existing.mcpServer?.args) &&
-      existing.mcpServer.args[0] === mcpPath
-    ) {
-      console.log(`  MCP config unchanged: ${capFile}`);
-    } else {
-      config.capabilities[existingMcpIdx] = mcpEntry;
-      changed = true;
-    }
-  } else {
-    config.capabilities.push(mcpEntry);
-    changed = true;
-  }
-
-  if (changed) {
-    writeCapabilitiesJson(config);
-    console.log(`  MCP config updated: ${capFile}`);
-  }
-  return changed;
-}
-
-function removeOfficeaceCapabilities() {
+function removeOfficeaceSkillCapabilities() {
   const capFile = officeaceCapabilitiesFile();
   if (!existsSync(capFile)) return;
   let config;
@@ -226,14 +282,13 @@ function removeOfficeaceCapabilities() {
   config.capabilities = config.capabilities.filter(
     (c) =>
       !(
-        (c.id === 'huaweicloud-devkit' && c.type === 'mcp') ||
         (c.id === 'huaweicloud-core' && c.type === 'skill') ||
         (c.source === 'custom' && c.id && c.id.startsWith('huawei'))
       ),
   );
   if (config.capabilities.length !== origLen) {
     writeCapabilitiesJson(config);
-    console.log(`  Capabilities cleaned: ${capFile}`);
+    console.log(`  Skill capabilities cleaned: ${capFile}`);
   }
 }
 
@@ -1367,7 +1422,7 @@ async function installOfficeAce() {
   copyDir(safetyDir, join(pluginDest, 'safety'));
   console.log(`  Safety Policy -> ${join(pluginDest, 'safety')}`);
 
-  ensureOfficeaceCapabilities();
+  ensureOfficeaceMcpInSqlite();
   registerOfficeaceSkillEntries();
 }
 
@@ -1384,7 +1439,7 @@ async function updateOfficeAce() {
   console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
   copyDir(safetyDir, join(pluginDest, 'safety'));
   console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
-  ensureOfficeaceCapabilities();
+  ensureOfficeaceMcpInSqlite();
   registerOfficeaceSkillEntries();
   mkdirSync(pluginDest, { recursive: true });
   writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
@@ -1412,7 +1467,8 @@ function uninstallOfficeAce() {
   if (removeIfExists(officeacePluginsDir())) {
     console.log('  Removed MCP server and safety policy');
   }
-  removeOfficeaceCapabilities();
+  removeOfficeaceSkillCapabilities();
+  removeOfficeaceMcpFromSqlite();
 }
 
 function officeaceStatus() {
@@ -1433,15 +1489,23 @@ function officeaceStatus() {
   console.log(
     `  Skills: ${skillCount > 0 ? `\x1b[32m${skillCount} installed\x1b[0m` : '\x1b[31mNot installed\x1b[0m'}`,
   );
-  const capFile = officeaceCapabilitiesFile();
-  if (existsSync(capFile)) {
+  const dbPath = officeaceSqlitePath();
+  if (existsSync(dbPath)) {
     try {
-      const config = JSON.parse(readFileSync(capFile, 'utf8'));
-      const hasMcp = (config.capabilities || []).some((c) => c.id === 'huaweicloud-devkit' && c.type === 'mcp');
-      console.log(`  MCP config: ${hasMcp ? '\x1b[32mConfigured\x1b[0m' : '\x1b[31mNot configured\x1b[0m'}`);
+      const db = openOfficeaceDb();
+      const row = db.prepare("SELECT enabled, status FROM mcp_connectors WHERE name = 'huaweicloud-devkit'").get();
+      db.close();
+      if (row) {
+        const statusIcon = row.status === 'connected' ? '\x1b[32m' : '\x1b[33m';
+        console.log(`  MCP config: ${statusIcon}${row.status}\x1b[0m (enabled: ${row.enabled ? 'yes' : 'no'})`);
+      } else {
+        console.log(`  MCP config: \x1b[31mNot configured\x1b[0m`);
+      }
     } catch {
       console.log(`  MCP config: \x1b[31mInvalid\x1b[0m`);
     }
+  } else {
+    console.log(`  MCP config: \x1b[31mDatabase not found\x1b[0m`);
   }
 }
 

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -14,7 +14,7 @@ import { homedir, platform } from 'node:os';
 import { createInterface } from 'node:readline';
 import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import Database from 'better-sqlite3';
+import initSqlJs from 'sql.js';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { SUPPORTED_AGENT_TARGETS } from './auth/agent-registration.mjs';
 import {
@@ -157,103 +157,104 @@ function officeaceSqlitePath() {
   return join(resolve(capDir, '..'), 'data', 'mcp-connectors.sqlite');
 }
 
-function openOfficeaceDb() {
-  return new Database(officeaceSqlitePath());
+let _sql = null;
+async function getSql() {
+  if (!_sql) _sql = await initSqlJs();
+  return _sql;
 }
 
-function officeaceGetOwnerUserId() {
-  if (!existsSync(officeaceSqlitePath())) return null;
-  try {
-    const db = openOfficeaceDb();
-    const row = db.prepare('SELECT owner_user_id FROM mcp_connectors WHERE owner_user_id IS NOT NULL LIMIT 1').get();
-    db.close();
-    return row?.owner_user_id || null;
-  } catch {
-    return null;
-  }
-}
-
-function ensureOfficeaceMcpInSqlite() {
+function loadOfficeaceDb() {
   const dbPath = officeaceSqlitePath();
-  if (!existsSync(dbPath)) {
-    console.log(`  \x1b[31mOfficeAce database not found: ${dbPath}\x1b[0m`);
+  if (!existsSync(dbPath)) return null;
+  return { dbPath, buffer: readFileSync(dbPath) };
+}
+
+function saveOfficeaceDb(dbPath, db) {
+  writeFileSync(dbPath, Buffer.from(db.export()));
+  db.close();
+}
+
+async function officeaceGetOwnerUserId(currentDb) {
+  try {
+    const results = currentDb.exec('SELECT owner_user_id FROM mcp_connectors WHERE owner_user_id IS NOT NULL LIMIT 1');
+    if (results.length > 0 && results[0].values.length > 0) {
+      return results[0].values[0][0];
+    }
+  } catch {}
+  return null;
+}
+
+async function ensureOfficeaceMcpInSqlite() {
+  const loaded = loadOfficeaceDb();
+  if (!loaded) {
+    console.log(`  \x1b[31mOfficeAce database not found: ${officeaceSqlitePath()}\x1b[0m`);
     console.log(`  \x1b[33mPlease ensure OfficeAce is installed and has been launched at least once.\x1b[0m`);
     return false;
   }
 
+  const SQL = await getSql();
+  const db = new SQL.Database(loaded.buffer);
   const mcpPath = join(officeacePluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
   const env = [{ key: 'HUAWEICLOUD_AGENT_TOOLKIT_MODE', value: 'local', sensitive: false }];
   const hcloudBin = findHcloudBin();
   if (hcloudBin) env.push({ key: 'HCLOUD_BIN', value: hcloudBin.replace(/\\/g, '/'), sensitive: false });
 
   const now = Date.now();
-  let db;
+  const argsJson = JSON.stringify([mcpPath]);
+  const envJson = JSON.stringify(env);
+
   try {
-    db = openOfficeaceDb();
-
-    const existing = db
-      .prepare("SELECT id, command, args_json FROM mcp_connectors WHERE name = 'huaweicloud-devkit'")
-      .get();
-
-    const argsJson = JSON.stringify([mcpPath]);
-    const envJson = JSON.stringify(env);
-
-    if (existing) {
-      if (existing.command === 'node' && existing.args_json === argsJson) {
-        console.log(`  MCP config unchanged: ${dbPath}`);
+    const results = db.exec("SELECT id, command, args_json FROM mcp_connectors WHERE name = 'huaweicloud-devkit'");
+    if (results.length > 0 && results[0].values.length > 0) {
+      const [id, command, existingArgsJson] = results[0].values[0];
+      if (command === 'node' && existingArgsJson === argsJson) {
+        console.log(`  MCP config unchanged: ${loaded.dbPath}`);
         db.close();
         return true;
       }
-      db.prepare(
-        'UPDATE mcp_connectors SET command = ?, args_json = ?, env_json = ?, updated_at = ?, status = ?, enabled = 1 WHERE id = ?',
-      ).run('node', argsJson, envJson, now, 'disconnected', existing.id);
-      console.log(`  MCP config updated: ${dbPath}`);
+      db.run(
+        "UPDATE mcp_connectors SET command = 'node', args_json = ?, env_json = ?, updated_at = ?, status = 'disconnected', enabled = 1 WHERE id = ?",
+        [argsJson, envJson, now, id],
+      );
+      console.log(`  MCP config updated: ${loaded.dbPath}`);
     } else {
-      const ownerUserId = officeaceGetOwnerUserId();
+      const ownerUserId = await officeaceGetOwnerUserId(db);
       if (!ownerUserId) {
         console.log(`  \x1b[31mCannot determine owner_user_id from database\x1b[0m`);
         db.close();
         return false;
       }
-      db.prepare(
-        `INSERT INTO mcp_connectors (id, owner_user_id, type, name, normalized_name, transport, timeout_ms, command, args_json, env_json, enabled, status, created_at, updated_at, version, seeded)
-         VALUES (?, ?, 'custom', 'huaweicloud-devkit', 'huaweicloud-devkit', 'stdio', 60000, 'node', ?, ?, 1, 'disconnected', ?, ?, 1, 0)`,
-      ).run(randomUUID(), ownerUserId, argsJson, envJson, now, now);
-      console.log(`  MCP config created: ${dbPath}`);
+      db.run(
+        "INSERT INTO mcp_connectors (id, owner_user_id, type, name, normalized_name, transport, timeout_ms, command, args_json, env_json, enabled, status, created_at, updated_at, version, seeded) VALUES (?, ?, 'custom', 'huaweicloud-devkit', 'huaweicloud-devkit', 'stdio', 60000, 'node', ?, ?, 1, 'disconnected', ?, ?, 1, 0)",
+        [randomUUID(), ownerUserId, argsJson, envJson, now, now],
+      );
+      console.log(`  MCP config created: ${loaded.dbPath}`);
     }
-    db.close();
+    saveOfficeaceDb(loaded.dbPath, db);
     return true;
   } catch (err) {
-    if (db) {
-      try {
-        db.close();
-      } catch {}
-    }
+    db.close();
     console.log(`  \x1b[31mFailed to write MCP config: ${err.message}\x1b[0m`);
     return false;
   }
 }
 
-function removeOfficeaceMcpFromSqlite() {
-  const dbPath = officeaceSqlitePath();
-  if (!existsSync(dbPath)) return;
-  let db;
+async function removeOfficeaceMcpFromSqlite() {
+  const loaded = loadOfficeaceDb();
+  if (!loaded) return;
+
+  const SQL = await getSql();
+  const db = new SQL.Database(loaded.buffer);
+
   try {
-    db = openOfficeaceDb();
-    db.prepare(
+    db.run(
       "DELETE FROM mcp_connector_tools WHERE connector_id IN (SELECT id FROM mcp_connectors WHERE name = 'huaweicloud-devkit')",
-    ).run();
-    const result2 = db.prepare("DELETE FROM mcp_connectors WHERE name = 'huaweicloud-devkit'").run();
-    if (result2.changes > 0) {
-      console.log(`  MCP config removed: ${dbPath}`);
-    }
-    db.close();
+    );
+    db.run("DELETE FROM mcp_connectors WHERE name = 'huaweicloud-devkit'");
+    saveOfficeaceDb(loaded.dbPath, db);
+    console.log(`  MCP config removed: ${loaded.dbPath}`);
   } catch (err) {
-    if (db) {
-      try {
-        db.close();
-      } catch {}
-    }
+    db.close();
     console.log(`  \x1b[31mFailed to remove MCP config: ${err.message}\x1b[0m`);
   }
 }
@@ -1427,7 +1428,7 @@ async function installOfficeAce() {
   copyDir(safetyDir, join(pluginDest, 'safety'));
   console.log(`  Safety Policy -> ${join(pluginDest, 'safety')}`);
 
-  ensureOfficeaceMcpInSqlite();
+  await ensureOfficeaceMcpInSqlite();
   registerOfficeaceSkillEntries();
 }
 
@@ -1444,13 +1445,13 @@ async function updateOfficeAce() {
   console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
   copyDir(safetyDir, join(pluginDest, 'safety'));
   console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
-  ensureOfficeaceMcpInSqlite();
+  await ensureOfficeaceMcpInSqlite();
   registerOfficeaceSkillEntries();
   mkdirSync(pluginDest, { recursive: true });
   writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
 }
 
-function uninstallOfficeAce() {
+async function uninstallOfficeAce() {
   const skillsDir = officeaceSkillsDir();
   let removed = 0;
   if (existsSync(skillsDir)) {
@@ -1473,10 +1474,10 @@ function uninstallOfficeAce() {
     console.log('  Removed MCP server and safety policy');
   }
   removeOfficeaceSkillCapabilities();
-  removeOfficeaceMcpFromSqlite();
+  await removeOfficeaceMcpFromSqlite();
 }
 
-function officeaceStatus() {
+async function officeaceStatus() {
   const pluginDir = officeacePluginsDir();
   const skillsDir = officeaceSkillsDir();
   console.log(
@@ -1494,15 +1495,17 @@ function officeaceStatus() {
   console.log(
     `  Skills: ${skillCount > 0 ? `\x1b[32m${skillCount} installed\x1b[0m` : '\x1b[31mNot installed\x1b[0m'}`,
   );
-  const dbPath = officeaceSqlitePath();
-  if (existsSync(dbPath)) {
+  const loaded = loadOfficeaceDb();
+  if (loaded) {
     try {
-      const db = openOfficeaceDb();
-      const row = db.prepare("SELECT enabled, status FROM mcp_connectors WHERE name = 'huaweicloud-devkit'").get();
+      const SQL = await getSql();
+      const db = new SQL.Database(loaded.buffer);
+      const results = db.exec("SELECT enabled, status FROM mcp_connectors WHERE name = 'huaweicloud-devkit'");
       db.close();
-      if (row) {
-        const statusIcon = row.status === 'connected' ? '\x1b[32m' : '\x1b[33m';
-        console.log(`  MCP config: ${statusIcon}${row.status}\x1b[0m (enabled: ${row.enabled ? 'yes' : 'no'})`);
+      if (results.length > 0 && results[0].values.length > 0) {
+        const [enabled, status] = results[0].values[0];
+        const statusIcon = status === 'connected' ? '\x1b[32m' : '\x1b[33m';
+        console.log(`  MCP config: ${statusIcon}${status}\x1b[0m (enabled: ${enabled ? 'yes' : 'no'})`);
       } else {
         console.log(`  MCP config: \x1b[31mNot configured\x1b[0m`);
       }

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -368,11 +368,11 @@ test('setup-cli.mjs supports the officeace target end to end', () => {
   assert.match(setup, /function officeaceCapabilitiesFile\(\)/);
   assert.match(setup, /function officeaceSkillsDir\(\)/);
   assert.match(setup, /function officeacePluginsDir\(\)/);
-  assert.match(setup, /function ensureOfficeaceCapabilities\(\)/);
-  assert.match(setup, /function removeOfficeaceCapabilities\(\)/);
+  assert.match(setup, /function ensureOfficeaceMcpInSqlite\(\)/);
+  assert.match(setup, /function removeOfficeaceMcpFromSqlite\(\)/);
   assert.match(setup, /function registerOfficeaceSkillEntries\(\)/);
   assert.match(setup, /copyDir\(skillsSrc, officeaceSkillsDir\(\)\)/);
-  assert.match(setup, /ensureOfficeaceCapabilities\(\)/);
+  assert.match(setup, /ensureOfficeaceMcpInSqlite\(\)/);
   assert.match(setup, /registerOfficeaceSkillEntries\(\)/);
   assert.match(setup, /type.*skill.*source.*custom/s);
   assert.match(setup, /mcpServer.*command.*node/s);


### PR DESCRIPTION
Replace capabilities.json with direct SQLite writes to OfficeAce's mcp-connectors.sqlite database.

### Changes

- Use \
ode:sqlite\ DatabaseSync to directly insert/update MCP connector records
- Read \owner_user_id\ from existing connectors for proper ownership
- env vars stored as JSON array with {key, value, sensitive} fields
- Remove JSON-based capabilities write/read helpers

### Note

\
ode:sqlite\ requires Node.js >= 22.5. This may conflict with the project's engine requirement of Node >= 20.