### PR TITLE
feat: add OpenClaw agent target support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "prettier": "^3.9.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -401,6 +401,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -12,6 +12,7 @@ export const SUPPORTED_AGENT_TARGETS = [
   'workbuddy',
   'dsh',
   'officeace',
+  'openclaw',
 ];
 
 function baseHome() {

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1735,7 +1735,9 @@ async function cmdInstall() {
                 ? 'OfficeAce'
                 : target === 'openclaw'
                   ? 'OpenClaw'
-                  : 'OpenCode';
+                  : target === 'all'
+                    ? '当前 agent'
+                    : 'OpenCode';
   const pad = ' '.repeat(24 - appName.length);
   console.log(`\n\x1b[1m\x1b[33m╔══════════════════════════════════════════════════════╗`);
   console.log(`\x1b[1m\x1b[33m║  MCP 工具在重启 ${appName} 会话后才生效${pad}║`);

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1639,6 +1639,7 @@ function autoDetectTarget() {
       },
     ],
     ['officeace', () => existsSync(officeaceCapabilitiesDir())],
+    ['openclaw', () => existsSync(join(homedir(), '.openclaw'))],
   ];
   const detected = checks.filter(([, check]) => check()).map(([name]) => name);
   if (detected.length === 0) {
@@ -1691,6 +1692,10 @@ async function cmdInstall() {
     console.log('\n[OfficeAce]');
     await installOfficeAce();
   }
+  if (target === 'openclaw' || target === 'all') {
+    console.log('\n[OpenClaw]');
+    await installCodexDesktop();
+  }
   if (target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
     if (!hasCodexCLI()) {
@@ -1728,7 +1733,9 @@ async function cmdInstall() {
               ? 'DSH'
               : target === 'officeace'
                 ? 'OfficeAce'
-                : 'OpenCode';
+                : target === 'openclaw'
+                  ? 'OpenClaw'
+                  : 'OpenCode';
   const pad = ' '.repeat(24 - appName.length);
   console.log(`\n\x1b[1m\x1b[33m╔══════════════════════════════════════════════════════╗`);
   console.log(`\x1b[1m\x1b[33m║  MCP 工具在重启 ${appName} 会话后才生效${pad}║`);
@@ -1760,9 +1767,11 @@ async function cmdInstall() {
           ? workbuddyPluginsDir()
           : target === 'officeace'
             ? officeacePluginsDir()
-            : target === 'codex-desktop'
+            : target === 'openclaw'
               ? codexDesktopPluginsDir()
-              : opencodePluginsDir();
+              : target === 'codex-desktop'
+                ? codexDesktopPluginsDir()
+                : opencodePluginsDir();
   mkdirSync(markerDir, { recursive: true });
   writeFileSync(join(markerDir, '.installed'), new Date().toISOString());
   if (target === 'opencode' || target === 'all') {
@@ -1782,6 +1791,9 @@ async function cmdInstall() {
   }
   if (target === 'officeace' || target === 'all') {
     console.log('Or describe your Huawei Cloud task in OfficeAce');
+  }
+  if (target === 'openclaw' || target === 'all') {
+    console.log('Or describe your Huawei Cloud task in OpenClaw');
   }
 }
 
@@ -1809,6 +1821,10 @@ async function cmdUninstall() {
   if (target === 'officeace' || target === 'all') {
     console.log('\n[OfficeAce]');
     uninstallOfficeAce();
+  }
+  if (target === 'openclaw' || target === 'all') {
+    console.log('\n[OpenClaw]');
+    uninstallCodexDesktop();
   }
   if (target === 'codex-desktop' || target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
@@ -1861,6 +1877,26 @@ async function cmdStatus() {
   if (target === 'officeace' || target === 'all') {
     console.log('\n[OfficeAce]');
     officeaceStatus();
+  }
+  if (target === 'openclaw' || target === 'all') {
+    console.log('\n[OpenClaw]');
+    const cdPluginDir = codexDesktopPluginsDir();
+    const cdSkillsDir = codexDesktopSkillsDir();
+    console.log(
+      `  MCP Server: ${existsSync(join(cdPluginDir, 'src', 'mcp-server.mjs')) ? '\x1b[32mInstalled\x1b[0m' : '\x1b[31mNot installed\x1b[0m'}`,
+    );
+    console.log(
+      `  Safety Policy: ${existsSync(join(cdPluginDir, 'safety', 'policy.json')) ? '\x1b[32mInstalled\x1b[0m' : '\x1b[31mNot installed\x1b[0m'}`,
+    );
+    let cdSkillCount = 0;
+    if (existsSync(cdSkillsDir)) {
+      cdSkillCount = readdirSync(cdSkillsDir, { withFileTypes: true }).filter(
+        (d) => d.isDirectory() && d.name.startsWith('huawei'),
+      ).length;
+    }
+    console.log(
+      `  Skills: ${cdSkillCount > 0 ? `\x1b[32m${cdSkillCount} installed\x1b[0m` : '\x1b[31mNot installed\x1b[0m'}`,
+    );
   }
   if (target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
@@ -2211,6 +2247,18 @@ async function cmdUpdate() {
     return;
   }
 
+  if (target === 'openclaw') {
+    if (!existsSync(join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
+      return;
+    }
+    console.log('[OpenClaw]');
+    await updateCodexDesktop();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mRestart OpenClaw for changes to take effect.\x1b[0m`);
+    return;
+  }
+
   if (target === 'all') {
     let updatedAny = false;
     if (existsSync(join(opencodePluginsDir(), 'src', 'mcp-server.mjs'))) {
@@ -2241,6 +2289,11 @@ async function cmdUpdate() {
     if (existsSync(join(officeacePluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\n[OfficeAce]');
       await updateOfficeAce();
+      updatedAny = true;
+    }
+    if (existsSync(join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\n[OpenClaw]');
+      await updateCodexDesktop();
       updatedAny = true;
     }
     if (codexStatus()) {


### PR DESCRIPTION
## Summary

Closes #227

Add OpenClaw as a supported agent target. OpenClaw uses the codex bundle plugin format, so it reuses codex-desktop install/uninstall/update functions.

## Changes

- `auth/agent-registration.mjs`: add `openclaw` to `SUPPORTED_AGENT_TARGETS`
- `setup-cli.mjs`:
  - `autoDetectTarget()`: detect `~/.openclaw/` directory
  - `cmdInstall()`: add OpenClaw install block, appName mapping, marker dir, restart message
  - `cmdUninstall()`: add OpenClaw uninstall block
  - `cmdStatus()`: add OpenClaw status display
  - `cmdUpdate()`: add OpenClaw update support (single + all)