### PR TITLE
feat: 新增激励金代金券 MCP 工具

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -72,6 +72,12 @@ export default [
     },
   },
   {
+    files: ['plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs'],
+    rules: {
+      'n/no-missing-import': ['error', { allowModules: ['undici'] }],
+    },
+  },
+  {
     files: ['plugins/huaweicloud-core/src/proxy/proxy-agent.mjs'],
     rules: {
       'n/prefer-node-protocol': 'off',

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -91,9 +91,17 @@ export async function hdkitCredentials(sessionId, devStageId, enableSts = true) 
 }
 
 export async function hdkitVoucherStatus() {
-  return await hdkitRequest('GET', 'voucher/status', undefined, 30000);
+  try {
+    return await hdkitRequest('GET', 'voucher/status', undefined, 30000);
+  } catch (err) {
+    return { claimed: false, message: '激励金服务暂不可用' };
+  }
 }
 
 export async function hdkitVoucherClaim() {
-  return await hdkitRequest('POST', 'voucher/claim', {});
+  try {
+    return await hdkitRequest('POST', 'voucher/claim', {});
+  } catch (err) {
+    return { claimed: false, message: '激励金服务暂不可用' };
+  }
 }

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -94,7 +94,7 @@ export async function hdkitVoucherStatus() {
   try {
     return await hdkitRequest('GET', 'voucher/status', undefined, 30000);
   } catch (error) {
-    return { claimed: false, message: '激励金服务暂不可用' };
+    return { claimed: false, message: 'Incentive service unavailable, please try again later' };
   }
 }
 
@@ -102,6 +102,6 @@ export async function hdkitVoucherClaim() {
   try {
     return await hdkitRequest('POST', 'voucher/claim', {});
   } catch (error) {
-    return { claimed: false, message: '激励金服务暂不可用' };
+    return { claimed: false, message: 'Incentive service unavailable, please try again later' };
   }
 }

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -89,3 +89,11 @@ export async function hdkitCredentials(sessionId, devStageId, enableSts = true) 
 
   return await hdkitRequest('POST', 'credentials', body);
 }
+
+export async function hdkitVoucherStatus() {
+  return await hdkitRequest('GET', 'voucher/status', undefined, 30000);
+}
+
+export async function hdkitVoucherClaim() {
+  return await hdkitRequest('POST', 'voucher/claim', {});
+}

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -93,7 +93,7 @@ export async function hdkitCredentials(sessionId, devStageId, enableSts = true) 
 export async function hdkitVoucherStatus() {
   try {
     return await hdkitRequest('GET', 'voucher/status', undefined, 30000);
-  } catch (err) {
+  } catch (error) {
     return { claimed: false, message: '激励金服务暂不可用' };
   }
 }
@@ -101,7 +101,7 @@ export async function hdkitVoucherStatus() {
 export async function hdkitVoucherClaim() {
   try {
     return await hdkitRequest('POST', 'voucher/claim', {});
-  } catch (err) {
+  } catch (error) {
     return { claimed: false, message: '激励金服务暂不可用' };
   }
 }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -19,7 +19,14 @@ import {
   getCurrentWorkspaceId,
   setWorkspaceId,
 } from './sandbox/session-manager.mjs';
-import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials, hdkitVoucherStatus, hdkitVoucherClaim } from './sandbox/hdkitservice-api.mjs';
+import {
+  hdkitCheckUser,
+  hdkitSignAgreement,
+  hdkitConnect,
+  hdkitCredentials,
+  hdkitVoucherStatus,
+  hdkitVoucherClaim,
+} from './sandbox/hdkitservice-api.mjs';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import {
   readGlobalCredentials,

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -19,7 +19,7 @@ import {
   getCurrentWorkspaceId,
   setWorkspaceId,
 } from './sandbox/session-manager.mjs';
-import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials } from './sandbox/hdkitservice-api.mjs';
+import { hdkitCheckUser, hdkitSignAgreement, hdkitConnect, hdkitCredentials, hdkitVoucherStatus, hdkitVoucherClaim } from './sandbox/hdkitservice-api.mjs';
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import {
   readGlobalCredentials,
@@ -639,6 +639,22 @@ export const TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    name: 'huaweicloud_voucher_status',
+    description: '查询激励金代金券领取状态。',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
+  {
+    name: 'huaweicloud_voucher_claim',
+    description: '领取激励金代金券。领取前会自动检查是否已领取。',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+    },
+  },
 ];
 
 export async function callTool(name, args = {}) {
@@ -805,6 +821,10 @@ export async function callTool(name, args = {}) {
     }
     case 'huaweicloud_sandbox_credentials':
       return await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
+    case 'huaweicloud_voucher_status':
+      return await hdkitVoucherStatus();
+    case 'huaweicloud_voucher_claim':
+      return await hdkitVoucherClaim();
     default:
       throw new Error(`Unknown tool: ${name}`);
   }

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -63,11 +63,13 @@ test('TOOL_DEFINITIONS includes all required tools including sandbox', () => {
     'huaweicloud_sandbox_sign_agreement',
     'huaweicloud_sandbox_connect',
     'huaweicloud_sandbox_credentials',
+    'huaweicloud_voucher_status',
+    'huaweicloud_voucher_claim',
   ];
   for (const name of required) {
     assert.ok(names.includes(name), `Missing tool: ${name}`);
   }
-  assert.ok(names.length >= 23);
+  assert.ok(names.length >= 25);
   assert.ok(names.includes('huaweicloud_search_marketplace'), 'Should have marketplace search tool');
 });
 


### PR DESCRIPTION
## 变更说明

对接激励金服务，新增代金券查询和领取 MCP 工具。

### 变更
- hdkitservice-api.mjs: 新增 hdkitVoucherStatus / hdkitVoucherClaim API 函数
- tools.mjs: 新增 huaweicloud_voucher_status / huaweicloud_voucher_claim MCP 工具
- test/tools.test.mjs: 新增 voucher 工具存在性断言