### PR TITLE
fix(sandbox): **/node_modules exclusion, nginx cleanup, archive size warning, upload log rotation

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -86,10 +86,21 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 3. **Sign agreement only** (`HDKIT_NOT_AGREEMENT`): **STOP and do NOT sign on your own.** Ask the developer: "Huawei Cloud sandbox requires signing the latest developer service agreement. May I sign it for you?" Then **wait for the developer to explicitly agree** (e.g. "签署" / "确认" / "sign it"). Only after explicit consent call `huaweicloud_sandbox_sign_agreement` and return its result (`signed`/`signedCount`) to the developer. **Never sign a legal agreement on the developer's behalf without their explicit, unambiguous consent.** Do not expose the underlying sandbox/DevBridge service as a separate entity the developer must understand or sign up for
 4. **Both missing** (`HDKIT_NOT_REALNAME_AND_AGREEMENT`): present **both** requirements together in one message — the real-name verification steps (console, step 2) **and** the agreement-signing request (step 3, wait for explicit consent) — so the developer can complete both at once
 5. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
-6. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
-7. **Execute commands**: use `huaweicloud_sandbox_exec_with_session` for interactive work (cd, env setup), or `huaweicloud_sandbox_exec_one_shot` for long-running builds/installs. See [Tool Selection Guide](#tool-selection-guide).
-8. **Upload project** (if deploying local code): `huaweicloud_sandbox_upload_project` to transfer a local project directory into `/workspace/<name>` — uses HTTP tunnel, much faster than base64 for multi-file projects. Use `huaweicloud_sandbox_upload_file` for single files.
-9. **Expose the deployed app and return the public URL**: set up a public access link for the app port and give the URL to the developer as the final result (see "Expose the deployed app (public URL)") — this step uses an internal tunnel mechanism that must never be mentioned to the developer
+6. **Cleanup previous deployments** (after first connect to a sandbox): nginx configs and DevBridge tunnels from previous deployments can cause port conflicts and quota errors. Run cleanup immediately after connect:
+
+   ```bash
+   # Remove stale nginx configs from previous deployments
+   sudo rm -f /etc/nginx/conf.d/app.conf /etc/nginx/conf.d/*.conf.bak 2>/dev/null
+   # Remove stale DevBridge tunnels
+   devbridge delete-all 2>/dev/null || true
+   # Reload nginx to apply
+   sudo nginx -s reload 2>/dev/null || true
+   ```
+
+7. **Inject credentials** (optional): `huaweicloud_sandbox_credentials` — enables cloud API access from sandbox
+8. **Execute commands**: use `huaweicloud_sandbox_exec_with_session` for interactive work (cd, env setup), or `huaweicloud_sandbox_exec_one_shot` for long-running builds/installs. See [Tool Selection Guide](#tool-selection-guide).
+9. **Upload project** (if deploying local code): `huaweicloud_sandbox_upload_project` to transfer a local project directory into `/workspace/<name>` — uses HTTP tunnel, much faster than base64 for multi-file projects. Use `huaweicloud_sandbox_upload_file` for single files.
+10. **Expose the deployed app and return the public URL**: set up a public access link for the app port and give the URL to the developer as the final result (see "Expose the deployed app (public URL)") — this step uses an internal tunnel mechanism that must never be mentioned to the developer
 
 ## File Transfer (local → sandbox)
 
@@ -105,7 +116,7 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
   "remote_dir": "/workspace",
   "extract": true,
   "exclude": [
-    "node_modules",
+    "**/node_modules",
     ".git",
     "__pycache__",
     ".next",
@@ -242,7 +253,7 @@ Follow the standard [Workflow](#workflow) steps 1-6 to connect to the sandbox, t
   "local_dir": "<projectPath>",
   "remote_dir": "/workspace",
   "exclude": [
-    "node_modules",
+    "**/node_modules",
     ".git",
     "__pycache__",
     ".next",
@@ -260,20 +271,20 @@ Follow the standard [Workflow](#workflow) steps 1-6 to connect to the sandbox, t
 
 **Always exclude build artifacts and dependency directories** — they will be re-installed/built inside the sandbox:
 
-| Pattern        | Why excluded                                   |
-| -------------- | ---------------------------------------------- |
-| `node_modules` | Dependencies — reinstall in sandbox            |
-| `.git`         | Version control — not needed for deployment    |
-| `__pycache__`  | Python bytecode cache                          |
-| `.next`        | Next.js build output — rebuild in sandbox      |
-| `.nuxt`        | Nuxt build cache — rebuild in sandbox          |
-| `.output`      | Nuxt production output — rebuild in sandbox    |
-| `.turbo`       | Turborepo cache — re-run in sandbox            |
-| `.cache`       | Generic tool cache (Parcel, Storybook, etc.)   |
-| `.swc`         | Taro/Webpack SWC cache — regenerate in sandbox |
-| `dist`         | Build output — rebuild in sandbox              |
-| `coverage`     | Test coverage reports — not needed for deploy  |
-| `*.pyc`        | Python compiled files                          |
+| Pattern           | Why excluded                                   |
+| ----------------- | ---------------------------------------------- |
+| `**/node_modules` | Dependencies — reinstall in sandbox            |
+| `.git`            | Version control — not needed for deployment    |
+| `__pycache__`     | Python bytecode cache                          |
+| `.next`           | Next.js build output — rebuild in sandbox      |
+| `.nuxt`           | Nuxt build cache — rebuild in sandbox          |
+| `.output`         | Nuxt production output — rebuild in sandbox    |
+| `.turbo`          | Turborepo cache — re-run in sandbox            |
+| `.cache`          | Generic tool cache (Parcel, Storybook, etc.)   |
+| `.swc`            | Taro/Webpack SWC cache — regenerate in sandbox |
+| `dist`            | Build output — rebuild in sandbox              |
+| `coverage`        | Test coverage reports — not needed for deploy  |
+| `*.pyc`           | Python compiled files                          |
 
 **Post-upload permission fix**: after `upload_project` extracts the project, fix file permissions lost during transfer (native binaries from other platforms, .bin symlinks):
 

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -1,7 +1,16 @@
 import { spawn, execFile } from 'node:child_process';
 import { promisify } from 'node:util';
 import { createConnection as netConnect } from 'node:net';
-import { existsSync, readFileSync, statSync, mkdirSync, rmSync, createReadStream, appendFileSync } from 'node:fs';
+import {
+  existsSync,
+  readFileSync,
+  statSync,
+  mkdirSync,
+  rmSync,
+  createReadStream,
+  appendFileSync,
+  unlinkSync,
+} from 'node:fs';
 import { createHash, randomBytes } from 'node:crypto';
 import { join, dirname, basename } from 'node:path';
 import { tmpdir } from 'node:os';
@@ -266,6 +275,17 @@ function uploadLog(message) {
   console.error(line.trimEnd());
   try {
     appendFileSync(UPLOAD_LOG_PATH, line);
+  } catch {}
+}
+
+function rotateUploadLog(maxBytes = 100 * 1024) {
+  try {
+    if (existsSync(UPLOAD_LOG_PATH)) {
+      const stat = statSync(UPLOAD_LOG_PATH);
+      if (stat.size > maxBytes) {
+        unlinkSync(UPLOAD_LOG_PATH);
+      }
+    }
   } catch {}
 }
 
@@ -557,6 +577,8 @@ export async function uploadProjectWithSession(
     throw new Error(`sandbox upload project: path is not a directory: ${localDir}`);
   }
 
+  rotateUploadLog();
+
   const projectName = basename(localDir);
   const targetParentDir = remoteDir || '/workspace';
   const archiveRemotePath = `${targetParentDir}/${projectName}.tar.gz`;
@@ -566,6 +588,15 @@ export async function uploadProjectWithSession(
   const expectedMd5 = await computeMd5(archivePath);
 
   uploadLog(`uploadProject: ${localDir} -> ${archiveRemotePath} (archive=${archiveSize} bytes, md5=${expectedMd5})`);
+
+  const SIZE_50MB = 50 * 1024 * 1024;
+  if (archiveSize > SIZE_50MB) {
+    uploadLog(
+      `uploadProject: archive size ${(archiveSize / (1024 * 1024)).toFixed(1)}MB exceeds 50MB. ` +
+        `Dependencies or platform binaries may have been included. ` +
+        `Ensure exclude list contains "**/node_modules" to match all nesting levels.`,
+    );
+  }
 
   let result;
   let tunnelError;
@@ -577,7 +608,8 @@ export async function uploadProjectWithSession(
       break;
     } catch (error) {
       tunnelError = error;
-      uploadLog(`uploadProject: attempt ${attempt + 1}/${UPLOAD_MAX_RETRIES} failed: ${error.message}`);
+      const errorType = error.code || error.name || 'unknown';
+      uploadLog(`uploadProject: attempt ${attempt + 1}/${UPLOAD_MAX_RETRIES} failed [${errorType}]: ${error.message}`);
       await new Promise((r) => setTimeout(r, 5000));
     }
   }


### PR DESCRIPTION
﻿## Summary

Based on saas-platform monorepo deploy test report.

### P0 Fixes
- node_modules exclusion changed to **/node_modules (matches nested: apps/*/node_modules, packages/*/node_modules)
- Archive size warning: logs when archive exceeds 50MB, suggests checking exclude list

### P1 Fixes
- Nginx cleanup: auto-remove stale configs + nginx reload after sandbox connect
- Retry error logging: shows error type (code/name) per attempt, not just message

### P3 Fixes
- Upload log rotation: truncates when exceeding 100KB to prevent unbounded growth
