### PR TITLE
docs: rename Hermes Agent to Hermes for consistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Help AI coding agents use Huawei Cloud safely and accurately — a single integration that gives agents cloud knowledge, CLI tooling, and safety guardrails.
 
-Supports OpenCode, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes Agent, OpenClaw, and AtomCode.
+Supports OpenCode, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes, OpenClaw, and AtomCode.
 
 ## Prerequisites
 
@@ -98,13 +98,13 @@ npx --yes huaweicloud-devkit update --target officeace
 npx --yes huaweicloud-devkit uninstall --target officeace
 ```
 
-### Hermes Agent
+### Hermes
 
 ```bash
 npx --yes huaweicloud-devkit install --target hermes
 ```
 
-**Restart the Hermes Agent session** after installation.
+**Restart the Hermes session** after installation.
 
 ```bash
 npx --yes huaweicloud-devkit doctor --target hermes

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 帮助 AI 编码助手安全、准确地使用华为云——一站式集成云知识、CLI 工具和安全护栏。
 
-支持 OpenCode、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes Agent、OpenClaw、AtomCode。
+支持 OpenCode、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes、OpenClaw、AtomCode。
 
 ## 前置条件
 
@@ -98,13 +98,13 @@ npx --yes huaweicloud-devkit update --target officeace
 npx --yes huaweicloud-devkit uninstall --target officeace
 ```
 
-### Hermes Agent
+### Hermes
 
 ```bash
 npx --yes huaweicloud-devkit install --target hermes
 ```
 
-安装后**重启 Hermes Agent 会话**。
+安装后**重启 Hermes 会话**。
 
 ```bash
 npx --yes huaweicloud-devkit doctor --target hermes


### PR DESCRIPTION
Rename "Hermes Agent" to just "Hermes" in README.md and README.zh-CN.md:
- Section title
- Supported agents list
- Restart note