### PR TITLE
fix: use separate clawhub-publish environment for ClawHub job

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -72,7 +72,7 @@ jobs:
     needs: publish
     runs-on: ubuntu-24.04
     timeout-minutes: 10
-    environment: npm-publish
+    environment: clawhub-publish
     if: ${{ vars.CLAWHUB_ENABLED == 'true' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Fix

The ClawHub publish job was sharing the `npm-publish` environment, causing its approval prompt to show "npm-publish" instead of a ClawHub-related name.

Give it a dedicated `clawhub-publish` environment.

Note: after merging, go to Settings → Environments → create a `clawhub-publish` environment.