### PR TITLE
fix: remove WorkBuddy hooks to avoid high-risk prompt, add sandbox-first scenario routing

### DIFF
--- a/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
@@ -12,7 +12,6 @@
   "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
-  "hooks": "./hooks/",
   "interface": {
     "displayName": "HuaweiCloud Devkit",
     "shortDescription": "HuaweiCloud Devkit - Huawei Cloud guidance, CLI/API/SDK routing, MCP tools, and safety for coding agents.",

--- a/plugins/huaweicloud-core/skills/huaweicloud-capability-discovery/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-capability-discovery/SKILL.md
@@ -22,6 +22,17 @@ Use this skill to turn vague developer intent into a precise Huawei Cloud capabi
 9. When no built-in devkit skill matches, browse the community skill marketplace at https://github.com/huaweicloud/huaweicloud-skills. Fetch the index from https://raw.githubusercontent.com/huaweicloud/huaweicloud-skills/master/skills-index/index.json.
 10. When the deliverable is a PPT, architecture diagram (draw.io), or frontend page that needs official Huawei Cloud service logos, use the `huaweicloud_get_service_icon` MCP tool to get logo URLs from the official Icons library instead of guessing or hotlinking unofficial images.
 
+## Scenario Routing
+
+Match the scenario before picking a service. For "deploy a web app" requests, layer the recommendation instead of defaulting to a production service:
+
+| Scenario | Recommended path |
+|----------|------------------|
+| hello world / prototype / demo / temporary preview (free, quick try) | `huawei-sandbox` first — temporary runtime + public URL, ~8h validity, zero billed resources |
+| production / long-term / custom domain / high availability | `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce` for containers) |
+
+Route to the sandbox when the developer signals free/quick preview intent ("免费", "快速", "预览", "hello world", "原型", "演示"); route to production services only when production-grade hosting is explicitly required.
+
 ## Official Service Logos
 
 - Use `huaweicloud_get_service_icon` with the service name, alias, or Chinese name (e.g. `ecs`, `obs`, `modelarts`, `对象存储`). It returns the official CDN logo URL (`logo.source_url`), category, and product page link from https://open.huaweicloud.com/openplatform/icons.html.

--- a/plugins/huaweicloud-core/skills/huaweicloud-capability-discovery/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-capability-discovery/SKILL.md
@@ -26,10 +26,10 @@ Use this skill to turn vague developer intent into a precise Huawei Cloud capabi
 
 Match the scenario before picking a service. For "deploy a web app" requests, layer the recommendation instead of defaulting to a production service:
 
-| Scenario | Recommended path |
-|----------|------------------|
+| Scenario                                                             | Recommended path                                                                             |
+| -------------------------------------------------------------------- | -------------------------------------------------------------------------------------------- |
 | hello world / prototype / demo / temporary preview (free, quick try) | `huawei-sandbox` first — temporary runtime + public URL, ~8h validity, zero billed resources |
-| production / long-term / custom domain / high availability | `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce` for containers) |
+| production / long-term / custom domain / high availability           | `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce` for containers)                       |
 
 Route to the sandbox when the developer signals free/quick preview intent ("免费", "快速", "预览", "hello world", "原型", "演示"); route to production services only when production-grade hosting is explicitly required.
 

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
@@ -46,30 +46,30 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 
 ## Service Map
 
-| Workload                              | Primary Service      | Skill                    |
-| ------------------------------------- | -------------------- | ------------------------ |
+| Workload                                         | Primary Service      | Skill                    |
+| ------------------------------------------------ | -------------------- | ------------------------ |
 | Web application hosting (production / long-term) | ECS                  | huawei-ecs               |
-| Containerized microservices           | CCE                  | huawei-cce               |
-| Static file storage / CDN (long-term) | OBS                  | huawei-obs               |
-| Relational database (MySQL/PG)        | RDS                  | huawei-rds               |
-| Distributed SQL database              | GaussDB              | huawei-gaussdb           |
-| Document database (MongoDB API)       | DDS                  | huawei-dds-dcs           |
-| In-memory cache                       | DCS (Redis)          | huawei-dds-dcs           |
-| Serverless functions                  | FunctionGraph        | huawei-functiongraph     |
-| API management                        | APIG                 | huawei-apig              |
-| AI model training/inference           | ModelArts            | huawei-modelarts         |
-| Message queuing                       | DMS (Kafka/RabbitMQ) | huawei-smn-dms           |
-| Push notifications                    | SMN                  | huawei-smn-dms           |
-| Secret management                     | DEW (CSMS)           | huawei-dew               |
-| Key management                        | DEW (KMS)            | huawei-dew               |
-| DDoS protection                       | AAD                  | huawei-waf-aad           |
-| Web firewall                          | WAF                  | huawei-waf-aad           |
-| Monitoring dashboards                 | Cloud Eye (CES)      | huawei-cloud-eye         |
-| Audit trails                          | CTS                  | huawei-cts               |
-| Backup / disaster recovery            | CBR                  | huawei-cbr               |
-| CI/CD pipeline                        | CloudDeploy          | huawei-deployment        |
-| Temporary runtime / web app preview   | Sandbox (DevStation) | huawei-sandbox           |
-| Getting started                       | Account setup        | huaweicloud-cli-and-auth |
+| Containerized microservices                      | CCE                  | huawei-cce               |
+| Static file storage / CDN (long-term)            | OBS                  | huawei-obs               |
+| Relational database (MySQL/PG)                   | RDS                  | huawei-rds               |
+| Distributed SQL database                         | GaussDB              | huawei-gaussdb           |
+| Document database (MongoDB API)                  | DDS                  | huawei-dds-dcs           |
+| In-memory cache                                  | DCS (Redis)          | huawei-dds-dcs           |
+| Serverless functions                             | FunctionGraph        | huawei-functiongraph     |
+| API management                                   | APIG                 | huawei-apig              |
+| AI model training/inference                      | ModelArts            | huawei-modelarts         |
+| Message queuing                                  | DMS (Kafka/RabbitMQ) | huawei-smn-dms           |
+| Push notifications                               | SMN                  | huawei-smn-dms           |
+| Secret management                                | DEW (CSMS)           | huawei-dew               |
+| Key management                                   | DEW (KMS)            | huawei-dew               |
+| DDoS protection                                  | AAD                  | huawei-waf-aad           |
+| Web firewall                                     | WAF                  | huawei-waf-aad           |
+| Monitoring dashboards                            | Cloud Eye (CES)      | huawei-cloud-eye         |
+| Audit trails                                     | CTS                  | huawei-cts               |
+| Backup / disaster recovery                       | CBR                  | huawei-cbr               |
+| CI/CD pipeline                                   | CloudDeploy          | huawei-deployment        |
+| Temporary runtime / web app preview              | Sandbox (DevStation) | huawei-sandbox           |
+| Getting started                                  | Account setup        | huaweicloud-cli-and-auth |
 
 **Web app scenario layering**: for "deploy a web app", prefer `huawei-sandbox` for free/quick try (hello world, prototype, demo, temporary preview — temporary runtime + public URL, ~8h validity, zero billed resources); route to `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce`) for production / long-term / custom-domain / high-availability hosting.
 

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
@@ -48,7 +48,7 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 
 | Workload                              | Primary Service      | Skill                    |
 | ------------------------------------- | -------------------- | ------------------------ |
-| Web application hosting               | ECS                  | huawei-ecs               |
+| Web application hosting (production / long-term) | ECS                  | huawei-ecs               |
 | Containerized microservices           | CCE                  | huawei-cce               |
 | Static file storage / CDN (long-term) | OBS                  | huawei-obs               |
 | Relational database (MySQL/PG)        | RDS                  | huawei-rds               |
@@ -70,6 +70,8 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 | CI/CD pipeline                        | CloudDeploy          | huawei-deployment        |
 | Temporary runtime / web app preview   | Sandbox (DevStation) | huawei-sandbox           |
 | Getting started                       | Account setup        | huaweicloud-cli-and-auth |
+
+**Web app scenario layering**: for "deploy a web app", prefer `huawei-sandbox` for free/quick try (hello world, prototype, demo, temporary preview — temporary runtime + public URL, ~8h validity, zero billed resources); route to `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce`) for production / long-term / custom-domain / high-availability hosting.
 
 ## Deployment Target Options
 

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/references/select.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/references/select.md
@@ -28,3 +28,13 @@ Route based on answers:
 - SQL + massive scale / distributed -> huawei-gaussdb
 - Document model (MongoDB-compatible) -> huawei-dds-dcs
 - Cache / key-value -> huawei-dds-dcs (DCS)
+
+## Example: I need to deploy a web app
+
+Ask:
+- Is this a quick try / prototype / demo / temporary preview (free)?
+- Or production (long-term, custom domain, high availability)?
+
+Route by scenario:
+- Free / quick try / prototype / demo / temporary preview -> huawei-sandbox (temporary runtime + public URL, ~8h validity, zero billed resources)
+- Production / long-term / custom domain / high availability -> huawei-functiongraph / huawei-ecs (or huawei-cce for containers)

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/references/select.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/references/select.md
@@ -32,9 +32,11 @@ Route based on answers:
 ## Example: I need to deploy a web app
 
 Ask:
+
 - Is this a quick try / prototype / demo / temporary preview (free)?
 - Or production (long-term, custom domain, high availability)?
 
 Route by scenario:
+
 - Free / quick try / prototype / demo / temporary preview -> huawei-sandbox (temporary runtime + public URL, ~8h validity, zero billed resources)
 - Production / long-term / custom domain / high availability -> huawei-functiongraph / huawei-ecs (or huawei-cce for containers)

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -30,7 +30,10 @@ assert.equal(manifest.mcpServers, './.mcp.json');
 assert.ok(!Object.hasOwn(manifest, 'hooks'), 'Codex manifest should not include hooks until supported by validator');
 
 const workbuddyManifest = readJson(join(pluginRoot, '.workbuddy-plugin', 'plugin.json'));
-assert.ok(!Object.hasOwn(workbuddyManifest, 'hooks'), 'WorkBuddy manifest should not include hooks — hooks are Claude-specific and trigger manual trust prompts in WorkBuddy');
+assert.ok(
+  !Object.hasOwn(workbuddyManifest, 'hooks'),
+  'WorkBuddy manifest should not include hooks — hooks are Claude-specific and trigger manual trust prompts in WorkBuddy',
+);
 
 const pkg = readJson(join(root, 'package.json'));
 const pluginManifests = [

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -29,6 +29,9 @@ assert.equal(manifest.skills, './skills/');
 assert.equal(manifest.mcpServers, './.mcp.json');
 assert.ok(!Object.hasOwn(manifest, 'hooks'), 'Codex manifest should not include hooks until supported by validator');
 
+const workbuddyManifest = readJson(join(pluginRoot, '.workbuddy-plugin', 'plugin.json'));
+assert.ok(!Object.hasOwn(workbuddyManifest, 'hooks'), 'WorkBuddy manifest should not include hooks — hooks are Claude-specific and trigger manual trust prompts in WorkBuddy');
+
 const pkg = readJson(join(root, 'package.json'));
 const pluginManifests = [
   join(pluginRoot, '.codex-plugin', 'plugin.json'),


### PR DESCRIPTION
﻿## Summary

Two fixes from upstream issues #76 and #77.

### 1. Remove WorkBuddy hooks (#77)

`.workbuddy-plugin/plugin.json` included `"hooks": "./hooks/"` which uses Claude-specific `${CLAUDE_PLUGIN_ROOT}`. WorkBuddy processes these hooks as a custom connector capability and flags it as high-risk — users see a "Clean hcloud directory" prompt and must manually trust the connector.

- Removed `"hooks"` from WorkBuddy plugin manifest
- Added validation check in `validate-package.mjs` to prevent hooks in WorkBuddy manifest (same as existing Codex check)
- MCP server already enforces safety via its own policy engine

### 2. Sandbox-first scenario routing (#76)

Web app deployment requests were defaulting to FunctionGraph/ECS without considering free/quick-try scenarios.

- `capability-discovery/SKILL.md`: Added Scenario Routing — free/quick try → sandbox, production → FunctionGraph/ECS/CCE
- `huaweicloud-core/SKILL.md`: Service Map marked with production qualifier, added web app scenario layering
- `huaweicloud-core/references/select.md`: Added web app deployment decision example

### Changed files

| File | Change |
|------|--------|
| `.workbuddy-plugin/plugin.json` | Remove hooks |
| `scripts/validate-package.mjs` | Add WorkBuddy hooks validation |
| `capability-discovery/SKILL.md` | Add Scenario Routing section |
| `huaweicloud-core/SKILL.md` | Service Map + web app scenario layering |
| `huaweicloud-core/references/select.md` | Add web app decision example |
