### PR TITLE
fix: OpenClaw plugin issues - workspace cache, version sync, name unification

### DIFF
--- a/.agents/plugins/marketplace.json
+++ b/.agents/plugins/marketplace.json
@@ -5,7 +5,7 @@
   },
   "plugins": [
     {
-      "name": "huaweicloud-core",
+      "name": "huaweicloud-devkit",
       "source": {
         "source": "local",
         "path": "./plugins/huaweicloud-core"

--- a/plugins/huaweicloud-core/.claude-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.claude-plugin/plugin.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/huaweicloud"
   },
   "hooks": "./hooks/",
-  "name": "huaweicloud-core",
+  "name": "huaweicloud-devkit",
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",

--- a/plugins/huaweicloud-core/.codex-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.codex-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "huaweicloud-core",
+  "name": "huaweicloud-devkit",
   "version": "1.0.2-next.20",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {

--- a/plugins/huaweicloud-core/.cursor-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.cursor-plugin/plugin.json
@@ -23,7 +23,7 @@
     "url": "https://github.com/huaweicloud"
   },
   "hooks": "./hooks/",
-  "name": "huaweicloud-core",
+  "name": "huaweicloud-devkit",
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",

--- a/plugins/huaweicloud-core/.hermes-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.hermes-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "huaweicloud-core",
+  "name": "huaweicloud-devkit",
   "version": "1.0.2-next.20",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {

--- a/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
@@ -1,5 +1,5 @@
 {
-  "name": "huaweicloud-core",
+  "name": "huaweicloud-devkit",
   "version": "1.0.2-next.20",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {

--- a/plugins/huaweicloud-core/openclaw.plugin.json
+++ b/plugins/huaweicloud-core/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "name": "huaweicloud-devkit",
   "id": "huaweicloud-devkit",
   "displayName": "HuaweiCloud DevKit",
-  "version": "1.0.2-next.18",
+  "version": "1.0.2-next.20",
   "family": "bundle-plugin",
   "bundleFormat": "codex",
   "description": "Guide coding agents to use Huawei Cloud safely — KooCLI, APIs, SDKs, 28 MCP tools, skills, and safety guardrails.",

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -14,7 +14,12 @@ const execFileAsync = promisify(execFile);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 export const WS_EXEC_INDEX_URL = pathToFileURL(join(__dirname, '..', 'ws-exec', 'index.js')).href;
 
-const DEFAULT_WORKSPACE_ID = process.env.HW_WORKSPACE_ID || '0107bd9997aa4287bd2b4890b49af07d';
+let currentWorkspaceId = process.env.HW_WORKSPACE_ID || null;
+
+function setWorkspaceId(id) {
+  currentWorkspaceId = id;
+  process.env.HW_WORKSPACE_ID = id;
+}
 
 function resolveEnv() {
   const env = { ...process.env };
@@ -604,4 +609,4 @@ export async function closeAllSessions() {
   }
 }
 
-export { DEFAULT_WORKSPACE_ID, runNodeExec };
+export { currentWorkspaceId, setWorkspaceId, runNodeExec };

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -3046,7 +3046,7 @@ async function main() {
     default:
       console.log(BANNER);
       console.log(
-        'Usage: npx huaweicloud-devkit <command> [--target <opencode|codex|codearts|workbuddy|dsh|officeace|hermes|all>]\n',
+        'Usage: npx huaweicloud-devkit <command> [--target <opencode|codex|codearts|workbuddy|dsh|officeace|hermes|openclaw|all>]\n',
       );
       console.log('Commands:');
       console.log('  install      Install skills, MCP server, safety policy');
@@ -3061,7 +3061,7 @@ async function main() {
       console.log('  help         Show this help');
       console.log('\nOptions:');
       console.log(
-        '  --target     Target agent: opencode (default), codex, codearts, workbuddy, dsh, officeace, hermes, all',
+        '  --target     Target agent: opencode (default), codex, codearts, workbuddy, dsh, officeace, hermes, openclaw, all',
       );
       console.log('\nExamples:');
       console.log('  npx huaweicloud-devkit install');

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -14,7 +14,8 @@ import {
   closeSession,
   uploadFileWithSession,
   uploadProjectWithSession,
-  DEFAULT_WORKSPACE_ID,
+  currentWorkspaceId,
+  setWorkspaceId,
 } from './sandbox/session-manager.mjs';
 import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials } from './sandbox/hdkitservice-api.mjs';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
@@ -664,21 +665,21 @@ export async function callTool(name, args = {}) {
       setRuntimeCredentials(args.ak, args.sk, undefined, args.region);
       return { status: 'ok', message: 'Runtime credentials set for this MCP session.' };
     case 'huaweicloud_sandbox_exec_with_session': {
-      const sandboxWsId2 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId2 = args.workspace_id || currentWorkspaceId;
       const sandboxUser2 = args.username || 'root';
       const sandboxTimeout2 = args.timeout_ms || 120000;
       const sandboxResult2 = await execWithSession(sandboxWsId2, args.command, sandboxUser2, sandboxTimeout2);
       return { stdout: sandboxResult2.stdout, exitCode: sandboxResult2.exitCode };
     }
     case 'huaweicloud_sandbox_exec_one_shot': {
-      const sandboxWsId3 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId3 = args.workspace_id || currentWorkspaceId;
       const sandboxUser3 = args.username || 'root';
       const sandboxTimeout3 = args.timeout_ms || 120000;
       const sandboxResult3 = await execOneShot(sandboxWsId3, args.command, sandboxUser3, sandboxTimeout3);
       return { stdout: sandboxResult3.stdout, exitCode: sandboxResult3.exitCode };
     }
     case 'huaweicloud_sandbox_close_session': {
-      const sandboxWsId4 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId4 = args.workspace_id || currentWorkspaceId;
       const sandboxUser4 = args.username || 'root';
       const closed = await closeSession(sandboxWsId4, sandboxUser4);
       return closed ? 'ok' : 'not_connected';
@@ -687,7 +688,7 @@ export async function callTool(name, args = {}) {
       if (!args.local_path || !args.remote_path) {
         throw new Error('local_path and remote_path are required.');
       }
-      const sandboxWsId5 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId5 = args.workspace_id || currentWorkspaceId;
       const sandboxUser5 = args.username || 'root';
       const sandboxTimeout5 = args.timeout_ms || 120000;
       return await uploadFileWithSession(
@@ -702,7 +703,7 @@ export async function callTool(name, args = {}) {
       if (!args.local_dir) {
         throw new Error('local_dir is required.');
       }
-      const sandboxWsId6 = args.workspace_id || DEFAULT_WORKSPACE_ID;
+      const sandboxWsId6 = args.workspace_id || currentWorkspaceId;
       const sandboxUser6 = args.username || 'root';
       const sandboxTimeout6 = args.timeout_ms || 120000;
       return await uploadProjectWithSession(
@@ -722,7 +723,11 @@ export async function callTool(name, args = {}) {
     case 'huaweicloud_sandbox_sign_agreement':
       return await hdkitSignAgreement();
     case 'huaweicloud_sandbox_connect':
-      return await hdkitConnect(args);
+      const connectResult = await hdkitConnect(args);
+      if (connectResult?.dev_stage_id) {
+        setWorkspaceId(connectResult.dev_stage_id);
+      }
+      return connectResult;
     case 'huaweicloud_sandbox_credentials':
       return await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
     default:

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -425,7 +425,7 @@ export const TOOL_DEFINITIONS = [
         target: {
           type: 'string',
           description:
-            'Agent target to check: opencode, codex, codex-desktop, codearts, workbuddy, dsh, officeace, hermes, or all (default).',
+            'Agent target to check: opencode, codex, codex-desktop, codearts, workbuddy, dsh, officeace, hermes, openclaw, or all (default).',
         },
       },
     },

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -722,12 +722,13 @@ export async function callTool(name, args = {}) {
       return await hdkitCheckUser();
     case 'huaweicloud_sandbox_sign_agreement':
       return await hdkitSignAgreement();
-    case 'huaweicloud_sandbox_connect':
+    case 'huaweicloud_sandbox_connect': {
       const connectResult = await hdkitConnect(args);
       if (connectResult?.dev_stage_id) {
         setWorkspaceId(connectResult.dev_stage_id);
       }
       return connectResult;
+    }
     case 'huaweicloud_sandbox_credentials':
       return await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
     default:

--- a/scripts/create-release-pr.mjs
+++ b/scripts/create-release-pr.mjs
@@ -44,6 +44,13 @@ const pluginRoot = 'plugins/huaweicloud-core';
   writeJson(p, m);
 });
 
+{
+  const p = join(pluginRoot, 'openclaw.plugin.json');
+  const m = readJson(p);
+  m.version = version;
+  writeJson(p, m);
+}
+
 let commits;
 try {
   commits = execSync(`git log "v${previousVersion}"..HEAD --no-merges --format="- %s"`, {
@@ -82,6 +89,7 @@ const changedFiles = [
   `${pluginRoot}/.cursor-plugin/plugin.json`,
   `${pluginRoot}/.workbuddy-plugin/plugin.json`,
   `${pluginRoot}/.hermes-plugin/plugin.json`,
+  `${pluginRoot}/openclaw.plugin.json`,
 ];
 execSync(`npx prettier --write ${changedFiles.join(' ')}`, { cwd: root, stdio: 'inherit' });
 
@@ -94,6 +102,7 @@ run(`git add ${pluginRoot}/.claude-plugin/plugin.json`);
 run(`git add ${pluginRoot}/.cursor-plugin/plugin.json`);
 run(`git add ${pluginRoot}/.workbuddy-plugin/plugin.json`);
 run(`git add ${pluginRoot}/.hermes-plugin/plugin.json`);
+run(`git add ${pluginRoot}/openclaw.plugin.json`);
 try {
   run('git add .version-override');
 } catch {

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -24,7 +24,7 @@ assertExists(join(pluginRoot, 'safety', 'rules', 'cloud-risk-rules.json'));
 assertExists(join(root, 'integrations', 'opencode', 'opencode.json'));
 
 const manifest = readJson(join(pluginRoot, '.codex-plugin', 'plugin.json'));
-assert.equal(manifest.name, 'huaweicloud-core');
+assert.equal(manifest.name, 'huaweicloud-devkit');
 assert.equal(manifest.skills, './skills/');
 assert.equal(manifest.mcpServers, './.mcp.json');
 assert.ok(!Object.hasOwn(manifest, 'hooks'), 'Codex manifest should not include hooks until supported by validator');

--- a/scripts/validate-package.mjs
+++ b/scripts/validate-package.mjs
@@ -42,6 +42,7 @@ const pluginManifests = [
   join(pluginRoot, '.cursor-plugin', 'plugin.json'),
   join(pluginRoot, '.workbuddy-plugin', 'plugin.json'),
   join(pluginRoot, '.hermes-plugin', 'plugin.json'),
+  join(pluginRoot, 'openclaw.plugin.json'),
 ];
 for (const path of pluginManifests) {
   const manifest = readJson(path);

--- a/test/agent-install.test.mjs
+++ b/test/agent-install.test.mjs
@@ -255,7 +255,7 @@ test('hermes install creates skills, MCP server, and safety policy', () => {
   try {
     const res = run('hermes', home, cwd, 'install');
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /\[Hermes\]/);
+    assert.match(res.stdout, /\[Hermes Agent\]/);
     assert.match(res.stdout, /Installation complete/);
     assert.ok(countSkills(join(home, '.hermes', 'skills')) >= 6);
     const pd = join(home, '.hermes', 'huaweicloud-plugins');

--- a/test/agent-install.test.mjs
+++ b/test/agent-install.test.mjs
@@ -212,3 +212,85 @@ test('cli help lists supported agent targets', () => {
     rmSync(cwd, { recursive: true, force: true });
   }
 });
+
+test('openclaw install creates skills, MCP server, and safety policy in .agents', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+  try {
+    const res = run('openclaw', home, cwd, 'install');
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /\[OpenClaw\]/);
+    assert.match(res.stdout, /Installation complete/);
+    assert.ok(countSkills(join(home, '.agents', 'skills')) >= 6);
+    const pd = join(home, '.agents', 'huaweicloud-plugins');
+    assert.ok(existsSync(join(pd, 'src', 'mcp-server.mjs')));
+    assert.ok(existsSync(join(pd, 'src', 'tools.mjs')));
+    assert.ok(existsSync(join(pd, 'safety', 'policy.json')));
+    assert.ok(existsSync(join(pd, '.installed')));
+    assert.equal(pluginVersion(pd), pkg.version);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('openclaw uninstall removes installed files', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+  try {
+    assert.equal(run('openclaw', home, cwd, 'install').status, 0);
+    const res = run('openclaw', home, cwd, 'uninstall');
+    assert.match(res.stdout, /Uninstall complete/);
+    assert.equal(countSkills(join(home, '.agents', 'skills')), 0);
+    assert.ok(!existsSync(join(home, '.agents', 'huaweicloud-plugins')));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('hermes install creates skills, MCP server, and safety policy', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+  try {
+    const res = run('hermes', home, cwd, 'install');
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /\[Hermes\]/);
+    assert.match(res.stdout, /Installation complete/);
+    assert.ok(countSkills(join(home, '.hermes', 'skills')) >= 6);
+    const pd = join(home, '.hermes', 'huaweicloud-plugins');
+    assert.ok(existsSync(join(pd, 'src', 'mcp-server.mjs')));
+    assert.ok(existsSync(join(pd, 'safety', 'policy.json')));
+    assert.equal(pluginVersion(pd), pkg.version);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('hermes uninstall removes installed files', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+  try {
+    assert.equal(run('hermes', home, cwd, 'install').status, 0);
+    const res = run('hermes', home, cwd, 'uninstall');
+    assert.match(res.stdout, /Uninstall complete/);
+    assert.equal(countSkills(join(home, '.hermes', 'skills')), 0);
+    assert.ok(!existsSync(join(home, '.hermes', 'huaweicloud-plugins')));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('codex target does not crash without Codex CLI', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+  try {
+    const res = run('codex', home, cwd, 'install');
+    assert.match(res.stdout, /Codex CLI not found/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/test/codearts-adaptation.test.mjs
+++ b/test/codearts-adaptation.test.mjs
@@ -188,7 +188,7 @@ test('cli help documents the codearts target', () => {
   try {
     const res = runCli(home, cwd, ['help']);
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|officeace\|hermes\|all>/);
+    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|officeace\|hermes\|openclaw\|all>/);
     assert.match(res.stdout, /install --target codearts/);
   } finally {
     rmSync(home, { recursive: true, force: true });

--- a/test/dsh-adaptation.test.mjs
+++ b/test/dsh-adaptation.test.mjs
@@ -209,7 +209,7 @@ test('cli help documents the dsh target', () => {
   try {
     const res = runCli(home, cwd, ['help']);
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|officeace\|hermes\|all>/);
+    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|officeace\|hermes\|openclaw\|all>/);
     assert.match(res.stdout, /install --target dsh/);
   } finally {
     rmSync(home, { recursive: true, force: true });

--- a/test/session-manager.test.mjs
+++ b/test/session-manager.test.mjs
@@ -4,6 +4,8 @@ import {
   WS_EXEC_INDEX_URL,
   splitBase64Chunks,
   UPLOAD_CHUNK_SIZE,
+  currentWorkspaceId,
+  setWorkspaceId,
 } from '../plugins/huaweicloud-core/src/sandbox/session-manager.mjs';
 
 test('ws-exec dynamic import uses file:// URL (Windows-safe)', async () => {
@@ -28,4 +30,16 @@ test('splitBase64Chunks returns a single chunk for small inputs', () => {
   const chunks = splitBase64Chunks(base64);
   assert.equal(chunks.length, 1);
   assert.equal(chunks[0], base64);
+});
+
+test('currentWorkspaceId defaults to null without env or setter', () => {
+  assert.equal(currentWorkspaceId, null);
+});
+
+test('setWorkspaceId caches and updates env var', () => {
+  const testId = 'test-workspace-123';
+  setWorkspaceId(testId);
+  assert.equal(currentWorkspaceId, testId);
+  assert.equal(process.env.HW_WORKSPACE_ID, testId);
+  setWorkspaceId(null);
 });

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -13,14 +13,14 @@ function readJson(path) {
 
 test('Codex plugin manifest and marketplace are installable', () => {
   const manifest = readJson(join(pluginRoot, '.codex-plugin', 'plugin.json'));
-  assert.equal(manifest.name, 'huaweicloud-core');
+  assert.equal(manifest.name, 'huaweicloud-devkit');
   assert.equal(manifest.skills, './skills/');
   assert.equal(manifest.mcpServers, './.mcp.json');
   assert.ok(!Object.hasOwn(manifest, 'hooks'), 'Codex manifest keeps hooks out');
 
   const marketplace = readJson(join(root, '.agents', 'plugins', 'marketplace.json'));
   assert.equal(marketplace.name, 'huaweicloud-devkit');
-  assert.equal(marketplace.plugins[0].name, 'huaweicloud-core');
+  assert.equal(marketplace.plugins[0].name, 'huaweicloud-devkit');
   assert.equal(marketplace.plugins[0].source.path, './plugins/huaweicloud-core');
 });
 

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -273,7 +273,7 @@ test('setup-cli.mjs supports the codearts target end to end', () => {
     /const skillsOptions = \[[\s\S]*?opencodeSkillsDir\(\)[\s\S]*?codexDesktopSkillsDir\(\)[\s\S]*?codeartsSkillsDir\(\)[\s\S]*?workbuddySkillsDir\(\)[\s\S]*?dshSkillsDir\(\)[\s\S]*?\];/,
   );
   // help text documents the target
-  assert.match(setup, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|officeace\|hermes\|all>/);
+  assert.match(setup, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|officeace\|hermes\|openclaw\|all>/);
   assert.match(setup, /install --target codearts/);
 });
 
@@ -356,7 +356,7 @@ test('setup-cli.mjs supports the dsh target end to end', () => {
   assert.match(setup, /dshPatchConfigured\(\)/);
   assert.match(setup, /dshSkillsDir\(\)/);
   // help text documents the target
-  assert.match(setup, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|officeace\|hermes\|all>/);
+  assert.match(setup, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|officeace\|hermes\|openclaw\|all>/);
   assert.match(setup, /install --target dsh/);
 });
 
@@ -368,7 +368,7 @@ test('tools.mjs resolves skills from the dsh directory', () => {
   // stale or empty dirs must not short-circuit the fallback chain
   assert.match(tools, /resolveSkillsRoot[\s\S]*?findSkillsRoot\(\[/);
   assert.match(tools, /\|\|\s*SKILLS_ROOT_DEV/);
-  assert.match(tools, /opencode, codex, codex-desktop, codearts, workbuddy, dsh, officeace, hermes, or all/);
+  assert.match(tools, /opencode, codex, codex-desktop, codearts, workbuddy, dsh, officeace, hermes, openclaw, or all/);
 });
 
 test('tools.mjs resolves skills from the officeace directory', () => {

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -24,6 +24,26 @@ test('Codex plugin manifest and marketplace are installable', () => {
   assert.equal(marketplace.plugins[0].source.path, './plugins/huaweicloud-core');
 });
 
+test('OpenClaw plugin manifest matches other agent manifests', () => {
+  const openclaw = readJson(join(pluginRoot, 'openclaw.plugin.json'));
+  assert.equal(openclaw.name, 'huaweicloud-devkit');
+  assert.equal(openclaw.family, 'bundle-plugin');
+  assert.equal(openclaw.bundleFormat, 'codex');
+  assert.ok(existsSync(join(pluginRoot, 'openclaw.plugin.json')));
+
+  // All plugin.json names must be consistent
+  const manifests = [
+    join(pluginRoot, '.codex-plugin', 'plugin.json'),
+    join(pluginRoot, '.claude-plugin', 'plugin.json'),
+    join(pluginRoot, '.cursor-plugin', 'plugin.json'),
+    join(pluginRoot, '.workbuddy-plugin', 'plugin.json'),
+    join(pluginRoot, '.hermes-plugin', 'plugin.json'),
+    join(pluginRoot, 'openclaw.plugin.json'),
+  ];
+  const names = new Set(manifests.map((p) => readJson(p).name));
+  assert.equal(names.size, 1, 'All plugin.json name fields must be identical');
+});
+
 test('OpenCode integration exposes skills, commands, and MCP config', () => {
   assert.ok(existsSync(join(root, 'integrations', 'opencode', 'opencode.json')));
   assert.ok(existsSync(join(root, 'integrations', 'opencode', 'commands', 'huaweicloud-doctor.md')));


### PR DESCRIPTION
Closes #237

## Fixes

### 1. DEFAULT_WORKSPACE_ID hardcoded → dynamic cache
- Remove hardcoded workspace ID `0107bd9997...`
- `connect` auto-caches `dev_stage_id` via `setWorkspaceId()`
- All terminal tools use cached ID as fallback
- Fixes HD.98340003 errors (94% wasted deploy time)

### 2. openclaw.plugin.json version out of sync
- Add `openclaw.plugin.json` to `create-release-pr.mjs` auto-bump
- Add `openclaw.plugin.json` to `validate-package.mjs` CI check
- Prevents version divergence in future releases

### 3. plugin.json name unified to `huaweicloud-devkit`
- .codex-plugin, .hermes-plugin, .cursor-plugin, .workbuddy-plugin, .claude-plugin
- Users searching `huaweicloud-devkit` in `openclaw plugins list` now find it
- Update validate-package.mjs name assertion

## Files

11 files, 43 additions, 19 deletions