### PR TITLE
feat: add OpenClaw agent target support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "prettier": "^3.9.6"
       },
       "engines": {
-        "node": ">=20"
+        "node": ">=22"
       }
     },
     "node_modules/@eslint-community/eslint-utils": {
@@ -401,6 +401,7 @@
       "version": "13.0.3",
       "resolved": "https://registry.npmjs.org/better-sqlite3/-/better-sqlite3-13.0.3.tgz",
       "integrity": "sha512-RbOBxmLBG8uvFUc15X9+9SFemKcQ0WBuISBVkpuiaUB2qblC8UWlHEjdWVoZ8AdhSwmoEgsiXKfopX0CQxaACQ==",
+      "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
         "node-addon-api": "^8.0.0"

--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -13,6 +13,7 @@ export const SUPPORTED_AGENT_TARGETS = [
   'dsh',
   'officeace',
   'hermes',
+  'openclaw',
 ];
 
 function baseHome() {

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1833,7 +1833,8 @@ function autoDetectTarget() {
       },
     ],
     ['officeace', () => existsSync(officeaceCapabilitiesDir())],
-    ['hermes', () => existsSync(hermesHomeDir())],
+['hermes', () => existsSync(hermesHomeDir())],
+    ['openclaw', () => existsSync(join(homedir(), '.openclaw'))],
   ];
   const detected = checks.filter(([, check]) => check()).map(([name]) => name);
   if (detected.length === 0) {
@@ -1886,9 +1887,14 @@ async function cmdInstall() {
     console.log('\n[OfficeAce]');
     await installOfficeAce();
   }
-  if (target === 'hermes' || target === 'all') {
+if (target === 'hermes' || target === 'all') {
     console.log('\n[Hermes Agent]');
     await installHermes();
+  }
+  if (target === 'openclaw' || target === 'all') {
+    console.log('\n[OpenClaw]');
+    await installCodexDesktop();
+  }
   }
   if (target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
@@ -1927,9 +1933,11 @@ async function cmdInstall() {
               ? 'DSH'
               : target === 'officeace'
                 ? 'OfficeAce'
-                : target === 'hermes'
+: target === 'hermes'
                   ? 'Hermes Agent'
-                  : 'OpenCode';
+                  : target === 'openclaw'
+                    ? 'OpenClaw'
+                    : '当前 agent';
   const pad = ' '.repeat(24 - appName.length);
   console.log(`\n\x1b[1m\x1b[33m╔══════════════════════════════════════════════════════╗`);
   console.log(`\x1b[1m\x1b[33m║  MCP 工具在重启 ${appName} 会话后才生效${pad}║`);
@@ -1961,9 +1969,11 @@ async function cmdInstall() {
           ? workbuddyPluginsDir()
           : target === 'officeace'
             ? officeacePluginsDir()
-            : target === 'codex-desktop'
+            : target === 'openclaw'
               ? codexDesktopPluginsDir()
-              : opencodePluginsDir();
+              : target === 'codex-desktop'
+                ? codexDesktopPluginsDir()
+                : opencodePluginsDir();
   mkdirSync(markerDir, { recursive: true });
   writeFileSync(join(markerDir, '.installed'), new Date().toISOString());
   if (target === 'opencode' || target === 'all') {
@@ -1983,6 +1993,9 @@ async function cmdInstall() {
   }
   if (target === 'officeace' || target === 'all') {
     console.log('Or describe your Huawei Cloud task in OfficeAce');
+  }
+  if (target === 'openclaw' || target === 'all') {
+    console.log('Or describe your Huawei Cloud task in OpenClaw');
   }
 }
 
@@ -2011,9 +2024,14 @@ async function cmdUninstall() {
     console.log('\n[OfficeAce]');
     uninstallOfficeAce();
   }
-  if (target === 'hermes' || target === 'all') {
+if (target === 'hermes' || target === 'all') {
     console.log('\n[Hermes Agent]');
     uninstallHermes();
+  }
+  if (target === 'openclaw' || target === 'all') {
+    console.log('\n[OpenClaw]');
+    uninstallCodexDesktop();
+  }
   }
   if (target === 'codex-desktop' || target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
@@ -2067,9 +2085,29 @@ async function cmdStatus() {
     console.log('\n[OfficeAce]');
     officeaceStatus();
   }
-  if (target === 'hermes' || target === 'all') {
+if (target === 'hermes' || target === 'all') {
     console.log('\n[Hermes Agent]');
     hermesStatus();
+  }
+  if (target === 'openclaw' || target === 'all') {
+    console.log('\n[OpenClaw]');
+    const cdPluginDir = codexDesktopPluginsDir();
+    const cdSkillsDir = codexDesktopSkillsDir();
+    console.log(
+      `  MCP Server: ${existsSync(join(cdPluginDir, 'src', 'mcp-server.mjs')) ? '\x1b[32mInstalled\x1b[0m' : '\x1b[31mNot installed\x1b[0m'}`,
+    );
+    console.log(
+      `  Safety Policy: ${existsSync(join(cdPluginDir, 'safety', 'policy.json')) ? '\x1b[32mInstalled\x1b[0m' : '\x1b[31mNot installed\x1b[0m'}`,
+    );
+    let cdSkillCount = 0;
+    if (existsSync(cdSkillsDir)) {
+      cdSkillCount = readdirSync(cdSkillsDir, { withFileTypes: true }).filter(
+        (d) => d.isDirectory() && d.name.startsWith('huawei'),
+      ).length;
+    }
+    console.log(
+      `  Skills: ${cdSkillCount > 0 ? `\x1b[32m${cdSkillCount} installed\x1b[0m` : '\x1b[31mNot installed\x1b[0m'}`,
+    );
   }
   if (target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
@@ -2438,7 +2476,7 @@ async function cmdUpdate() {
     return;
   }
 
-  if (target === 'hermes') {
+if (target === 'hermes') {
     if (!existsSync(join(hermesPluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
       return;
@@ -2448,6 +2486,19 @@ async function cmdUpdate() {
     console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
     console.log(`\x1b[33mRestart Hermes Agent for changes to take effect.\x1b[0m`);
     return;
+  }
+
+  if (target === 'openclaw') {
+    if (!existsSync(join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
+      return;
+    }
+    console.log('[OpenClaw]');
+    await updateCodexDesktop();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mRestart OpenClaw for changes to take effect.\x1b[0m`);
+    return;
+  }
   }
 
   if (target === 'all') {
@@ -2482,9 +2533,14 @@ async function cmdUpdate() {
       await updateOfficeAce();
       updatedAny = true;
     }
-    if (existsSync(join(hermesPluginsDir(), 'src', 'mcp-server.mjs'))) {
+if (existsSync(join(hermesPluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\n[Hermes Agent]');
       await updateHermes();
+      updatedAny = true;
+    }
+    if (existsSync(join(codexDesktopPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\n[OpenClaw]');
+      await updateCodexDesktop();
       updatedAny = true;
     }
     if (codexStatus()) {

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1833,7 +1833,7 @@ function autoDetectTarget() {
       },
     ],
     ['officeace', () => existsSync(officeaceCapabilitiesDir())],
-['hermes', () => existsSync(hermesHomeDir())],
+    ['hermes', () => existsSync(hermesHomeDir())],
     ['openclaw', () => existsSync(join(homedir(), '.openclaw'))],
   ];
   const detected = checks.filter(([, check]) => check()).map(([name]) => name);
@@ -1887,14 +1887,13 @@ async function cmdInstall() {
     console.log('\n[OfficeAce]');
     await installOfficeAce();
   }
-if (target === 'hermes' || target === 'all') {
+  if (target === 'hermes' || target === 'all') {
     console.log('\n[Hermes Agent]');
     await installHermes();
   }
   if (target === 'openclaw' || target === 'all') {
     console.log('\n[OpenClaw]');
     await installCodexDesktop();
-  }
   }
   if (target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
@@ -1933,7 +1932,7 @@ if (target === 'hermes' || target === 'all') {
               ? 'DSH'
               : target === 'officeace'
                 ? 'OfficeAce'
-: target === 'hermes'
+                : target === 'hermes'
                   ? 'Hermes Agent'
                   : target === 'openclaw'
                     ? 'OpenClaw'
@@ -2024,14 +2023,13 @@ async function cmdUninstall() {
     console.log('\n[OfficeAce]');
     uninstallOfficeAce();
   }
-if (target === 'hermes' || target === 'all') {
+  if (target === 'hermes' || target === 'all') {
     console.log('\n[Hermes Agent]');
     uninstallHermes();
   }
   if (target === 'openclaw' || target === 'all') {
     console.log('\n[OpenClaw]');
     uninstallCodexDesktop();
-  }
   }
   if (target === 'codex-desktop' || target === 'codex' || target === 'all') {
     console.log('\n[Codex]');
@@ -2085,7 +2083,7 @@ async function cmdStatus() {
     console.log('\n[OfficeAce]');
     officeaceStatus();
   }
-if (target === 'hermes' || target === 'all') {
+  if (target === 'hermes' || target === 'all') {
     console.log('\n[Hermes Agent]');
     hermesStatus();
   }
@@ -2476,7 +2474,7 @@ async function cmdUpdate() {
     return;
   }
 
-if (target === 'hermes') {
+  if (target === 'hermes') {
     if (!existsSync(join(hermesPluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
       return;
@@ -2498,7 +2496,6 @@ if (target === 'hermes') {
     console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
     console.log(`\x1b[33mRestart OpenClaw for changes to take effect.\x1b[0m`);
     return;
-  }
   }
 
   if (target === 'all') {
@@ -2533,7 +2530,7 @@ if (target === 'hermes') {
       await updateOfficeAce();
       updatedAny = true;
     }
-if (existsSync(join(hermesPluginsDir(), 'src', 'mcp-server.mjs'))) {
+    if (existsSync(join(hermesPluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\n[Hermes Agent]');
       await updateHermes();
       updatedAny = true;


### PR DESCRIPTION
Closes #227. Rebased onto latest dev with Hermes agent conflicts resolved.

OpenClaw uses the same `~/.agents/` install path as Codex Desktop, so all install/uninstall/status/update operations reuse `installCodexDesktop()` etc.

### Changes

| File | Change |
|------|--------|
| `agent-registration.mjs` | Add `openclaw` to SUPPORTED_AGENT_TARGETS |
| `setup-cli.mjs` | Add openclaw to autoDetectTarget, cmdInstall/Uninstall/Status/Update |
| `setup-cli.mjs` | appName fallback: `OpenCode` ? `?? agent` |

### Conflict resolution

Merged with Hermes agent entries in the same ternary chains.