### PR TITLE
docs: add NOTICE and source attribution headers for hwlink-derived code

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,39 @@
+This product contains third-party open source software.
+
+--------------------------------------------------------------------
+hwlink
+--------------------------------------------------------------------
+
+The following files in this project contain code derived from or
+originated from the hwlink project:
+
+  plugins/huaweicloud-core/src/ws-exec/hwlink-exec-client.js
+  plugins/huaweicloud-core/src/ws-exec/hwlink-fair-queue.js
+  plugins/huaweicloud-core/src/ws-exec/hwlink-multiplexer.js
+  plugins/huaweicloud-core/src/ws-exec/hwlink-packet.js
+  plugins/huaweicloud-core/src/ws-exec/hwlink-terminal-channel.js
+  plugins/huaweicloud-core/src/ws-exec/hwlink-tunnel-channel.mjs
+
+Source project:
+
+  hwlink
+  https://gitcode.com/huawei-developers/hwlink
+
+License:
+
+  ISC License
+
+Copyright (c) huawei-developers
+
+Permission to use, copy, modify, and/or distribute this software for
+any purpose with or without fee is hereby granted, provided that the
+above copyright notice and this permission notice appear in all copies.
+
+THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL
+WARRANTIES WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE
+AUTHOR BE LIABLE FOR ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL
+DAMAGES OR ANY DAMAGES WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR
+PROFITS, WHETHER IN AN ACTION OF CONTRACT, NEGLIGENCE OR OTHER
+TORTIOUS ACTION, ARISING OUT OF OR IN CONNECTION WITH THE USE OR
+PERFORMANCE OF THIS SOFTWARE.

--- a/plugins/huaweicloud-core/src/ws-exec/hwlink-exec-client.js
+++ b/plugins/huaweicloud-core/src/ws-exec/hwlink-exec-client.js
@@ -1,3 +1,12 @@
+/*
+ * This file contains code derived from hwlink.
+ *
+ * Source:
+ * https://gitcode.com/huawei-developers/hwlink
+ *
+ * Licensed under the ISC License.
+ */
+
 import {
   DEFAULT_TIMEOUT_MS,
   WebSocketExecError,

--- a/plugins/huaweicloud-core/src/ws-exec/hwlink-fair-queue.js
+++ b/plugins/huaweicloud-core/src/ws-exec/hwlink-fair-queue.js
@@ -1,3 +1,12 @@
+/*
+ * This file contains code derived from hwlink.
+ *
+ * Source:
+ * https://gitcode.com/huawei-developers/hwlink
+ *
+ * Licensed under the ISC License.
+ */
+
 const DEFAULT_HIGH_WATERMARK = 8 * 1024 * 1024;
 const DEFAULT_LOW_WATERMARK = 2 * 1024 * 1024;
 

--- a/plugins/huaweicloud-core/src/ws-exec/hwlink-multiplexer.js
+++ b/plugins/huaweicloud-core/src/ws-exec/hwlink-multiplexer.js
@@ -1,3 +1,12 @@
+/*
+ * This file contains code derived from hwlink.
+ *
+ * Source:
+ * https://gitcode.com/huawei-developers/hwlink
+ *
+ * Licensed under the ISC License.
+ */
+
 import { Buffer } from 'node:buffer';
 
 import { FairQueue } from './hwlink-fair-queue.js';

--- a/plugins/huaweicloud-core/src/ws-exec/hwlink-packet.js
+++ b/plugins/huaweicloud-core/src/ws-exec/hwlink-packet.js
@@ -1,3 +1,12 @@
+/*
+ * This file contains code derived from hwlink.
+ *
+ * Source:
+ * https://gitcode.com/huawei-developers/hwlink
+ *
+ * Licensed under the ISC License.
+ */
+
 const FIXED_HEADER_LEN = 20;
 const MAX_SEND_CHUNK_SIZE = 8 * 1024;
 

--- a/plugins/huaweicloud-core/src/ws-exec/hwlink-terminal-channel.js
+++ b/plugins/huaweicloud-core/src/ws-exec/hwlink-terminal-channel.js
@@ -1,3 +1,12 @@
+/*
+ * This file contains code derived from hwlink.
+ *
+ * Source:
+ * https://gitcode.com/huawei-developers/hwlink
+ *
+ * Licensed under the ISC License.
+ */
+
 import {
   OpCode,
   ReserveSource,

--- a/plugins/huaweicloud-core/src/ws-exec/hwlink-tunnel-channel.mjs
+++ b/plugins/huaweicloud-core/src/ws-exec/hwlink-tunnel-channel.mjs
@@ -1,3 +1,12 @@
+/*
+ * This file contains code derived from hwlink.
+ *
+ * Source:
+ * https://gitcode.com/huawei-developers/hwlink
+ *
+ * Licensed under the ISC License.
+ */
+
 import { createServer } from 'node:net';
 import {
   OpCode,


### PR DESCRIPTION
Add NOTICE file documenting hwlink ISC licensed code used in ws-exec. Add source attribution comment headers to all hwlink-derived source files.

Close #139

## Description

<!-- Briefly describe what this PR changes and why. -->

Closes #

## Type of change

- [ ] feat
- [ ] fix
- [X] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [X] chore
- [ ] ci
- [ ] security

## Checklist

- [ ] PR title follows [Conventional Commits](https://www.conventionalcommits.org/) (`<type>(<scope>): <subject>`)
- [ ] CI checks pass (PR Lint, CI, CodeQL)
- [ ] `npm test` passes locally
- [ ] `npm run validate` passes locally
- [ ] `npm run lint` passes locally
- [ ] Docs updated if needed (README / docs/CHANGELOG.md)

## Notes

<!-- Anything else reviewers should know. -->
