### PR TITLE
feat(modelarts): add marketplace fallback for advanced workflows

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-modelarts/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-modelarts/SKILL.md
@@ -63,3 +63,11 @@ Discover operation parameters with `--help` before executing any write operation
 
 - **OBS storage**: See `huawei-obs` for bucket and training data management
 - **VPC/Subnet**: See `huawei-vpc` for notebook network configuration
+
+## External Skills
+
+For advanced workflows (notebook lifecycle, training job diagnosis,
+hyperparameter tuning), search the marketplace:
+`huaweicloud_search_marketplace` query="ModelArts notebook/training/diagnosis"
+→ install via `npx skills add huaweicloud/huaweicloud-skills --skill <name> -y -g`
+→ load and execute.


### PR DESCRIPTION
## Summary

Add external skill fallback to `huawei-modelarts` so agents can find deeper coverage for complex workflows not covered by the 65-line built-in skill.

## Problem

`huawei-modelarts` is a thin built-in skill that matches the `ai` intent in `huaweicloud-core`. Because a built-in skill matches, `capability-discovery` step 9 marketplace fallback never triggers. For complex tasks like notebook lifecycle management or training job diagnosis, the agent has no path to discover the 13 upstream ModelArts skills.

## Fix

Add an `External Skills` section to `huawei-modelarts/SKILL.md` (+8 lines):

- Tells the agent to use `huaweicloud_search_marketplace` when the built-in skill is insufficient
- Provides install command: `npx skills add huaweicloud/huaweicloud-skills --skill <name> -y -g`
- Completes the same search-install-execute pattern established in `capability-discovery` step 9

## Verification

- `npm run validate` — 27 skills
- `node --test test/structure.test.mjs` — 20/20 pass
- `npm run lint:md` — 0 issues
- End-to-end test: marketplace search finds `huawei-cloud-modelarts-training-diagnosis`, install succeeds, SKILL.md contains actionable hcloud commands