### PR TITLE
docs: prioritize ClawHub install for OpenClaw, add alt npx method

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ openclaw plugins install clawhub:huaweicloud-devkit
 ```bash
 # Or via npx
 npx --yes huaweicloud-devkit install --target openclaw
+npx --yes huaweicloud-devkit status --target openclaw
+npx --yes huaweicloud-devkit update --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
 rm -rf ~/.npm/_npx/  # Linux/macOS only; Windows path TBD
 ```

--- a/README.md
+++ b/README.md
@@ -101,15 +101,15 @@ npx --yes huaweicloud-devkit uninstall --target officeace
 ### OpenClaw
 
 ```bash
-npx --yes huaweicloud-devkit install --target openclaw
+# Recommended (ClawHub)
+openclaw plugins install clawhub:huaweicloud-devkit
 ```
 
 **Restart OpenClaw** after installation.
 
 ```bash
-npx --yes huaweicloud-devkit doctor --target openclaw
-npx --yes huaweicloud-devkit status --target openclaw
-npx --yes huaweicloud-devkit update --target openclaw
+# Or via npx
+npx --yes huaweicloud-devkit install --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
 rm -rf ~/.npm/_npx/  # Linux/macOS only; Windows path TBD
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,6 +110,8 @@ openclaw plugins install clawhub:huaweicloud-devkit
 ```bash
 # 或通过 npx
 npx --yes huaweicloud-devkit install --target openclaw
+npx --yes huaweicloud-devkit status --target openclaw
+npx --yes huaweicloud-devkit update --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
 rm -rf ~/.npm/_npx/  # 仅 Linux/macOS；Windows 路径待确认
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,15 +101,15 @@ npx --yes huaweicloud-devkit uninstall --target officeace
 ### OpenClaw
 
 ```bash
-npx --yes huaweicloud-devkit install --target openclaw
+# 推荐方式 (ClawHub)
+openclaw plugins install clawhub:huaweicloud-devkit
 ```
 
 安装后**重启 OpenClaw**。
 
 ```bash
-npx --yes huaweicloud-devkit doctor --target openclaw
-npx --yes huaweicloud-devkit status --target openclaw
-npx --yes huaweicloud-devkit update --target openclaw
+# 或通过 npx
+npx --yes huaweicloud-devkit install --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
 rm -rf ~/.npm/_npx/  # 仅 Linux/macOS；Windows 路径待确认
 ```


### PR DESCRIPTION
## Changes

- OpenClaw section: ClawHub (`openclaw plugins install`) as primary method, npx as alternative
- Remove `doctor`/`status`/`update` commands from README (ClawHub manages plugin lifecycle)