### PR TITLE
docs: restore ClawHub-first install method for OpenClaw section

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,13 +101,15 @@ npx --yes huaweicloud-devkit uninstall --target officeace
 ### OpenClaw
 
 ```bash
-npx --yes huaweicloud-devkit install --target openclaw
+# Recommended (ClawHub)
+openclaw plugins install clawhub:huaweicloud-devkit
 ```
 
 **Restart OpenClaw** after installation.
 
 ```bash
-npx --yes huaweicloud-devkit doctor --target openclaw
+# Or via npx
+npx --yes huaweicloud-devkit install --target openclaw
 npx --yes huaweicloud-devkit status --target openclaw
 npx --yes huaweicloud-devkit update --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw

--- a/README.md
+++ b/README.md
@@ -103,9 +103,11 @@ npx --yes huaweicloud-devkit uninstall --target officeace
 ```bash
 # Recommended (ClawHub)
 openclaw plugins install clawhub:huaweicloud-devkit
+openclaw plugins uninstall huaweicloud-devkit
+openclaw plugins update huaweicloud-devkit
 ```
 
-**Restart OpenClaw** after installation.
+**Restart OpenClaw** after installation. If prompted for security risk acknowledgment, add `--acknowledge-clawhub-risk`.
 
 ```bash
 # Or via npx

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -101,13 +101,15 @@ npx --yes huaweicloud-devkit uninstall --target officeace
 ### OpenClaw
 
 ```bash
-npx --yes huaweicloud-devkit install --target openclaw
+# 推荐方式 (ClawHub)
+openclaw plugins install clawhub:huaweicloud-devkit
 ```
 
 安装后**重启 OpenClaw**。
 
 ```bash
-npx --yes huaweicloud-devkit doctor --target openclaw
+# 或通过 npx
+npx --yes huaweicloud-devkit install --target openclaw
 npx --yes huaweicloud-devkit status --target openclaw
 npx --yes huaweicloud-devkit update --target openclaw
 npx --yes huaweicloud-devkit uninstall --target openclaw

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -103,9 +103,11 @@ npx --yes huaweicloud-devkit uninstall --target officeace
 ```bash
 # 推荐方式 (ClawHub)
 openclaw plugins install clawhub:huaweicloud-devkit
+openclaw plugins uninstall huaweicloud-devkit
+openclaw plugins update huaweicloud-devkit
 ```
 
-安装后**重启 OpenClaw**。
+安装后**重启 OpenClaw**。如提示安全风险确认，加 `--acknowledge-clawhub-risk`。
 
 ```bash
 # 或通过 npx


### PR DESCRIPTION
## Fix

README OpenClaw section was reverted to npx-only during PR consolidation. Restore ClawHub as the recommended installation method with npx as alternative.

```markdown
# Recommended (ClawHub)
openclaw plugins install clawhub:huaweicloud-devkit

# Or via npx
npx --yes huaweicloud-devkit install --target openclaw
```