### PR TITLE
chore: sync openclaw.plugin.json version to 1.0.2-next.18

### DIFF
--- a/plugins/huaweicloud-core/openclaw.plugin.json
+++ b/plugins/huaweicloud-core/openclaw.plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "huaweicloud-devkit",
   "displayName": "HuaweiCloud DevKit",
-  "version": "1.0.2-next.16",
+  "version": "1.0.2-next.18",
   "family": "bundle-plugin",
   "bundleFormat": "codex",
   "description": "Guide coding agents to use Huawei Cloud safely — KooCLI, APIs, SDKs, 28 MCP tools, skills, and safety guardrails.",


### PR DESCRIPTION
Sync openclaw.plugin.json to 1.0.2-next.18 so the ClawHub bundle reports the correct version.