### PR TITLE
fix(officeace): use Windows registry for install directory discovery

### DIFF
--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -99,8 +99,30 @@ function dshRegistered() {
   }
 }
 
+function readOfficeaceRegistryInstallDir() {
+  if (process.platform !== 'win32') return null;
+  try {
+    const r = spawnSync('reg', ['query', 'HKCU\\SOFTWARE\\OfficeAce\\OfficeAce', '/v', 'InstallDir'], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 5000,
+    });
+    if (r.status === 0) {
+      const m = r.stdout.match(/InstallDir\s+REG_SZ\s+(.+)/);
+      if (m) return m[1].trim();
+    }
+  } catch {}
+  return null;
+}
+
 function officeaceCapabilitiesDir() {
-  if (process.env.OFFICEACE_HOME) return process.env.OFFICEACE_HOME;
+  const configRoot = process.env.OFFICE_CLAW_CONFIG_ROOT;
+  if (configRoot && existsSync(join(configRoot, 'capabilities.json'))) return configRoot;
+  const regDir = readOfficeaceRegistryInstallDir();
+  if (regDir) {
+    const dir = join(regDir, '.office-claw');
+    if (existsSync(join(dir, 'capabilities.json'))) return dir;
+  }
   const dotDir = join(baseHome(), '.office-claw');
   const dotCapFile = join(dotDir, 'capabilities.json');
   if (existsSync(dotCapFile)) return dotDir;

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -127,7 +127,9 @@ function officeaceCapabilitiesDir() {
   const dotCapFile = join(dotDir, 'capabilities.json');
   if (existsSync(dotCapFile)) return dotDir;
   if (process.platform === 'win32') {
-    for (const base of [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files']) {
+    const bases = [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files'];
+    if (process.env.LOCALAPPDATA) bases.push(join(process.env.LOCALAPPDATA, 'Programs'));
+    for (const base of bases) {
       if (!base) continue;
       const dir = join(base, 'OfficeAce', '.office-claw');
       if (existsSync(join(dir, 'capabilities.json'))) return dir;

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -123,9 +123,6 @@ function officeaceCapabilitiesDir() {
     const dir = join(regDir, '.office-claw');
     if (existsSync(join(dir, 'capabilities.json'))) return dir;
   }
-  const dotDir = join(baseHome(), '.office-claw');
-  const dotCapFile = join(dotDir, 'capabilities.json');
-  if (existsSync(dotCapFile)) return dotDir;
   if (process.platform === 'win32') {
     const bases = [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files'];
     if (process.env.LOCALAPPDATA) bases.push(join(process.env.LOCALAPPDATA, 'Programs'));
@@ -135,7 +132,7 @@ function officeaceCapabilitiesDir() {
       if (existsSync(join(dir, 'capabilities.json'))) return dir;
     }
   }
-  return dotDir;
+  return null;
 }
 
 function officeaceSqlitePath() {

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -135,8 +135,12 @@ function officeaceCapabilitiesDir() {
   return null;
 }
 
+function officeaceCapabilitiesDirSafe() {
+  return officeaceCapabilitiesDir() || join(baseHome(), '.office-claw');
+}
+
 function officeaceSqlitePath() {
-  const capDir = officeaceCapabilitiesDir();
+  const capDir = officeaceCapabilitiesDirSafe();
   return join(resolve(capDir, '..'), 'data', 'mcp-connectors.sqlite');
 }
 
@@ -156,7 +160,7 @@ function officeaceRegistered() {
     }
   }
 
-  const capFile = join(officeaceCapabilitiesDir(), 'capabilities.json');
+  const capFile = join(officeaceCapabilitiesDirSafe(), 'capabilities.json');
   const cfg = readJsonSafe(capFile);
   const hasSkills = cfg?.capabilities?.some((c) => c.id === 'huaweicloud-core' && c.type === 'skill') ?? false;
 

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -128,11 +128,30 @@ function dshPluginsDir() {
   return join(dshRoot(), 'huaweicloud-plugins');
 }
 
+function readOfficeaceRegistryInstallDir() {
+  if (platform() !== 'win32') return null;
+  try {
+    const r = spawnSync('reg', ['query', 'HKCU\\SOFTWARE\\OfficeAce\\OfficeAce', '/v', 'InstallDir'], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 5000,
+    });
+    if (r.status === 0) {
+      const m = r.stdout.match(/InstallDir\s+REG_SZ\s+(.+)/);
+      if (m) return m[1].trim();
+    }
+  } catch {}
+  return null;
+}
+
 function officeaceCapabilitiesDir() {
-  if (process.env.OFFICEACE_HOME) return process.env.OFFICEACE_HOME;
-  const dotDir = join(homedir(), '.office-claw');
-  const dotCapFile = join(dotDir, 'capabilities.json');
-  if (existsSync(dotCapFile)) return dotDir;
+  const configRoot = process.env.OFFICE_CLAW_CONFIG_ROOT;
+  if (configRoot && existsSync(join(configRoot, 'capabilities.json'))) return configRoot;
+  const regDir = readOfficeaceRegistryInstallDir();
+  if (regDir) {
+    const dir = join(regDir, '.office-claw');
+    if (existsSync(join(dir, 'capabilities.json'))) return dir;
+  }
   if (platform() === 'win32') {
     for (const base of [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files']) {
       if (!base) continue;
@@ -140,7 +159,7 @@ function officeaceCapabilitiesDir() {
       if (existsSync(join(dir, 'capabilities.json'))) return dir;
     }
   }
-  return dotDir;
+  return join(homedir(), '.office-claw');
 }
 function officeaceCapabilitiesFile() {
   return join(officeaceCapabilitiesDir(), 'capabilities.json');
@@ -1434,7 +1453,39 @@ function dshStatus() {
   );
 }
 
+async function promptOfficeaceInstallDir() {
+  const rl = createInterface({ input: process.stdin, output: process.stdout });
+  const ask = (q) => new Promise((resolve) => rl.question(q, resolve));
+  while (true) {
+    const path = (await ask('  Install directory: ')).trim();
+    if (!path) {
+      console.log('  \x1b[33mPath cannot be empty.\x1b[0m');
+      continue;
+    }
+    const capFile = join(path, '.office-claw', 'capabilities.json');
+    if (existsSync(capFile)) {
+      rl.close();
+      return path;
+    }
+    console.log(`  \x1b[33mcapabilities.json not found at: ${capFile}\x1b[0m`);
+    console.log('  Please verify the path and try again.');
+  }
+}
+
 async function installOfficeAce() {
+  const capDir = officeaceCapabilitiesDir();
+  if (!existsSync(join(capDir, 'capabilities.json'))) {
+    if (process.stdin.isTTY) {
+      console.log('  \x1b[33mOfficeAce capabilities.json not found at:\x1b[0m');
+      console.log(`    ${join(capDir, 'capabilities.json')}`);
+      console.log('  Please enter the OfficeAce install directory.');
+      const entered = await promptOfficeaceInstallDir();
+      process.env.OFFICE_CLAW_CONFIG_ROOT = join(entered, '.office-claw');
+    } else {
+      console.log('  \x1b[31mOfficeAce capabilities.json not found. Please set OFFICE_CLAW_CONFIG_ROOT env var and retry.\x1b[0m');
+      return;
+    }
+  }
   const skillsSrc = join(PLUGIN_ROOT, 'skills');
   const srcDir = join(PLUGIN_ROOT, 'src');
   const safetyDir = join(PLUGIN_ROOT, 'safety');

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -153,7 +153,9 @@ function officeaceCapabilitiesDir() {
     if (existsSync(join(dir, 'capabilities.json'))) return dir;
   }
   if (platform() === 'win32') {
-    for (const base of [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files']) {
+    const bases = [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files'];
+    if (process.env.LOCALAPPDATA) bases.push(join(process.env.LOCALAPPDATA, 'Programs'));
+    for (const base of bases) {
       if (!base) continue;
       const dir = join(base, 'OfficeAce', '.office-claw');
       if (existsSync(join(dir, 'capabilities.json'))) return dir;

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1486,7 +1486,9 @@ async function installOfficeAce() {
       const entered = await promptOfficeaceInstallDir();
       process.env.OFFICE_CLAW_CONFIG_ROOT = join(entered, '.office-claw');
     } else {
-      console.log('  \x1b[31mOfficeAce install directory not found. Please set OFFICE_CLAW_CONFIG_ROOT env var and retry.\x1b[0m');
+      console.log(
+        '  \x1b[31mOfficeAce install directory not found. Please set OFFICE_CLAW_CONFIG_ROOT env var and retry.\x1b[0m',
+      );
       return;
     }
   }

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -161,20 +161,24 @@ function officeaceCapabilitiesDir() {
       if (existsSync(join(dir, 'capabilities.json'))) return dir;
     }
   }
-  return join(homedir(), '.office-claw');
+  return null;
+}
+
+function officeaceCapabilitiesDirSafe() {
+  return officeaceCapabilitiesDir() || join(homedir(), '.office-claw');
 }
 function officeaceCapabilitiesFile() {
-  return join(officeaceCapabilitiesDir(), 'capabilities.json');
+  return join(officeaceCapabilitiesDirSafe(), 'capabilities.json');
 }
 function officeaceSkillsDir() {
-  return join(officeaceCapabilitiesDir(), 'skills');
+  return join(officeaceCapabilitiesDirSafe(), 'skills');
 }
 function officeacePluginsDir() {
-  return join(officeaceCapabilitiesDir(), 'huaweicloud-plugins');
+  return join(officeaceCapabilitiesDirSafe(), 'huaweicloud-plugins');
 }
 
 function officeaceSqlitePath() {
-  const capDir = officeaceCapabilitiesDir();
+  const capDir = officeaceCapabilitiesDirSafe();
   return join(resolve(capDir, '..'), 'data', 'mcp-connectors.sqlite');
 }
 
@@ -290,7 +294,7 @@ function readCapabilitiesJson() {
 }
 
 function writeCapabilitiesJson(config) {
-  mkdirSync(officeaceCapabilitiesDir(), { recursive: true });
+  mkdirSync(officeaceCapabilitiesDirSafe(), { recursive: true });
   writeFileSync(officeaceCapabilitiesFile(), JSON.stringify(config, null, 2));
 }
 
@@ -1475,16 +1479,14 @@ async function promptOfficeaceInstallDir() {
 }
 
 async function installOfficeAce() {
-  const capDir = officeaceCapabilitiesDir();
-  if (!existsSync(join(capDir, 'capabilities.json'))) {
+  if (!officeaceCapabilitiesDir()) {
     if (process.stdin.isTTY) {
-      console.log('  \x1b[33mOfficeAce capabilities.json not found at:\x1b[0m');
-      console.log(`    ${join(capDir, 'capabilities.json')}`);
+      console.log('  \x1b[33mOfficeAce install directory not found automatically.\x1b[0m');
       console.log('  Please enter the OfficeAce install directory.');
       const entered = await promptOfficeaceInstallDir();
       process.env.OFFICE_CLAW_CONFIG_ROOT = join(entered, '.office-claw');
     } else {
-      console.log('  \x1b[31mOfficeAce capabilities.json not found. Please set OFFICE_CLAW_CONFIG_ROOT env var and retry.\x1b[0m');
+      console.log('  \x1b[31mOfficeAce install directory not found. Please set OFFICE_CLAW_CONFIG_ROOT env var and retry.\x1b[0m');
       return;
     }
   }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -5,6 +5,7 @@ import { readFileSync, readdirSync, existsSync, writeFileSync } from 'node:fs';
 import { join, dirname } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import { homedir } from 'node:os';
+import { spawnSync } from 'node:child_process';
 import { searchMarketplace } from './search-market.mjs';
 import { getServiceIcon } from './icon-library.mjs';
 import {
@@ -42,16 +43,40 @@ function dshSkillsDir() {
   const home = process.env.DSH_HOME || join(homedir(), '.dsh');
   return join(home, 'skills');
 }
+function readOfficeaceRegistryInstallDir() {
+  if (process.platform !== 'win32') return null;
+  try {
+    const r = spawnSync('reg', ['query', 'HKCU\\SOFTWARE\\OfficeAce\\OfficeAce', '/v', 'InstallDir'], {
+      encoding: 'utf8',
+      windowsHide: true,
+      timeout: 5000,
+    });
+    if (r.status === 0) {
+      const m = r.stdout.match(/InstallDir\s+REG_SZ\s+(.+)/);
+      if (m) return m[1].trim();
+    }
+  } catch {}
+  return null;
+}
+
 function officeaceSkillsRoot() {
-  if (process.env.OFFICEACE_HOME) return join(process.env.OFFICEACE_HOME, 'skills');
+  const mcpCwd = process.env.OFFICE_CLAW_MCP_CWD;
+  if (mcpCwd) return join(mcpCwd, 'skills');
+  const configRoot = process.env.OFFICE_CLAW_CONFIG_ROOT;
+  if (configRoot && existsSync(join(configRoot, 'capabilities.json'))) return join(configRoot, 'skills');
+  const regDir = readOfficeaceRegistryInstallDir();
+  if (regDir) {
+    const dir = join(regDir, '.office-claw', 'skills');
+    if (existsSync(dir)) return dir;
+  }
   const dotDir = join(homedir(), '.office-claw');
   const dotCapFile = join(dotDir, 'capabilities.json');
   if (existsSync(dotCapFile)) return join(dotDir, 'skills');
   if (process.platform === 'win32') {
     for (const base of [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files']) {
       if (!base) continue;
-      const dir = join(base, 'OfficeAce', '.office-claw');
-      if (existsSync(join(dir, 'capabilities.json'))) return join(dir, 'skills');
+      const dir = join(base, 'OfficeAce', '.office-claw', 'skills');
+      if (existsSync(dir)) return dir;
     }
   }
   return join(dotDir, 'skills');

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -67,9 +67,6 @@ function officeaceSkillsRoot() {
     const dir = join(regDir, '.office-claw', 'skills');
     if (existsSync(dir)) return dir;
   }
-  const dotDir = join(homedir(), '.office-claw');
-  const dotCapFile = join(dotDir, 'capabilities.json');
-  if (existsSync(dotCapFile)) return join(dotDir, 'skills');
   if (process.platform === 'win32') {
     const bases = [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files'];
     if (process.env.LOCALAPPDATA) bases.push(join(process.env.LOCALAPPDATA, 'Programs'));
@@ -79,7 +76,7 @@ function officeaceSkillsRoot() {
       if (existsSync(dir)) return dir;
     }
   }
-  return join(dotDir, 'skills');
+  return null;
 }
 export function listSkillDirs(root) {
   if (!existsSync(root)) return [];

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -60,8 +60,6 @@ function readOfficeaceRegistryInstallDir() {
 }
 
 function officeaceSkillsRoot() {
-  const mcpCwd = process.env.OFFICE_CLAW_MCP_CWD;
-  if (mcpCwd) return join(mcpCwd, 'skills');
   const configRoot = process.env.OFFICE_CLAW_CONFIG_ROOT;
   if (configRoot && existsSync(join(configRoot, 'capabilities.json'))) return join(configRoot, 'skills');
   const regDir = readOfficeaceRegistryInstallDir();

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -71,7 +71,9 @@ function officeaceSkillsRoot() {
   const dotCapFile = join(dotDir, 'capabilities.json');
   if (existsSync(dotCapFile)) return join(dotDir, 'skills');
   if (process.platform === 'win32') {
-    for (const base of [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files']) {
+    const bases = [process.env.ProgramFiles, 'C:\\Program Files', 'D:\\Program Files'];
+    if (process.env.LOCALAPPDATA) bases.push(join(process.env.LOCALAPPDATA, 'Programs'));
+    for (const base of bases) {
       if (!base) continue;
       const dir = join(base, 'OfficeAce', '.office-claw', 'skills');
       if (existsSync(dir)) return dir;

--- a/test/officeace-adaptation.test.mjs
+++ b/test/officeace-adaptation.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync, mkdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,21 +10,21 @@ const root = fileURLToPath(new URL('..', import.meta.url));
 const setupCli = join(root, 'bin', 'setup.cjs');
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
 
-function makeEnv(home, officeAceHome) {
+function makeEnv(home, officeaceConfigRoot) {
   return {
     ...process.env,
     USERPROFILE: home,
     HOME: home,
     HOMEDRIVE: home.slice(0, 2),
     HOMEPATH: home.slice(2),
-    OFFICEACE_HOME: officeAceHome,
+    OFFICE_CLAW_CONFIG_ROOT: officeaceConfigRoot,
   };
 }
 
-function runCli(home, cwd, args, officeAceHome = join(home, '.office-claw')) {
+function runCli(home, cwd, args, officeaceConfigRoot = join(home, '.office-claw')) {
   return spawnSync(process.execPath, [setupCli, ...args], {
     cwd,
-    env: makeEnv(home, officeAceHome),
+    env: makeEnv(home, officeaceConfigRoot),
     encoding: 'utf8',
     timeout: 60000,
   });
@@ -39,6 +39,8 @@ test('officeace install copies skills, MCP server, and safety policy', () => {
   const home = mkdtempSync(join(tmpdir(), 'oa-home-'));
   const cwd = mkdtempSync(join(tmpdir(), 'oa-proj-'));
   const oaHome = join(home, '.office-claw');
+  mkdirSync(oaHome, { recursive: true });
+  writeFileSync(join(oaHome, 'capabilities.json'), '{"capabilities":[]}');
   try {
     const res = runCli(home, cwd, ['install', '--target', 'officeace'], oaHome);
     assert.equal(res.status, 0, res.stderr);
@@ -63,6 +65,8 @@ test('officeace uninstall removes installed files', () => {
   const home = mkdtempSync(join(tmpdir(), 'oa-home-'));
   const cwd = mkdtempSync(join(tmpdir(), 'oa-proj-'));
   const oaHome = join(home, '.office-claw');
+  mkdirSync(oaHome, { recursive: true });
+  writeFileSync(join(oaHome, 'capabilities.json'), '{"capabilities":[]}');
   try {
     assert.equal(runCli(home, cwd, ['install', '--target', 'officeace'], oaHome).status, 0);
     const res = runCli(home, cwd, ['uninstall', '--target', 'officeace'], oaHome);

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -352,9 +352,10 @@ test('tools.mjs resolves skills from the dsh directory', () => {
 test('tools.mjs resolves skills from the officeace directory', () => {
   const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
   assert.match(tools, /function officeaceSkillsRoot\(\)/);
-  assert.match(tools, /process\.env\.OFFICEACE_HOME/);
+  assert.match(tools, /OFFICE_CLAW_CONFIG_ROOT/);
   assert.match(tools, /office-claw/);
   assert.match(tools, /capabilities\.json/);
+  assert.match(tools, /readOfficeaceRegistryInstallDir/);
 });
 
 test('setup-cli.mjs supports the officeace target end to end', () => {
@@ -368,6 +369,7 @@ test('setup-cli.mjs supports the officeace target end to end', () => {
   assert.match(setup, /function officeaceCapabilitiesFile\(\)/);
   assert.match(setup, /function officeaceSkillsDir\(\)/);
   assert.match(setup, /function officeacePluginsDir\(\)/);
+  assert.match(setup, /function readOfficeaceRegistryInstallDir\(\)/);
   assert.match(setup, /function ensureOfficeaceMcpInSqlite\(\)/);
   assert.match(setup, /function removeOfficeaceMcpFromSqlite\(\)/);
   assert.match(setup, /function registerOfficeaceSkillEntries\(\)/);

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -352,10 +352,9 @@ test('tools.mjs resolves skills from the dsh directory', () => {
 test('tools.mjs resolves skills from the officeace directory', () => {
   const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
   assert.match(tools, /function officeaceSkillsRoot\(\)/);
-  assert.match(tools, /OFFICE_CLAW_CONFIG_ROOT/);
+  assert.match(tools, /function readOfficeaceRegistryInstallDir\(\)/);
   assert.match(tools, /office-claw/);
   assert.match(tools, /capabilities\.json/);
-  assert.match(tools, /readOfficeaceRegistryInstallDir/);
 });
 
 test('setup-cli.mjs supports the officeace target end to end', () => {


### PR DESCRIPTION
Replace the invented `OFFICEACE_HOME` env var with reliable Windows registry lookup (`HKCU\SOFTWARE\OfficeAce\OfficeAce\InstallDir`) as the primary discovery mechanism for OfficeAce installation directory.

### Discovery chain

**setup-cli.mjs (installer):**
```
Registry ? Scan(Program Files + AppData\Programs) ? Interactive prompt (loop until valid)
```

**tools.mjs / agent-registration.mjs:**
```
OFFICE_CLAW_CONFIG_ROOT(session cache) ? Registry ? Scan(Program Files + AppData\Programs)
```

### Why

- `OFFICEACE_HOME` was never set by OfficeAce ? our own invention
- Registry key verified: present on install, cleared on uninstall, works for both system-level and user-level installs
- User-level installs (`AppData\Local\Programs\`) were missed by the old `Program Files`-only scan
- Interactive prompt added for fresh installs where auto-discovery fails

### Changed files

| File | Change |
|------|--------|
| `setup-cli.mjs` | New `readOfficeaceRegistryInstallDir()`, `promptOfficeaceInstallDir()`, simplified `officeaceCapabilitiesDir()` |
| `tools.mjs` | New `readOfficeaceRegistryInstallDir()`, simplified `officeaceSkillsRoot()` |
| `agent-registration.mjs` | New `readOfficeaceRegistryInstallDir()`, simplified `officeaceCapabilitiesDir()` |
| `officeace-adaptation.test.mjs` | Updated env var, capabilities.json fixture |
| `structure.test.mjs` | Updated assertions for new registry helpers |