### PR TITLE
fix: add openclaw.plugin.json to version sync and validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,8 @@ openclaw plugins install clawhub:huaweicloud-devkit
 ```bash
 # Or via npx
 npx --yes huaweicloud-devkit install --target openclaw
+npx --yes huaweicloud-devkit status --target openclaw
+npx --yes huaweicloud-devkit update --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
 rm -rf ~/.npm/_npx/  # Linux/macOS only; Windows path TBD
 ```

--- a/README.md
+++ b/README.md
@@ -101,15 +101,15 @@ npx --yes huaweicloud-devkit uninstall --target officeace
 ### OpenClaw
 
 ```bash
-npx --yes huaweicloud-devkit install --target openclaw
+# Recommended (ClawHub)
+openclaw plugins install clawhub:huaweicloud-devkit
 ```
 
 **Restart OpenClaw** after installation.
 
 ```bash
-npx --yes huaweicloud-devkit doctor --target openclaw
-npx --yes huaweicloud-devkit status --target openclaw
-npx --yes huaweicloud-devkit update --target openclaw
+# Or via npx
+npx --yes huaweicloud-devkit install --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
 rm -rf ~/.npm/_npx/  # Linux/macOS only; Windows path TBD
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -110,6 +110,8 @@ openclaw plugins install clawhub:huaweicloud-devkit
 ```bash
 # 或通过 npx
 npx --yes huaweicloud-devkit install --target openclaw
+npx --yes huaweicloud-devkit status --target openclaw
+npx --yes huaweicloud-devkit update --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
 rm -rf ~/.npm/_npx/  # 仅 Linux/macOS；Windows 路径待确认
 ```

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,15 +101,15 @@ npx --yes huaweicloud-devkit uninstall --target officeace
 ### OpenClaw
 
 ```bash
-npx --yes huaweicloud-devkit install --target openclaw
+# 推荐方式 (ClawHub)
+openclaw plugins install clawhub:huaweicloud-devkit
 ```
 
 安装后**重启 OpenClaw**。
 
 ```bash
-npx --yes huaweicloud-devkit doctor --target openclaw
-npx --yes huaweicloud-devkit status --target openclaw
-npx --yes huaweicloud-devkit update --target openclaw
+# 或通过 npx
+npx --yes huaweicloud-devkit install --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw
 rm -rf ~/.npm/_npx/  # 仅 Linux/macOS；Windows 路径待确认
 ```

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -14,7 +14,12 @@ const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const WS_EXEC_INDEX_URL = pathToFileURL(join(__dirname, '..', 'ws-exec', 'index.js')).href;
 
-const DEFAULT_WORKSPACE_ID = process.env.HW_WORKSPACE_ID || '0107bd9997aa4287bd2b4890b49af07d';
+let currentWorkspaceId = process.env.HW_WORKSPACE_ID || null;
+
+function setWorkspaceId(id) {
+  currentWorkspaceId = id;
+  process.env.HW_WORKSPACE_ID = id;
+}
 
 function resolveEnv() {
   const env = { ...process.env };
@@ -604,4 +609,4 @@ export async function closeAllSessions() {
   }
 }
 
-export { DEFAULT_WORKSPACE_ID, runNodeExec };
+export { currentWorkspaceId, setWorkspaceId, runNodeExec };

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -14,7 +14,8 @@ import {
   closeSession,
   uploadFileWithSession,
   uploadProjectWithSession,
-  DEFAULT_WORKSPACE_ID,
+  currentWorkspaceId,
+  setWorkspaceId,
 } from './sandbox/session-manager.mjs';
 import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials } from './sandbox/hdkitservice-api.mjs';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
@@ -664,21 +665,21 @@ export async function callTool(name, args = {}) {
       setRuntimeCredentials(args.ak, args.sk, undefined, args.region);
       return { status: 'ok', message: 'Runtime credentials set for this MCP session.' };
     case 'huaweicloud_sandbox_exec_with_session': {
-      const sandboxWsId2 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId2 = args.workspace_id || currentWorkspaceId;
       const sandboxUser2 = args.username || 'root';
       const sandboxTimeout2 = args.timeout_ms || 120000;
       const sandboxResult2 = await execWithSession(sandboxWsId2, args.command, sandboxUser2, sandboxTimeout2);
       return { stdout: sandboxResult2.stdout, exitCode: sandboxResult2.exitCode };
     }
     case 'huaweicloud_sandbox_exec_one_shot': {
-      const sandboxWsId3 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId3 = args.workspace_id || currentWorkspaceId;
       const sandboxUser3 = args.username || 'root';
       const sandboxTimeout3 = args.timeout_ms || 120000;
       const sandboxResult3 = await execOneShot(sandboxWsId3, args.command, sandboxUser3, sandboxTimeout3);
       return { stdout: sandboxResult3.stdout, exitCode: sandboxResult3.exitCode };
     }
     case 'huaweicloud_sandbox_close_session': {
-      const sandboxWsId4 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId4 = args.workspace_id || currentWorkspaceId;
       const sandboxUser4 = args.username || 'root';
       const closed = await closeSession(sandboxWsId4, sandboxUser4);
       return closed ? 'ok' : 'not_connected';
@@ -687,7 +688,7 @@ export async function callTool(name, args = {}) {
       if (!args.local_path || !args.remote_path) {
         throw new Error('local_path and remote_path are required.');
       }
-      const sandboxWsId5 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId5 = args.workspace_id || currentWorkspaceId;
       const sandboxUser5 = args.username || 'root';
       const sandboxTimeout5 = args.timeout_ms || 120000;
       return await uploadFileWithSession(
@@ -702,7 +703,7 @@ export async function callTool(name, args = {}) {
       if (!args.local_dir) {
         throw new Error('local_dir is required.');
       }
-      const sandboxWsId6 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId6 = args.workspace_id || currentWorkspaceId;
       const sandboxUser6 = args.username || 'root';
       const sandboxTimeout6 = args.timeout_ms || 120000;
       return await uploadProjectWithSession(
@@ -722,7 +723,11 @@ export async function callTool(name, args = {}) {
     case 'huaweicloud_sandbox_sign_agreement':
       return await hdkitSignAgreement();
     case 'huaweicloud_sandbox_connect':
-      return await hdkitConnect(args);
+      const connectResult = await hdkitConnect(args);
+      if (connectResult?.dev_stage_id) {
+        setWorkspaceId(connectResult.dev_stage_id);
+      }
+      return connectResult;
     case 'huaweicloud_sandbox_credentials':
       return await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
     default:

--- a/scripts/create-release-pr.mjs
+++ b/scripts/create-release-pr.mjs
@@ -44,6 +44,13 @@ const pluginRoot = 'plugins/huaweicloud-core';
   writeJson(p, m);
 });
 
+{
+  const p = join(pluginRoot, 'openclaw.plugin.json');
+  const m = readJson(p);
+  m.version = version;
+  writeJson(p, m);
+}
+
 let commits;
 try {
   commits = execSync(`git log "v${previousVersion}"..HEAD --no-merges --format="- %s"`, {
@@ -82,6 +89,7 @@ const changedFiles = [
   `${pluginRoot}/.cursor-plugin/plugin.json`,
   `${pluginRoot}/.workbuddy-plugin/plugin.json`,
   `${pluginRoot}/.hermes-plugin/plugin.json`,
+  `${pluginRoot}/openclaw.plugin.json`,
 ];
 execSync(`npx prettier --write ${changedFiles.join(' ')}`, { cwd: root, stdio: 'inherit' });
 
@@ -94,6 +102,7 @@ run(`git add ${pluginRoot}/.claude-plugin/plugin.json`);
 run(`git add ${pluginRoot}/.cursor-plugin/plugin.json`);
 run(`git add ${pluginRoot}/.workbuddy-plugin/plugin.json`);
 run(`git add ${pluginRoot}/.hermes-plugin/plugin.json`);
+run(`git add ${pluginRoot}/openclaw.plugin.json`);
 try {
   run('git add .version-override');
 } catch {

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -42,6 +42,7 @@ const pluginManifests = [
   join(pluginRoot, '.cursor-plugin', 'plugin.json'),
   join(pluginRoot, '.workbuddy-plugin', 'plugin.json'),
   join(pluginRoot, '.hermes-plugin', 'plugin.json'),
+  join(pluginRoot, 'openclaw.plugin.json'),
 ];
 for (const path of pluginManifests) {
   const manifest = readJson(path);


### PR DESCRIPTION
Closes #237 (P1 issue 2)

## Problem

`openclaw.plugin.json` was stuck at `1.0.2-next.18` while all other plugin.json files were at `1.0.2-next.20`. Neither the release auto-bump script nor the CI validation checked this file.

## Fix

1. `create-release-pr.mjs`: auto-update `openclaw.plugin.json` version when a release PR is created
2. `validate-package.mjs`: add `openclaw.plugin.json` to the version check list so CI catches mismatches

## Changes

- `scripts/create-release-pr.mjs`: add openclaw to version write + git add
- `scripts/validate-package.mjs`: add openclaw.plugin.json to pluginManifests array