### PR TITLE
feat: voucher MCP 工具支持可选 domain_id 参数

### DIFF
--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -90,17 +90,19 @@ export async function hdkitCredentials(sessionId, devStageId, enableSts = true) 
   return await hdkitRequest('POST', 'credentials', body);
 }
 
-export async function hdkitVoucherStatus() {
+export async function hdkitVoucherStatus(domainId) {
   try {
-    return await hdkitRequest('GET', 'voucher/status', undefined, 30000);
+    const path = domainId ? `voucher/status?domain_id=${encodeURIComponent(domainId)}` : 'voucher/status';
+    return await hdkitRequest('GET', path, undefined, 30000);
   } catch (error) {
     return { claimed: false, message: 'Incentive service unavailable, please try again later' };
   }
 }
 
-export async function hdkitVoucherClaim() {
+export async function hdkitVoucherClaim(domainId) {
   try {
-    return await hdkitRequest('POST', 'voucher/claim', {});
+    const body = domainId ? { domain_id: domainId } : {};
+    return await hdkitRequest('POST', 'voucher/claim', body);
   } catch (error) {
     return { claimed: false, message: 'Incentive service unavailable, please try again later' };
   }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -651,7 +651,9 @@ export const TOOL_DEFINITIONS = [
     description: '查询激励金代金券领取状态。',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        domain_id: { type: 'string' },
+      },
     },
   },
   {
@@ -659,7 +661,9 @@ export const TOOL_DEFINITIONS = [
     description: '领取激励金代金券。领取前会自动检查是否已领取。',
     inputSchema: {
       type: 'object',
-      properties: {},
+      properties: {
+        domain_id: { type: 'string' },
+      },
     },
   },
 ];
@@ -829,9 +833,9 @@ export async function callTool(name, args = {}) {
     case 'huaweicloud_sandbox_credentials':
       return await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
     case 'huaweicloud_voucher_status':
-      return await hdkitVoucherStatus();
+      return await hdkitVoucherStatus(args.domain_id);
     case 'huaweicloud_voucher_claim':
-      return await hdkitVoucherClaim();
+      return await hdkitVoucherClaim(args.domain_id);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }


### PR DESCRIPTION
- **feat: 新增激励金代金券 MCP 工具**
- **style: 修复 prettier 格式问题**
- **fix: voucher 工具后端不可用时优雅降级**
- **fix: 修复 hdkitservice-api.mjs 中 undici 动态导入的 lint 报错**
- **style: 修复 catch 参数命名，符合 unicorn/catch-error-name 规则**
- **fix: 错误提示改为英文**
- **feat: voucher MCP 工具支持可选 domain_id 参数**
