### PR TITLE
feat: 代金券能力可发现化，新增 huawei-voucher skill 与路由

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-voucher/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-voucher/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: huawei-voucher
+description: '查询和领取华为云激励代金券（一人一次）。当用户询问插件能力、首次使用，或提到"领券/代金券/优惠券/激励金/领取"等话题时，先查询领取状态：未领取（claimed=false）则主动提示可领取，已领取（claimed=true）则不打扰。Triggers: voucher, coupon, incentive, 领券, 代金券, 优惠券, 激励金, 领取. NOT for: 账单/费用查询（用 huawei-billing）。'
+version: 1
+---
+
+# 华为云激励代金券
+
+## 主动提示准则（核心）
+
+此能力仅在用户尚未领取时才有价值，需避免已领取用户被反复打扰：
+
+1. 当用户**询问插件能力 / 首次使用 / 提到福利领取类话题**时，先调用 `huaweicloud_voucher_status` 查询领取状态。
+2. 若 `claimed=false` → 主动告知"可领取华为云代金券（一人一次）"，并询问是否现在领取。
+3. 若 `claimed=true` → 静默处理，不再提及代金券，不打扰用户。
+
+## 流程
+
+### 1. 查询状态
+
+调用 `huaweicloud_voucher_status`（生产环境无需 `domain_id`，测试环境需传 `domain_id`）。
+
+返回 `{ claimed, message }`：
+
+- `claimed=true` + `message="已领取"` → 已领取，告知结果即可，不再引导
+- `claimed=false` + `message="未领取"` → 未领取，可引导领取
+
+### 2. 领取代金券
+
+调用 `huaweicloud_voucher_claim`（生产环境无需 `domain_id`）。
+
+返回 `{ claimed, voucherId, amount, message }`。
+
+### 3. 结果解读（错误码 UX）
+
+| 返回 message 关键特征                        | 含义                        | 对用户表述           |
+| -------------------------------------------- | --------------------------- | -------------------- |
+| `领取成功`                                   | 发券成功                    | 告知券已到账         |
+| `已领取过` / `已领取`                        | 该账号已领过                | 告知已领取，不打扰   |
+| `本月代金券总额度已用完，所有账号均无法领取` | 全局额度用尽（HD.60630042） | 告知下月再试         |
+| `请先完成实名认证`                           | 账号未实名（HD.60630022）   | 引导去控制台实名认证 |
+| `发券失败: <原文>`                           | 其他错误                    | 原样转达，不展开     |
+
+## 环境注意
+
+- 生产环境：`voucher_status` / `voucher_claim` 无需传 `domain_id`，后端从 IAM 自动解析账号。
+- 测试环境：需传 `domain_id`（华为云账号 ID）；未传时返回 `测试环境需提供 domain_id`，此时可用 `hcloud IAM KeystoneListAuthDomains` 查询账号 ID 后补传。
+
+## 注意事项
+
+- 每个账号（domain_id）仅可领取一次，重复调用返回已领取。
+- 领取结果以激励服务返回为准，不要凭本地认知猜测。

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
@@ -43,6 +43,7 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 | troubleshoot  | Troubleshooting Routing | error, bug, failed, AccessDenied, quota                                              | Handoff to huaweicloud-troubleshooting                                                                                                                                                   |
 | api-sdk       | API/SDK Routing         | API call, SDK, REST, integration, code example                                       | Handoff to huaweicloud-api-and-sdk                                                                                                                                                       |
 | report-issue  | Issue Reporting         | wrong service, you picked wrong, incorrect                                           | Read references/report-issue.md                                                                                                                                                          |
+| voucher       | Voucher Routing         | 领券, 代金券, 优惠券, 激励金, 领取, voucher, coupon, incentive                       | Handoff to huawei-voucher                                                                                                                                                                |
 
 ## Service Map
 
@@ -70,6 +71,7 @@ Do not rely on training data for facts. Huawei Cloud services, pricing, quotas, 
 | CI/CD pipeline                                   | CloudDeploy          | huawei-deployment        |
 | Temporary runtime / web app preview              | Sandbox (DevStation) | huawei-sandbox           |
 | Getting started                                  | Account setup        | huaweicloud-cli-and-auth |
+| Incentive voucher                                | Voucher              | huawei-voucher           |
 
 **Web app scenario layering**: for "deploy a web app", prefer `huawei-sandbox` for free/quick try (hello world, prototype, demo, temporary preview — temporary runtime + public URL, ~8h validity, zero billed resources); route to `huawei-functiongraph` / `huawei-ecs` (or `huawei-cce`) for production / long-term / custom-domain / high-availability hosting.
 

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -648,7 +648,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'huaweicloud_voucher_status',
-    description: 'Query the Huawei Cloud incentive voucher claim status.',
+    description: '查询代金券领取状态。',
     inputSchema: {
       type: 'object',
       properties: {
@@ -661,7 +661,7 @@ export const TOOL_DEFINITIONS = [
   },
   {
     name: 'huaweicloud_voucher_claim',
-    description: 'Claim the Huawei Cloud incentive voucher. Automatically checks if already claimed.',
+    description: '领取代金券（一人一次）。重复领取会返回已领取。',
     inputSchema: {
       type: 'object',
       properties: {
@@ -1189,6 +1189,11 @@ function serviceCatalog(intent = '') {
       keywords: ['dds', 'dcs', 'mongodb', 'redis', 'memcached', 'cache', 'document db'],
       skills: ['huawei-dds-dcs'],
       services: ['DDS', 'DCS'],
+    },
+    {
+      keywords: ['voucher', 'coupon', 'incentive', 'credit', '领券', '代金券', '优惠券', '激励金', '领取'],
+      skills: ['huawei-voucher'],
+      services: ['Incentive Voucher'],
     },
   ];
   const matched = [];


### PR DESCRIPTION
## 变更内容

解决代金券能力"不可发现"的问题：用户安装插件后不知道可领代金券，Agent 也不会主动提及（代金券工具藏在几十个工具中，未进入能力目录）。

### 1. voucher 工具 description 改中文（对齐 dev_poc）

| 工具 | 之前 | 现在 |
|------|------|------|
| `huaweicloud_voucher_status` | `Query the Huawei Cloud incentive voucher claim status.` | `查询代金券领取状态。` |
| `huaweicloud_voucher_claim` | `Claim the Huawei Cloud incentive voucher. Automatically checks if already claimed.` | `领取代金券（一人一次）。重复领取会返回已领取。` |

`domain_id` 参数的 `Optional...` description 保持不变。

### 2. 新增 `huawei-voucher` skill

正文内固化「查状态 → 条件提示」准则：

- 用户询问插件能力 / 首次使用 / 提到领取类话题时，先调 `voucher_status` 查 `claimed`
- `claimed=false` → 主动提示可领取（一人一次）；`claimed=true` → 静默不打扰
- 附错误码 UX 表（已领取 / 额度用完 / 实名引导 / 其他透传原文）与环境注意

### 3. 路由接线

- `serviceCatalog` routeMap 加 `voucher/领券/代金券/优惠券/激励金/领取/coupon/incentive` 关键词 → `huawei-voucher`
- `huaweicloud-core` 的 Sub-skill Registry + Service Map 加 voucher 条目

## 验证

- prettier / eslint / markdownlint 全部通过