### PR TITLE
fix(sandbox): add workspace_id validation and improve connect ID propagation

### DIFF
--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -530,7 +530,7 @@ export async function uploadProjectWithSession(
   if (!workspaceId) {
     throw new Error(
       'sandbox upload project: workspace_id is required. ' +
-      'Set HW_WORKSPACE_ID env var or ensure huaweicloud_sandbox_connect was called first.'
+        'Set HW_WORKSPACE_ID env var or ensure huaweicloud_sandbox_connect was called first.',
     );
   }
   if (!existsSync(localDir)) {

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -527,6 +527,12 @@ export async function uploadProjectWithSession(
   timeoutMs = 300000,
   options = {},
 ) {
+  if (!workspaceId) {
+    throw new Error(
+      'sandbox upload project: workspace_id is required. ' +
+      'Set HW_WORKSPACE_ID env var or ensure huaweicloud_sandbox_connect was called first.'
+    );
+  }
   if (!existsSync(localDir)) {
     throw new Error(`sandbox upload project: local directory not found: ${localDir}`);
   }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -468,7 +468,7 @@ export const TOOL_DEFINITIONS = [
       required: ['command'],
       properties: {
         command: { type: 'string', description: 'The shell command to execute on the remote workspace' },
-        workspace_id: { type: 'string', description: 'The workspace ID' },
+        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
         username: { type: 'string', description: 'Login username for the remote terminal (default: root)' },
         timeout_ms: { type: 'number', description: 'Execution timeout in milliseconds (default: 120000)' },
       },
@@ -483,7 +483,7 @@ export const TOOL_DEFINITIONS = [
       required: ['command'],
       properties: {
         command: { type: 'string', description: 'The shell command to execute on the remote workspace' },
-        workspace_id: { type: 'string', description: 'The workspace ID' },
+        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
         username: { type: 'string', description: 'Login username for the remote terminal (default: root)' },
         timeout_ms: { type: 'number', description: 'Execution timeout in milliseconds (default: 120000)' },
       },
@@ -495,7 +495,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        workspace_id: { type: 'string', description: 'The workspace ID' },
+        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
         username: { type: 'string', description: 'Login username (default: root)' },
       },
     },
@@ -510,7 +510,7 @@ export const TOOL_DEFINITIONS = [
       properties: {
         local_path: { type: 'string', description: 'Absolute path to the local file to upload.' },
         remote_path: { type: 'string', description: 'Target path in the sandbox, e.g. /workspace/<repo>/index.html.' },
-        workspace_id: { type: 'string', description: 'The workspace ID' },
+        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
         username: { type: 'string', description: 'Login username (default: root)' },
         timeout_ms: { type: 'number', description: 'Per-command execution timeout in milliseconds (default: 120000)' },
       },
@@ -530,7 +530,7 @@ export const TOOL_DEFINITIONS = [
           description:
             'Remote parent directory where project will be extracted (default: /workspace). Final layout: <remote_dir>/<dirname>/',
         },
-        workspace_id: { type: 'string', description: 'Workspace ID (defaults to HW_WORKSPACE_ID env var)' },
+        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
         username: { type: 'string', description: 'Login username (default: root)' },
         exclude: {
           type: 'array',
@@ -666,6 +666,12 @@ export async function callTool(name, args = {}) {
       return { status: 'ok', message: 'Runtime credentials set for this MCP session.' };
     case 'huaweicloud_sandbox_exec_with_session': {
       const sandboxWsId2 = args.workspace_id || currentWorkspaceId;
+      if (!sandboxWsId2) {
+        throw new Error(
+          'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
+          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+        );
+      }
       const sandboxUser2 = args.username || 'root';
       const sandboxTimeout2 = args.timeout_ms || 120000;
       const sandboxResult2 = await execWithSession(sandboxWsId2, args.command, sandboxUser2, sandboxTimeout2);
@@ -673,6 +679,12 @@ export async function callTool(name, args = {}) {
     }
     case 'huaweicloud_sandbox_exec_one_shot': {
       const sandboxWsId3 = args.workspace_id || currentWorkspaceId;
+      if (!sandboxWsId3) {
+        throw new Error(
+          'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
+          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+        );
+      }
       const sandboxUser3 = args.username || 'root';
       const sandboxTimeout3 = args.timeout_ms || 120000;
       const sandboxResult3 = await execOneShot(sandboxWsId3, args.command, sandboxUser3, sandboxTimeout3);
@@ -680,6 +692,12 @@ export async function callTool(name, args = {}) {
     }
     case 'huaweicloud_sandbox_close_session': {
       const sandboxWsId4 = args.workspace_id || currentWorkspaceId;
+      if (!sandboxWsId4) {
+        throw new Error(
+          'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
+          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+        );
+      }
       const sandboxUser4 = args.username || 'root';
       const closed = await closeSession(sandboxWsId4, sandboxUser4);
       return closed ? 'ok' : 'not_connected';
@@ -689,6 +707,12 @@ export async function callTool(name, args = {}) {
         throw new Error('local_path and remote_path are required.');
       }
       const sandboxWsId5 = args.workspace_id || currentWorkspaceId;
+      if (!sandboxWsId5) {
+        throw new Error(
+          'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
+          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+        );
+      }
       const sandboxUser5 = args.username || 'root';
       const sandboxTimeout5 = args.timeout_ms || 120000;
       return await uploadFileWithSession(
@@ -704,6 +728,12 @@ export async function callTool(name, args = {}) {
         throw new Error('local_dir is required.');
       }
       const sandboxWsId6 = args.workspace_id || currentWorkspaceId;
+      if (!sandboxWsId6) {
+        throw new Error(
+          'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
+          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+        );
+      }
       const sandboxUser6 = args.username || 'root';
       const sandboxTimeout6 = args.timeout_ms || 120000;
       return await uploadProjectWithSession(
@@ -724,8 +754,9 @@ export async function callTool(name, args = {}) {
       return await hdkitSignAgreement();
     case 'huaweicloud_sandbox_connect': {
       const connectResult = await hdkitConnect(args);
-      if (connectResult?.dev_stage_id) {
-        setWorkspaceId(connectResult.dev_stage_id);
+      const devStageId = connectResult?.dev_stage_id || connectResult?.devStageId;
+      if (devStageId) {
+        setWorkspaceId(devStageId);
       }
       return connectResult;
     }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -468,7 +468,11 @@ export const TOOL_DEFINITIONS = [
       required: ['command'],
       properties: {
         command: { type: 'string', description: 'The shell command to execute on the remote workspace' },
-        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
+        workspace_id: {
+          type: 'string',
+          description:
+            'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.',
+        },
         username: { type: 'string', description: 'Login username for the remote terminal (default: root)' },
         timeout_ms: { type: 'number', description: 'Execution timeout in milliseconds (default: 120000)' },
       },
@@ -483,7 +487,11 @@ export const TOOL_DEFINITIONS = [
       required: ['command'],
       properties: {
         command: { type: 'string', description: 'The shell command to execute on the remote workspace' },
-        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
+        workspace_id: {
+          type: 'string',
+          description:
+            'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.',
+        },
         username: { type: 'string', description: 'Login username for the remote terminal (default: root)' },
         timeout_ms: { type: 'number', description: 'Execution timeout in milliseconds (default: 120000)' },
       },
@@ -495,7 +503,11 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
+        workspace_id: {
+          type: 'string',
+          description:
+            'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.',
+        },
         username: { type: 'string', description: 'Login username (default: root)' },
       },
     },
@@ -510,7 +522,11 @@ export const TOOL_DEFINITIONS = [
       properties: {
         local_path: { type: 'string', description: 'Absolute path to the local file to upload.' },
         remote_path: { type: 'string', description: 'Target path in the sandbox, e.g. /workspace/<repo>/index.html.' },
-        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
+        workspace_id: {
+          type: 'string',
+          description:
+            'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.',
+        },
         username: { type: 'string', description: 'Login username (default: root)' },
         timeout_ms: { type: 'number', description: 'Per-command execution timeout in milliseconds (default: 120000)' },
       },
@@ -530,7 +546,11 @@ export const TOOL_DEFINITIONS = [
           description:
             'Remote parent directory where project will be extracted (default: /workspace). Final layout: <remote_dir>/<dirname>/',
         },
-        workspace_id: { type: 'string', description: 'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.' },
+        workspace_id: {
+          type: 'string',
+          description:
+            'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.',
+        },
         username: { type: 'string', description: 'Login username (default: root)' },
         exclude: {
           type: 'array',
@@ -669,7 +689,7 @@ export async function callTool(name, args = {}) {
       if (!sandboxWsId2) {
         throw new Error(
           'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
-          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+            'or set HW_WORKSPACE_ID environment variable before starting the agent.',
         );
       }
       const sandboxUser2 = args.username || 'root';
@@ -682,7 +702,7 @@ export async function callTool(name, args = {}) {
       if (!sandboxWsId3) {
         throw new Error(
           'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
-          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+            'or set HW_WORKSPACE_ID environment variable before starting the agent.',
         );
       }
       const sandboxUser3 = args.username || 'root';
@@ -695,7 +715,7 @@ export async function callTool(name, args = {}) {
       if (!sandboxWsId4) {
         throw new Error(
           'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
-          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+            'or set HW_WORKSPACE_ID environment variable before starting the agent.',
         );
       }
       const sandboxUser4 = args.username || 'root';
@@ -710,7 +730,7 @@ export async function callTool(name, args = {}) {
       if (!sandboxWsId5) {
         throw new Error(
           'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
-          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+            'or set HW_WORKSPACE_ID environment variable before starting the agent.',
         );
       }
       const sandboxUser5 = args.username || 'root';
@@ -731,7 +751,7 @@ export async function callTool(name, args = {}) {
       if (!sandboxWsId6) {
         throw new Error(
           'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
-          'or set HW_WORKSPACE_ID environment variable before starting the agent.'
+            'or set HW_WORKSPACE_ID environment variable before starting the agent.',
         );
       }
       const sandboxUser6 = args.username || 'root';


### PR DESCRIPTION
## Problem

`huaweicloud_sandbox_upload_project` (and other sandbox tools) fail with `HD.98340003: Get dev environment is null` when `workspace_id` is not explicitly passed and `HW_WORKSPACE_ID` env var is not set (common on Windows).

## Root Cause

Three layers:
1. **Entry validation**: `workspace_id` resolves to null/undefined but no error is thrown — the null value propagates to the API call
2. **Field compatibility**: `sandbox_connect` only checks `dev_stage_id`, missing `devStageId` (camelCase) from some API responses
3. **Description gap**: Tool definitions say `"The workspace ID"` — too vague for AI to know it must be passed

## Changes

| File | Change |
|------|--------|
| `src/tools.mjs` | Add `workspace_id` null check in 5 sandbox tools (exec_with_session, exec_one_shot, close_session, upload_file, upload_project) |
| `src/tools.mjs` | `sandbox_connect` supports both `dev_stage_id` and `devStageId` field names |
| `src/tools.mjs` | Update 5 tool definition `workspace_id` descriptions to guide AI correct parameter passing |
| `src/sandbox/session-manager.mjs` | Add defensive `workspaceId` validation in `uploadProjectWithSession` entry |

## Testing

- `npm run lint:js` — 0 errors
- `node --test test/session-manager.test.mjs` — 5/5 pass
- All 153/154 tests pass (1 pre-existing failure unrelated to this change)