### PR TITLE
feat: add OpenClaw agent target support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ Any agent that supports MCP can use the standard config:
   "mcpServers": {
     "huaweicloud-devkit": {
       "command": "npx",
-      "args": ["-y", "-p", "huaweicloud-devkit@next", "huaweicloud-devkit-mcp"]
+      "args": ["-y", "-p", "huaweicloud-devkit", "huaweicloud-devkit-mcp"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ npx --yes huaweicloud-devkit doctor --target opencode
 npx --yes huaweicloud-devkit status --target opencode
 npx --yes huaweicloud-devkit update --target opencode
 npx --yes huaweicloud-devkit uninstall --target opencode
-rm -rf ~/.npm/_npx/  # Linux/macOS: clear npx cache to remove old version residue
+rm -rf ~/.npm/_npx/  # Linux/macOS only; Windows path TBD
 ```
 
 ### CodeArts Agent
@@ -111,7 +111,7 @@ npx --yes huaweicloud-devkit doctor --target openclaw
 npx --yes huaweicloud-devkit status --target openclaw
 npx --yes huaweicloud-devkit update --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
-rm -rf ~/.npm/_npx/  # Linux/macOS: clear npx cache to remove old version residue
+rm -rf ~/.npm/_npx/  # Linux/macOS only; Windows path TBD
 ```
 
 ### Other Agents

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Help AI coding agents use Huawei Cloud safely and accurately — a single integration that gives agents cloud knowledge, CLI tooling, and safety guardrails.
 
-Supports OpenCode, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), and OfficeAce.
+Supports OpenCode, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, and OpenClaw.
 
 ## Prerequisites
 
@@ -96,6 +96,22 @@ npx --yes huaweicloud-devkit doctor --target officeace
 npx --yes huaweicloud-devkit status --target officeace
 npx --yes huaweicloud-devkit update --target officeace
 npx --yes huaweicloud-devkit uninstall --target officeace
+```
+
+### OpenClaw
+
+```bash
+npx --yes huaweicloud-devkit install --target openclaw
+```
+
+**Restart OpenClaw** after installation.
+
+```bash
+npx --yes huaweicloud-devkit doctor --target openclaw
+npx --yes huaweicloud-devkit status --target openclaw
+npx --yes huaweicloud-devkit update --target openclaw
+npx --yes huaweicloud-devkit uninstall --target openclaw
+rm -rf ~/.npm/_npx/  # Linux/macOS: clear npx cache to remove old version residue
 ```
 
 ### Other Agents

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -123,7 +123,7 @@ rm -rf ~/.npm/_npx/  # 仅 Linux/macOS；Windows 路径待确认
   "mcpServers": {
     "huaweicloud-devkit": {
       "command": "npx",
-      "args": ["-y", "-p", "huaweicloud-devkit@next", "huaweicloud-devkit-mcp"]
+      "args": ["-y", "-p", "huaweicloud-devkit", "huaweicloud-devkit-mcp"]
     }
   }
 }

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 帮助 AI 编码助手安全、准确地使用华为云——一站式集成云知识、CLI 工具和安全护栏。
 
-支持 OpenCode、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce。
+支持 OpenCode、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、OpenClaw。
 
 ## 前置条件
 
@@ -96,6 +96,22 @@ npx --yes huaweicloud-devkit doctor --target officeace
 npx --yes huaweicloud-devkit status --target officeace
 npx --yes huaweicloud-devkit update --target officeace
 npx --yes huaweicloud-devkit uninstall --target officeace
+```
+
+### OpenClaw
+
+```bash
+npx --yes huaweicloud-devkit install --target openclaw
+```
+
+安装后**重启 OpenClaw**。
+
+```bash
+npx --yes huaweicloud-devkit doctor --target openclaw
+npx --yes huaweicloud-devkit status --target openclaw
+npx --yes huaweicloud-devkit update --target openclaw
+npx --yes huaweicloud-devkit uninstall --target openclaw
+rm -rf ~/.npm/_npx/  # Linux/macOS: 清理 npx 缓存避免旧版残留
 ```
 
 ### 其他 Agent

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -31,7 +31,7 @@ npx --yes huaweicloud-devkit doctor --target opencode
 npx --yes huaweicloud-devkit status --target opencode
 npx --yes huaweicloud-devkit update --target opencode
 npx --yes huaweicloud-devkit uninstall --target opencode
-rm -rf ~/.npm/_npx/  # Linux/macOS: 清理 npx 缓存避免旧版残留
+rm -rf ~/.npm/_npx/  # 仅 Linux/macOS；Windows 路径待确认
 ```
 
 ### CodeArts Agent（码道）
@@ -111,7 +111,7 @@ npx --yes huaweicloud-devkit doctor --target openclaw
 npx --yes huaweicloud-devkit status --target openclaw
 npx --yes huaweicloud-devkit update --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
-rm -rf ~/.npm/_npx/  # Linux/macOS: 清理 npx 缓存避免旧版残留
+rm -rf ~/.npm/_npx/  # 仅 Linux/macOS；Windows 路径待确认
 ```
 
 ### 其他 Agent

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -12,6 +12,7 @@ export const SUPPORTED_AGENT_TARGETS = [
   'workbuddy',
   'dsh',
   'officeace',
+  'hermes',
   'openclaw',
 ];
 
@@ -168,6 +169,26 @@ function officeaceRegistered() {
   return hasMcp || hasSkills;
 }
 
+function hermesHome() {
+  if (process.env.HERMES_HOME) return process.env.HERMES_HOME;
+  // Hermes on Windows stores under LOCALAPPDATA, not ~/.hermes
+  if (process.platform === 'win32' && process.env.LOCALAPPDATA) {
+    return join(process.env.LOCALAPPDATA, 'hermes');
+  }
+  return join(baseHome(), '.hermes');
+}
+
+function hermesRegistered() {
+  const configPath = join(hermesHome(), 'config.yaml');
+  if (!existsSync(configPath)) return false;
+  try {
+    const content = readFileSync(configPath, 'utf8');
+    return content.includes('mcp_servers:') && content.includes('huaweicloud-devkit');
+  } catch {
+    return false;
+  }
+}
+
 export function getAgentRegistrationStatuses(target = 'all') {
   const requested = target === 'all' ? SUPPORTED_AGENT_TARGETS : [target];
   const result = { target, agents: {} };
@@ -180,6 +201,7 @@ export function getAgentRegistrationStatuses(target = 'all') {
     if (agent === 'workbuddy') configured = workbuddyRegistered();
     if (agent === 'dsh') configured = dshRegistered();
     if (agent === 'officeace') configured = officeaceRegistered();
+    if (agent === 'hermes') configured = hermesRegistered();
     result.agents[agent] = { configured };
   }
   return result;

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -12,7 +12,6 @@ export const SUPPORTED_AGENT_TARGETS = [
   'workbuddy',
   'dsh',
   'officeace',
-  'hermes',
   'openclaw',
 ];
 
@@ -169,26 +168,6 @@ function officeaceRegistered() {
   return hasMcp || hasSkills;
 }
 
-function hermesHome() {
-  if (process.env.HERMES_HOME) return process.env.HERMES_HOME;
-  // Hermes on Windows stores under LOCALAPPDATA, not ~/.hermes
-  if (process.platform === 'win32' && process.env.LOCALAPPDATA) {
-    return join(process.env.LOCALAPPDATA, 'hermes');
-  }
-  return join(baseHome(), '.hermes');
-}
-
-function hermesRegistered() {
-  const configPath = join(hermesHome(), 'config.yaml');
-  if (!existsSync(configPath)) return false;
-  try {
-    const content = readFileSync(configPath, 'utf8');
-    return content.includes('mcp_servers:') && content.includes('huaweicloud-devkit');
-  } catch {
-    return false;
-  }
-}
-
 export function getAgentRegistrationStatuses(target = 'all') {
   const requested = target === 'all' ? SUPPORTED_AGENT_TARGETS : [target];
   const result = { target, agents: {} };
@@ -201,7 +180,6 @@ export function getAgentRegistrationStatuses(target = 'all') {
     if (agent === 'workbuddy') configured = workbuddyRegistered();
     if (agent === 'dsh') configured = dshRegistered();
     if (agent === 'officeace') configured = officeaceRegistered();
-    if (agent === 'hermes') configured = hermesRegistered();
     result.agents[agent] = { configured };
   }
   return result;


### PR DESCRIPTION
Closes #227

## Changes

- `auth/agent-registration.mjs`: add `openclaw` to `SUPPORTED_AGENT_TARGETS`
- `setup-cli.mjs`:
  - `autoDetectTarget()`: detect `~/.openclaw/` directory
  - `cmdInstall()`: add OpenClaw install block (reuse codex-desktop), add to appName
  - `cmdUninstall()`: add OpenClaw uninstall block
  - `cmdStatus()`: add OpenClaw status display
  - `cmdUpdate()`: add OpenClaw update support
  - `appName` fallback: `OpenCode` → `当前 agent` for all/unknown targets