### PR TITLE
fix(sandbox): use git archive for git repos to exclude all ignored files

### DIFF
--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -299,21 +299,26 @@ async function createTarGz(localDir, exclude = []) {
   mkdirSync(archiveDir, { recursive: true });
   const archivePath = join(archiveDir, archiveName);
 
-  const args = [];
-  for (const pattern of exclude) {
-    if (pattern.startsWith('**/')) {
-      const base = pattern.slice(3);
-      for (let depth = 0; depth <= 4; depth++) {
-        const prefix = depth === 0 ? '' : '*/'.repeat(depth);
-        args.push('--exclude', `${prefix}${base}`);
+  const hasGit = existsSync(join(localDir, '.git'));
+  if (hasGit) {
+    await execFileAsync('git', ['-C', localDir, 'archive', '--format=tar.gz', `--output=${archivePath}`, 'HEAD']);
+  } else {
+    const args = [];
+    for (const pattern of exclude) {
+      if (pattern.startsWith('**/')) {
+        const base = pattern.slice(3);
+        for (let depth = 0; depth <= 4; depth++) {
+          const prefix = depth === 0 ? '' : '*/'.repeat(depth);
+          args.push('--exclude', `${prefix}${base}`);
+        }
+      } else {
+        args.push('--exclude', pattern);
       }
-    } else {
-      args.push('--exclude', pattern);
     }
+    args.push('-czf', archivePath, '-C', dirname(localDir), basename(localDir));
+    await execFileAsync('tar', args);
   }
-  args.push('-czf', archivePath, '-C', dirname(localDir), basename(localDir));
 
-  await execFileAsync('tar', args);
   return archivePath;
 }
 


### PR DESCRIPTION
## Summary

Replaces `tar --exclude` with `git archive HEAD` for git repos. `git archive` naturally excludes:
- All `.gitignore` entries (node_modules, dist, .next, .nuxt, .output, .turbo, .cache, coverage at any depth)
- Untracked files
- `.git` directory

For non-git directories, fall back to the existing tar with multi-level exclude patterns.

## Tested
- Git repo: 329KB archive, zero node_modules
- Non-git fallback: tar with **/node_modules → multi-level --exclude works as before