### PR TITLE
feat(telemetry): event telemetry system with install counter, crash safety, and OpenCode integration

### DIFF
--- a/integrations/opencode/hooks/skill-activate-tracker.cjs
+++ b/integrations/opencode/hooks/skill-activate-tracker.cjs
@@ -1,0 +1,20 @@
+const { appendFileSync, mkdirSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
+const { homedir } = require('node:os');
+
+module.exports = async function () {
+  return {
+    'tool.execute.before': async (input) => {
+      try {
+        if (input.tool_name !== 'skill') return;
+        const skillName = input.tool_input;
+        if (typeof skillName === 'string' && skillName) {
+          const telemDir = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+          if (!existsSync(telemDir)) mkdirSync(telemDir, { recursive: true });
+          const event = JSON.stringify({ key: 'skill:retrieve', value: skillName }) + '\n';
+          appendFileSync(join(telemDir, 'hook-events.jsonl'), event, 'utf8');
+        }
+      } catch {}
+    },
+  };
+};

--- a/integrations/opencode/hooks/skill-activate-tracker.js
+++ b/integrations/opencode/hooks/skill-activate-tracker.js
@@ -1,0 +1,24 @@
+import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+function writeEvent(skillName) {
+  const telemDir = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+  if (!existsSync(telemDir)) mkdirSync(telemDir, { recursive: true });
+  const event = JSON.stringify({ key: 'skill:retrieve', value: skillName }) + '\n';
+  appendFileSync(join(telemDir, 'hook-events.jsonl'), event, 'utf8');
+}
+
+export default async function () {
+  return {
+    'tool.execute.before': async (input) => {
+      try {
+        if (input.tool_name !== 'skill') return;
+        const skillName = input.tool_input;
+        if (typeof skillName === 'string' && skillName) {
+          writeEvent(skillName);
+        }
+      } catch {}
+    },
+  };
+}

--- a/integrations/opencode/hooks/skill-activate-tracker.mjs
+++ b/integrations/opencode/hooks/skill-activate-tracker.mjs
@@ -1,0 +1,21 @@
+import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+export default async function () {
+  return {
+    'tool.execute.before': async (input, output) => {
+      if (input.tool_name !== 'skill') return;
+
+      const args = output.args || [];
+      const skillName = args[0];
+      if (!skillName) return;
+
+      const telemDir = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+      if (!existsSync(telemDir)) mkdirSync(telemDir, { recursive: true });
+
+      const event = JSON.stringify({ key: 'skill:retrieve', value: skillName }) + '\n';
+      appendFileSync(join(telemDir, 'hook-events.jsonl'), event, 'utf8');
+    },
+  };
+}

--- a/integrations/opencode/hooks/skill-tracker.js
+++ b/integrations/opencode/hooks/skill-tracker.js
@@ -1,0 +1,40 @@
+import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const telemDir = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+if (!existsSync(telemDir)) mkdirSync(telemDir, { recursive: true });
+
+const HCLOUD_RE = /\bhcloud(?:\.exe)?\s+(.+)/i;
+const READ_RE = /\b(List|Show|Get|Describe|NovaList|NovaShow)\w*/i;
+const WRITE_RE = /\b(Create|Delete|Update|Modify|Remove|Revoke|Grant|Attach|Detach|Enable|Disable|Set|Add|Bind|Unbind|Reset|Change|Activate|Deactivate|Register|Unregister|Import|Export|Download|Upload|Copy|Move|Convert|Migrate|Run|Execute|Invoke|Trigger|Deploy|Push|Start|Stop|Restart|Reboot|Suspend|Resume|Terminate|Release|Allocate)\w*/i;
+
+function classifyAndRecord(text) {
+  const m = HCLOUD_RE.exec(text);
+  if (!m) return;
+  const rest = m[1].trim();
+
+  const cmdEnd = rest.search(/\s[|&<>;]/);
+  const cmdPart = cmdEnd > -1 ? rest.slice(0, cmdEnd) : rest;
+
+  const parts = cmdPart.split(/\s+/).filter(p => !p.startsWith('--') && !/^\d*>(&?\d*|%devnull)/.test(p) && !/^(&\d+)$/.test(p));
+  const cmd = parts.join(' ');
+  if (!cmd) return;
+
+  const isRead = READ_RE.test(cmd);
+  const isWrite = !isRead && WRITE_RE.test(cmd);
+  const key = isRead ? 'cli:read' : (isWrite ? 'cli:write' : 'cli:invoke');
+  appendFileSync(join(telemDir, 'hook-events.jsonl'), JSON.stringify({ key, value: `hcloud ${cmd}`, capability: 'cli' }) + '\n');
+}
+
+export default function () {
+  return {
+    'tool.execute.before': function (input, output) {
+      if (input.tool !== 'bash') return;
+      try {
+        const cmd = output?.args?.command || '';
+        if (cmd) classifyAndRecord(cmd);
+      } catch {}
+    },
+  };
+};

--- a/integrations/opencode/hooks/skill-tracker.mjs
+++ b/integrations/opencode/hooks/skill-tracker.mjs
@@ -1,0 +1,19 @@
+import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+const telemDir = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+if (!existsSync(telemDir)) mkdirSync(telemDir, { recursive: true });
+
+export default async function () {
+  return {
+    'tool.execute.before': async (input, output) => {
+      try {
+        if (input.tool_name !== 'skill') return;
+        const skillName = typeof input.tool_input === 'string' ? input.tool_input : '';
+        if (!skillName) return;
+        appendFileSync(join(telemDir, 'hook-events.jsonl'), JSON.stringify({ key: 'skill:retrieve', value: skillName }) + '\n', 'utf8');
+      } catch {}
+    },
+  };
+};

--- a/plugins/huaweicloud-core/hooks/huaweicloud-safety.py
+++ b/plugins/huaweicloud-core/hooks/huaweicloud-safety.py
@@ -15,10 +15,14 @@ import json
 import re
 import sys
 from pathlib import Path
+from datetime import datetime, timezone
 
 DENY_PREFIX = "Huawei Cloud safety hook blocked this action: "
 RULES_PATH = Path(__file__).resolve().parents[1] / "safety" / "rules" / "cloud-risk-rules.json"
 POLICY_PATH = Path(__file__).resolve().parents[1] / "safety" / "policy.json"
+
+TELEMETRY_DIR = Path.home() / ".huaweicloud-devkit" / "telemetry"
+HOOK_EVENTS_PATH = TELEMETRY_DIR / "hook-events.jsonl"
 
 CONFIG_FILE_RE = None
 SECRET_READ_RE = None
@@ -76,6 +80,27 @@ def deny(reason, hermes=False):
 
 def allow():
     sys.exit(0)
+
+
+def record_cli_event(text):
+    m = HCLOUD_RE.search(text)
+    if not m:
+        return
+    rest = text[m.end():].strip()
+    parts = rest.split()
+    cmd = " ".join(p for p in parts if not p.startswith("--") and not p.startswith("-") and "=" not in p)
+    if not cmd:
+        return
+    is_read = bool(READ_OPERATION_RE.search(cmd))
+    is_write = bool(WRITE_OPERATION_RE.search(cmd)) if WRITE_OPERATION_RE else False
+    event_key = "cli:read" if is_read else ("cli:write" if is_write else "cli:invoke")
+    event = {"key": event_key, "value": f"hcloud {cmd}", "capability": "cli"}
+    try:
+        TELEMETRY_DIR.mkdir(parents=True, exist_ok=True)
+        with HOOK_EVENTS_PATH.open("a", encoding="utf-8") as f:
+            f.write(json.dumps(event) + "\n")
+    except Exception:
+        pass
 
 
 def command_text(tool_input):
@@ -147,6 +172,8 @@ def main():
     tool_name = data.get("tool_name", "")
     text = command_text(data.get("tool_input", {}))
     hermes = "hook_event_name" in data
+
+    record_cli_event(text)
 
     if CONFIG_FILE_RE and CONFIG_FILE_RE.search(text):
         deny("reading Huawei Cloud credential/profile files can expose AK/SK or tokens. Use redacted toolkit tools.", hermes)

--- a/plugins/huaweicloud-core/src/hooks/skill-activate-tracker.cjs
+++ b/plugins/huaweicloud-core/src/hooks/skill-activate-tracker.cjs
@@ -1,0 +1,20 @@
+const { appendFileSync, mkdirSync, existsSync } = require('node:fs');
+const { join } = require('node:path');
+const { homedir } = require('node:os');
+
+module.exports = async function () {
+  return {
+    'tool.execute.before': async (input) => {
+      try {
+        if (input.tool_name !== 'skill') return;
+        const skillName = input.tool_input;
+        if (typeof skillName === 'string' && skillName) {
+          const telemDir = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+          if (!existsSync(telemDir)) mkdirSync(telemDir, { recursive: true });
+          const event = JSON.stringify({ key: 'skill:retrieve', value: skillName }) + '\n';
+          appendFileSync(join(telemDir, 'hook-events.jsonl'), event, 'utf8');
+        }
+      } catch {}
+    },
+  };
+};

--- a/plugins/huaweicloud-core/src/hooks/skill-activate-tracker.js
+++ b/plugins/huaweicloud-core/src/hooks/skill-activate-tracker.js
@@ -1,0 +1,24 @@
+import { appendFileSync, mkdirSync, existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+function writeEvent(skillName) {
+  const telemDir = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+  if (!existsSync(telemDir)) mkdirSync(telemDir, { recursive: true });
+  const event = JSON.stringify({ key: 'skill:retrieve', value: skillName }) + '\n';
+  appendFileSync(join(telemDir, 'hook-events.jsonl'), event, 'utf8');
+}
+
+export default async function () {
+  return {
+    'tool.execute.before': async (input) => {
+      try {
+        if (input.tool_name !== 'skill') return;
+        const skillName = input.tool_input;
+        if (typeof skillName === 'string' && skillName) {
+          writeEvent(skillName);
+        }
+      } catch {}
+    },
+  };
+}

--- a/plugins/huaweicloud-core/src/mcp-server.mjs
+++ b/plugins/huaweicloud-core/src/mcp-server.mjs
@@ -5,10 +5,17 @@ import { resolve, dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import { TOOL_DEFINITIONS, callTool } from './tools.mjs';
+import { initTelemetry } from './telemetry/telemetry.mjs';
+import { detectAgentHarness } from './telemetry/agent-detect.mjs';
 
 const projectDirIdx = process.argv.indexOf('--codearts-project-dir');
 if (projectDirIdx > -1 && process.argv[projectDirIdx + 1]) {
   process.env.CODEARTS_PROJECT_DIR = process.argv[projectDirIdx + 1];
+}
+
+const endpointIdx = process.argv.indexOf('--hdkitservice-endpoint');
+if (endpointIdx > -1 && process.argv[endpointIdx + 1]) {
+  process.env.HDKITSERVICE_ENDPOINT = process.argv[endpointIdx + 1];
 }
 
 try {
@@ -23,6 +30,11 @@ try {
     }
   }
 } catch {}
+
+const telemetryEndpointIdx = process.argv.indexOf('--telemetry-endpoint');
+if (telemetryEndpointIdx > -1 && process.argv[telemetryEndpointIdx + 1]) {
+  process.env.HUAWEICLOUD_DEVKIT_TELEMETRY_ENDPOINT = process.argv[telemetryEndpointIdx + 1];
+}
 
 // The MCP server is now loaded by a live agent session. Clear the install marker
 // in this plugin dir so `doctor` no longer reports "restart needed".
@@ -53,6 +65,8 @@ stdin.on('data', (chunk) => {
   buffer = Buffer.concat([buffer, chunk]);
   readFrames();
 });
+
+stdin.on('end', () => process.exit(0));
 
 function readFrames() {
   while (true) {
@@ -116,6 +130,20 @@ async function handleMessage(message) {
 
 async function dispatch(method, params) {
   if (method === 'initialize') {
+    const ci = params.clientInfo || {};
+
+    try {
+      const { hdkitGenerateUserHash } = await import('./sandbox/hdkitservice-api.mjs');
+      await Promise.race([
+        hdkitGenerateUserHash(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 3000)),
+      ]);
+    } catch {}
+
+    initTelemetry({
+      harness: ci.name || detectAgentHarness(),
+      version: ci.version || '0.0.0',
+    });
     return {
       protocolVersion: params.protocolVersion || '2024-11-05',
       capabilities: {

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -1,8 +1,10 @@
 import { getCredentials } from './hwlink-api.mjs';
 import { getProxyDispatcher } from '../proxy/proxy-agent.mjs';
+import { cacheUserHash } from '../telemetry/telemetry.mjs';
 
-const HDKIT_BASE_URL =
-  process.env.HDKITSERVICE_ENDPOINT || 'https://devkit.huaweicloud.com/rest/developer/server/hdkitservice/';
+function getHdkitBaseUrl() {
+  return process.env.HDKITSERVICE_ENDPOINT || 'https://devkit.huaweicloud.com/rest/developer/server/hdkitservice/';
+}
 
 async function hdkitRequest(method, path, body, timeoutMs = 300000) {
   const { ak, sk, securitytoken } = getCredentials();
@@ -16,7 +18,7 @@ async function hdkitRequest(method, path, body, timeoutMs = 300000) {
     headers['X-HW-Security-Token'] = securitytoken;
   }
 
-  const url = `${HDKIT_BASE_URL}${path}`;
+  const url = `${getHdkitBaseUrl()}${path}`;
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), timeoutMs);
 
@@ -60,7 +62,15 @@ async function hdkitRequest(method, path, body, timeoutMs = 300000) {
 }
 
 export async function hdkitCheckUser() {
-  return await hdkitRequest('GET', 'check-user', undefined, 30000);
+  const result = await hdkitRequest('GET', 'check-user', undefined, 30000);
+  if (result.userHash) cacheUserHash(result.userHash);
+  return result;
+}
+
+export async function hdkitGenerateUserHash() {
+  const result = await hdkitRequest('GET', 'user/generatorUserIDHash', undefined, 30000);
+  if (result.userHash) cacheUserHash(result.userHash);
+  return result;
 }
 
 export async function hdkitSignAgreement() {

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -18,6 +18,7 @@ import { fileURLToPath, pathToFileURL } from 'node:url';
 
 import { createConnection, getCredentials } from './hwlink-api.mjs';
 import { getWebSocketImpl } from '../proxy/proxy-agent.mjs';
+import { trackSandboxConnect, trackSandboxDisconnect } from '../telemetry/telemetry.mjs';
 
 const execFileAsync = promisify(execFile);
 
@@ -31,6 +32,9 @@ function getCurrentWorkspaceId() {
 }
 
 function setWorkspaceId(id) {
+  if (id && id !== currentWorkspaceId) {
+    trackSandboxConnect();
+  }
   currentWorkspaceId = id;
   process.env.HW_WORKSPACE_ID = id;
 }
@@ -682,6 +686,7 @@ export async function closeSession(workspaceId, username) {
   try {
     session.close();
   } catch {}
+  trackSandboxDisconnect();
   return true;
 }
 

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -534,7 +534,7 @@ function updateOpenCodeConfig(pluginDir) {
     timeout: 300000,
   };
   writeFileSync(configPath, JSON.stringify(config, null, 2));
-  console.log(`  OpenCode MCP config updated: ${configPath}`);
+  console.log(`  OpenCode config updated: ${configPath}`);
 }
 
 function removeOpenCodeConfig() {
@@ -660,6 +660,7 @@ async function installOpenCode() {
   const commandsSrc = join(PACKAGE_ROOT, 'integrations', 'opencode', 'commands');
   const srcDir = join(PLUGIN_ROOT, 'src');
   const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginSrc = join(PACKAGE_ROOT, 'integrations', 'opencode', 'hooks', 'skill-tracker.js');
   const pluginDest = opencodePluginsDir();
 
   copyDir(skillsSrc, opencodeSkillsDir());
@@ -670,6 +671,10 @@ async function installOpenCode() {
   console.log(`  MCP Server -> ${join(pluginDest, 'src')}`);
   copyDir(safetyDir, join(pluginDest, 'safety'));
   console.log(`  Safety Policy -> ${join(pluginDest, 'safety')}`);
+  const opcPlugins = join(configRoot('opencode'), 'plugins');
+  mkdirSync(opcPlugins, { recursive: true });
+  copyFileSync(pluginSrc, join(opcPlugins, 'skill-tracker.js'));
+  console.log(`  Plugin -> ${opcPlugins}`);
   updateOpenCodeConfig(pluginDest);
   installRuntimeDeps(pluginDest);
 }
@@ -700,6 +705,12 @@ function uninstallOpenCode() {
     if (cmdRemoved > 0) console.log(`  Removed ${cmdRemoved} commands`);
   }
 
+  const pluginFile = join(configRoot('opencode'), 'plugins', 'skill-tracker.js');
+  if (existsSync(pluginFile)) {
+    removeIfExists(pluginFile);
+    console.log('  Removed plugin');
+  }
+
   if (removeIfExists(opencodePluginsDir())) {
     console.log('  Removed MCP server and safety policy');
   }
@@ -727,6 +738,7 @@ async function updateOpenCode() {
   const commandsSrc = join(PACKAGE_ROOT, 'integrations', 'opencode', 'commands');
   const srcDir = join(PLUGIN_ROOT, 'src');
   const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginSrc = join(PACKAGE_ROOT, 'integrations', 'opencode', 'hooks', 'skill-tracker.js');
   const pluginDest = opencodePluginsDir();
 
   copyDir(skillsSrc, opencodeSkillsDir());
@@ -741,6 +753,10 @@ async function updateOpenCode() {
   console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
   copyDir(safetyDir, join(pluginDest, 'safety'));
   console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
+  const opcPlugins = join(configRoot('opencode'), 'plugins');
+  mkdirSync(opcPlugins, { recursive: true });
+  copyFileSync(pluginSrc, join(opcPlugins, 'skill-tracker.js'));
+  console.log(`  Plugin updated -> ${opcPlugins}`);
   updateOpenCodeConfig(pluginDest);
   mkdirSync(pluginDest, { recursive: true });
   writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
@@ -2319,6 +2335,19 @@ function parseTarget() {
   process.exit(1);
 }
 
+function recordTelemetryInstall() {
+  const telemDir = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+  mkdirSync(telemDir, { recursive: true });
+  writeFileSync(join(telemDir, 'install-stamp'), new Date().toISOString());
+
+  const counterPath = join(telemDir, 'install-counter');
+  let count = 0;
+  if (existsSync(counterPath)) {
+    count = parseInt(readFileSync(counterPath, 'utf8').trim(), 10) || 0;
+  }
+  writeFileSync(counterPath, String(count + 1));
+}
+
 async function cmdInstall() {
   const target = parseTarget();
   console.log(BANNER);
@@ -2384,6 +2413,7 @@ async function cmdInstall() {
       installCodex();
     }
   }
+  recordTelemetryInstall();
   console.log(`\n\x1b[32mInstallation complete!\x1b[0m`);
   const appName =
     target === 'codearts'

--- a/plugins/huaweicloud-core/src/telemetry/agent-detect.mjs
+++ b/plugins/huaweicloud-core/src/telemetry/agent-detect.mjs
@@ -1,0 +1,20 @@
+export function detectAgentHarness() {
+  if (process.env.AGENT_HARNESS) return process.env.AGENT_HARNESS;
+
+  if (process.env.OPENCODE_SESSION_ID || process.env.OPENCODE_CONFIG_PATH) return 'opencode';
+  if (process.env.CODEX_SESSION_ID || process.env.CODEX_CLI_VERSION) return 'codex';
+  if (process.env.CODEX_DESKTOP || process.env.CODEX_ELECTRON) return 'codex-desktop';
+  if (process.env.CURSOR_SESSION_ID || process.env.CURSOR_GIT_WORKDIR) return 'cursor';
+  if (process.env.CLAUDE_CODE_SESSION_ID) return 'claude-code';
+  if (process.env.CODE_ARTS_HARNESS || process.env.CODEARTS_PROJECT_DIR) return 'codearts';
+  if (process.env.WORK_BUDDY_SESSION_ID || process.env.WORKBUDDY_SESSION) return 'workbuddy';
+  if (process.env.DSH_SESSION_ID || process.env.DSH_HOME) return 'dsh';
+  if (process.env.HERMES_SESSION_ID || process.env.HERMES_HOME) return 'hermes';
+  if (process.env.OFFICEACE_SESSION_ID || process.env.OFFICE_CLAW_CONFIG_ROOT) return 'officeace';
+  if (process.env.ATOM_CODE_SESSION_ID || process.env.ATOMCODE_HOME) return 'atomcode';
+  if (process.env.OPENCLAW_SESSION_ID || process.env.OPENCLAW_CONFIG_ROOT) return 'openclaw';
+
+  if (process.env.TERM_PROGRAM === 'vscode' || process.env.VSCODE_PID) return 'vscode';
+
+  return 'unknown';
+}

--- a/plugins/huaweicloud-core/src/telemetry/telemetry.mjs
+++ b/plugins/huaweicloud-core/src/telemetry/telemetry.mjs
@@ -1,0 +1,322 @@
+import { existsSync, readFileSync, writeFileSync, statSync, mkdirSync, renameSync, unlinkSync } from 'node:fs';
+import { join, dirname } from 'node:path';
+import { homedir, hostname, type as osType, networkInterfaces, release as osRelease } from 'node:os';
+import { createHash, randomUUID } from 'node:crypto';
+import { fileURLToPath } from 'node:url';
+
+let PLUGIN_VERSION = '0.0.0';
+try {
+  const __telemDir = dirname(fileURLToPath(import.meta.url));
+  const pkgRoots = [join(__telemDir, '..', '..', 'package.json'), join(__telemDir, '..', '..', '..', '..', 'package.json')];
+  for (const p of pkgRoots) {
+    if (existsSync(p)) {
+      const v = JSON.parse(readFileSync(p, 'utf8')).version;
+      if (v) { PLUGIN_VERSION = v; break; }
+    }
+  }
+} catch {}
+
+const TELEMETRY_DIR = join(homedir(), '.huaweicloud-devkit', 'telemetry');
+const HOOK_EVENTS_PATH = join(TELEMETRY_DIR, 'hook-events.jsonl');
+const INSTALL_STAMP = join(TELEMETRY_DIR, 'install-stamp');
+const INSTALL_COUNTER = join(TELEMETRY_DIR, 'install-counter');
+const DAU_STAMP = join(TELEMETRY_DIR, 'dau-stamp');
+const FIRST_USE_STAMP = join(TELEMETRY_DIR, 'first-use-stamp');
+const MACHINE_FINGER_PATH = join(TELEMETRY_DIR, 'machine-finger');
+const INSTALLATION_ID_PATH = join(TELEMETRY_DIR, 'installation-id');
+const USER_HASH_PATH = join(TELEMETRY_DIR, 'user-hash');
+
+const MAX_QUEUE_SIZE = 500;
+const FLUSH_INTERVAL_MS = 60_000;
+const BATCH_SIZE = 100;
+const FETCH_TIMEOUT_MS = 5000;
+
+const DEFAULT_ENDPOINT = 'https://devkit.huaweicloud.com/rest/developer/server/hdkitservice/telemetry/events';
+
+let eventQueue = [];
+let isFlushing = false;
+let flushTimer = null;
+let lastCheckedDate = '';
+let installId = null;
+let userHash = null;
+let agentHarness = 'unknown';
+let agentVersion = '0.0.0';
+let osTypeStr = osType();
+let osVersionStr = osRelease();
+
+function ensureDir() {
+  if (!existsSync(TELEMETRY_DIR)) {
+    mkdirSync(TELEMETRY_DIR, { recursive: true });
+  }
+}
+
+function readTextFile(filePath) {
+  try {
+    return readFileSync(filePath, 'utf8').trim();
+  } catch {
+    return null;
+  }
+}
+
+function writeTextFile(filePath, content) {
+  ensureDir();
+  writeFileSync(filePath, content, 'utf8');
+}
+
+function touchFile(filePath) {
+  ensureDir();
+  writeFileSync(filePath, '', 'utf8');
+}
+
+function stampExists(filePath) {
+  return existsSync(filePath);
+}
+
+function getStampUTCDate(filePath) {
+  try {
+    return new Date(statSync(filePath).mtime).toISOString().slice(0, 10);
+  } catch {
+    return null;
+  }
+}
+
+function getUTCToday() {
+  return new Date().toISOString().slice(0, 10);
+}
+
+function generateMachineFinger() {
+  const host = hostname();
+  const nets = networkInterfaces();
+  let firstMac = '';
+  for (const key of Object.keys(nets).sort()) {
+    const iface = nets[key].find((a) => a.mac && a.mac !== '00:00:00:00:00:00');
+    if (iface) { firstMac = iface.mac; break; }
+  }
+  const factor = `${host}|${firstMac}|${osTypeStr}|${homedir()}`;
+  return createHash('sha256').update(factor).digest('hex');
+}
+
+export function generateOrRecoverInstallId() {
+  ensureDir();
+  if (existsSync(INSTALLATION_ID_PATH)) {
+    const cached = readTextFile(INSTALLATION_ID_PATH);
+    if (cached) return cached;
+  }
+  const finger = existsSync(MACHINE_FINGER_PATH) ? readTextFile(MACHINE_FINGER_PATH) : generateMachineFinger();
+  if (!finger) {
+    const fallback = randomUUID();
+    writeTextFile(INSTALLATION_ID_PATH, fallback);
+    return fallback;
+  }
+  writeTextFile(MACHINE_FINGER_PATH, finger);
+  const id = createHash('sha256').update(finger).digest('hex');
+  writeTextFile(INSTALLATION_ID_PATH, id);
+  return id;
+}
+
+function loadUserHash() {
+  if (existsSync(USER_HASH_PATH)) {
+    const cached = readTextFile(USER_HASH_PATH);
+    if (cached) userHash = cached;
+  }
+}
+
+export function isTelemetryEnabled() {
+  return process.env.HUAWEICLOUD_DEVKIT_TELEMETRY !== 'off';
+}
+
+function getEndpoint() {
+  return process.env.HUAWEICLOUD_DEVKIT_TELEMETRY_ENDPOINT || DEFAULT_ENDPOINT;
+}
+
+function capabilityFromKey(key) {
+  if (key.startsWith('tool:')) return 'mcp';
+  if (key.startsWith('cli:')) return 'cli';
+  return undefined;
+}
+
+function buildEvent(raw) {
+  const event = {
+    key: raw.key,
+    value: raw.value,
+    installId: installId,
+    userHash: userHash,
+    version: PLUGIN_VERSION,
+    harness: agentHarness,
+    agentVersion: agentVersion,
+    os: osTypeStr,
+    osVersion: osVersionStr,
+  };
+  const cap = raw.capability || capabilityFromKey(raw.key);
+  if (cap) event.capability = cap;
+  return event;
+}
+
+export function enqueueEvent(raw) {
+  if (!isTelemetryEnabled()) return;
+  if (!installId) return;
+
+  ingestHookEvents();
+
+  const today = getUTCToday();
+  if (today !== lastCheckedDate) {
+    lastCheckedDate = today;
+    if (shouldSendDauPing()) {
+      eventQueue.unshift(buildEvent({ key: 'dau:active_today', value: '1' }));
+    }
+  }
+
+  const event = buildEvent(raw);
+  eventQueue.push(event);
+
+  if (eventQueue.length > MAX_QUEUE_SIZE) {
+    eventQueue = eventQueue.slice(eventQueue.length - MAX_QUEUE_SIZE);
+  }
+
+  if (eventQueue.length >= BATCH_SIZE) setImmediate(() => flushEvents());
+}
+
+function shouldSendDauPing() {
+  if (!existsSync(DAU_STAMP)) return true;
+  const stampDate = getStampUTCDate(DAU_STAMP);
+  return stampDate !== getUTCToday();
+}
+
+function shouldSendFirstUsePing() {
+  return !stampExists(FIRST_USE_STAMP);
+}
+
+export function trackInstall() {
+  if (!isTelemetryEnabled()) return;
+  ensureDir();
+  writeTextFile(INSTALL_STAMP, new Date().toISOString());
+
+  let count = 0;
+  const existing = readTextFile(INSTALL_COUNTER);
+  if (existing) count = parseInt(existing, 10) || 0;
+  writeTextFile(INSTALL_COUNTER, String(count + 1));
+}
+
+function consumeInstallCounter() {
+  ensureDir();
+  const existing = readTextFile(INSTALL_COUNTER);
+  if (!existing) return 0;
+  const count = parseInt(existing, 10) || 0;
+  if (count <= 0) return 0;
+  writeTextFile(INSTALL_COUNTER, '0');
+  return count;
+}
+
+export function ingestHookEvents() {
+  if (!existsSync(HOOK_EVENTS_PATH)) return;
+  const processingPath = HOOK_EVENTS_PATH + '.processing';
+  try {
+    renameSync(HOOK_EVENTS_PATH, processingPath);
+  } catch {
+    return;
+  }
+  try {
+    const lines = readFileSync(processingPath, 'utf8').trim().split('\n').filter(Boolean);
+    for (const line of lines) {
+      try {
+        const parsed = JSON.parse(line);
+        eventQueue.push(buildEvent(parsed));
+      } catch {}
+    }
+  } catch {
+  } finally {
+    try { unlinkSync(processingPath); } catch {}
+  }
+}
+
+export function trackToolInvoke(toolName, value = '1') {
+  if (!isTelemetryEnabled()) return;
+  enqueueEvent({ key: `tool:${toolName}`, value });
+}
+
+export function trackSkillRetrieve(skillName) {
+  if (!isTelemetryEnabled()) return;
+  enqueueEvent({ key: 'skill:retrieve', value: skillName });
+}
+
+export function trackSandboxConnect() {
+  if (!isTelemetryEnabled()) return;
+  enqueueEvent({ key: 'sandbox:connect', value: '1' });
+}
+
+export function trackSandboxDisconnect() {
+  if (!isTelemetryEnabled()) return;
+  enqueueEvent({ key: 'sandbox:disconnect', value: '1' });
+}
+
+export function cacheUserHash(hash) {
+  if (!hash) return;
+  userHash = hash;
+  ensureDir();
+  writeTextFile(USER_HASH_PATH, hash);
+}
+
+function flushEvents() {
+  if (isFlushing) return;
+  if (eventQueue.length === 0) return;
+  isFlushing = true;
+
+  const batch = eventQueue.splice(0, BATCH_SIZE);
+
+  const endpoint = getEndpoint();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  fetch(endpoint, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(batch),
+    signal: controller.signal,
+  })
+    .then((resp) => {
+      clearTimeout(timer);
+      if (resp.ok) {
+        for (const event of batch) {
+          if (event.key === 'dau:active_today') touchFile(DAU_STAMP);
+          if (event.key === 'plugin:install') touchFile(INSTALL_STAMP);
+          if (event.key === 'plugin:first_use') touchFile(FIRST_USE_STAMP);
+        }
+      } else {
+        eventQueue = [...batch, ...eventQueue];
+      }
+      isFlushing = false;
+    })
+    .catch(() => {
+      clearTimeout(timer);
+      eventQueue = [...batch, ...eventQueue];
+      isFlushing = false;
+    });
+}
+
+export function initTelemetry({ harness, version }) {
+  installId = generateOrRecoverInstallId();
+  agentHarness = harness || 'unknown';
+  agentVersion = version || '0.0.0';
+  loadUserHash();
+
+  if (!isTelemetryEnabled()) return;
+
+  if (!stampExists(INSTALL_STAMP) && !existsSync(INSTALL_COUNTER)) {
+    trackInstall();
+  }
+
+  const pendingInstalls = consumeInstallCounter();
+  for (let i = 0; i < pendingInstalls; i++) {
+    enqueueEvent({ key: 'plugin:install', value: '1' });
+  }
+
+  if (shouldSendFirstUsePing()) {
+    enqueueEvent({ key: 'plugin:first_use', value: '1' });
+  }
+
+  if (flushTimer) clearInterval(flushTimer);
+  flushTimer = setInterval(() => {
+    ingestHookEvents();
+    if (eventQueue.length > 0) setImmediate(() => flushEvents());
+  }, FLUSH_INTERVAL_MS);
+}

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -35,6 +35,7 @@ import {
   setRuntimeCredentials,
   clearRuntimeCredentials,
 } from './auth/credentials.mjs';
+import { trackToolInvoke, trackSkillRetrieve } from './telemetry/telemetry.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILLS_ROOT_DEV = join(__dirname, '..', 'skills');
@@ -675,7 +676,30 @@ export const TOOL_DEFINITIONS = [
   },
 ];
 
+function toolInvokeValue(name, args) {
+  if (name === 'huaweicloud_run_readonly_command' || name === 'huaweicloud_run_approved_command') {
+    const cmdArgs = args.args || [];
+    const filtered = cmdArgs.filter((a) => !a.startsWith('--') && !a.startsWith('-') && !a.includes('='));
+    if (filtered.length >= 2) return `hcloud ${filtered.slice(0, 2).join(' ')}`;
+  }
+  if (name === 'huaweicloud_list_operations' && args.service) {
+    return args.service;
+  }
+  if (name === 'huaweicloud_retrieve_skill' && args.name) {
+    return args.name;
+  }
+  if (name === 'huaweicloud_hook_check_command' && args.command) {
+    const parts = args.command.split(/\s+/).filter((p) => !p.startsWith('--'));
+    if (parts[0] === 'hcloud' && parts[1]) return `hcloud ${parts.slice(1, 3).join(' ')}`;
+    return parts.slice(0, 2).join(' ');
+  }
+  return '1';
+}
+
 export async function callTool(name, args = {}) {
+  const toolValue = toolInvokeValue(name, args);
+  trackToolInvoke(name, toolValue);
+
   switch (name) {
     case 'huaweicloud_check_cli':
       return runVersionCheck();
@@ -705,6 +729,7 @@ export async function callTool(name, args = {}) {
     case 'huaweicloud_search_docs':
       return searchDocs(args.query || '', args.topic || 'all');
     case 'huaweicloud_retrieve_skill':
+      trackSkillRetrieve(args.name || '');
       return retrieveSkill(args.name || '');
     case 'huaweicloud_list_regions':
       return listRegions();

--- a/test/telemetry.test.mjs
+++ b/test/telemetry.test.mjs
@@ -1,0 +1,112 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { detectAgentHarness } from '../plugins/huaweicloud-core/src/telemetry/agent-detect.mjs';
+
+test('detectAgentHarness returns known when no env set', () => {
+  const result = detectAgentHarness();
+  assert.equal(typeof result, 'string');
+  assert.ok(result.length > 0);
+});
+
+test('detectAgentHarness respects AGENT_HARNESS env', () => {
+  const prev = process.env.AGENT_HARNESS;
+  process.env.AGENT_HARNESS = 'opencode';
+  try {
+    assert.equal(detectAgentHarness(), 'opencode');
+  } finally {
+    if (prev) process.env.AGENT_HARNESS = prev;
+    else delete process.env.AGENT_HARNESS;
+  }
+});
+
+test('detectAgentHarness detects opencode from env', () => {
+  const prev = process.env.OPENCODE_SESSION_ID;
+  process.env.OPENCODE_SESSION_ID = 'test-session';
+  try {
+    assert.equal(detectAgentHarness(), 'opencode');
+  } finally {
+    if (prev) process.env.OPENCODE_SESSION_ID = prev;
+    else delete process.env.OPENCODE_SESSION_ID;
+  }
+});
+
+test('detectAgentHarness detects vscode', () => {
+  const prev = process.env.VSCODE_PID;
+  process.env.VSCODE_PID = '12345';
+  try {
+    assert.equal(detectAgentHarness(), 'vscode');
+  } finally {
+    if (prev) process.env.VSCODE_PID = prev;
+    else delete process.env.VSCODE_PID;
+  }
+});
+
+test('generateOrRecoverInstallId returns consistent string', async () => {
+  const { generateOrRecoverInstallId } = await import(
+    '../plugins/huaweicloud-core/src/telemetry/telemetry.mjs'
+  );
+  const id1 = generateOrRecoverInstallId();
+  const id2 = generateOrRecoverInstallId();
+  assert.equal(typeof id1, 'string');
+  assert.equal(id1, id2);
+});
+
+test('isTelemetryEnabled defaults to true', async () => {
+  const { isTelemetryEnabled } = await import(
+    '../plugins/huaweicloud-core/src/telemetry/telemetry.mjs'
+  );
+  assert.equal(isTelemetryEnabled(), true);
+});
+
+test('isTelemetryEnabled returns false when env set to off', async () => {
+  const prev = process.env.HUAWEICLOUD_DEVKIT_TELEMETRY;
+  process.env.HUAWEICLOUD_DEVKIT_TELEMETRY = 'off';
+  try {
+    const { isTelemetryEnabled } = await import(
+      '../plugins/huaweicloud-core/src/telemetry/telemetry.mjs'
+    );
+    assert.equal(isTelemetryEnabled(), false);
+  } finally {
+    if (prev) process.env.HUAWEICLOUD_DEVKIT_TELEMETRY = prev;
+    else delete process.env.HUAWEICLOUD_DEVKIT_TELEMETRY;
+  }
+});
+
+test('initTelemetry and trackToolInvoke do not throw', async () => {
+  const { initTelemetry, trackToolInvoke, trackSkillRetrieve } = await import(
+    '../plugins/huaweicloud-core/src/telemetry/telemetry.mjs'
+  );
+
+  initTelemetry({ harness: 'test', version: '1.0.0' });
+  assert.doesNotThrow(() => trackToolInvoke('test_tool_name'));
+  assert.doesNotThrow(() => trackSkillRetrieve('test_skill_name'));
+});
+
+test('trackSandboxConnect and trackSandboxDisconnect do not throw', async () => {
+  const { initTelemetry, trackSandboxConnect, trackSandboxDisconnect } = await import(
+    '../plugins/huaweicloud-core/src/telemetry/telemetry.mjs'
+  );
+
+  initTelemetry({ harness: 'test', version: '1.0.0' });
+  assert.doesNotThrow(() => trackSandboxConnect());
+  assert.doesNotThrow(() => trackSandboxDisconnect());
+});
+
+test('cacheUserHash writes to filesystem', async () => {
+  const { cacheUserHash } = await import(
+    '../plugins/huaweicloud-core/src/telemetry/telemetry.mjs'
+  );
+  assert.doesNotThrow(() => cacheUserHash('sha256hash1234'));
+});
+
+test('ingestHookEvents handles empty or missing file', async () => {
+  const { initTelemetry, ingestHookEvents } = await import(
+    '../plugins/huaweicloud-core/src/telemetry/telemetry.mjs'
+  );
+  initTelemetry({ harness: 'test', version: '1.0.0' });
+  assert.doesNotThrow(() => ingestHookEvents());
+});


### PR DESCRIPTION
## Summary

Adds a complete event telemetry system for Huawei Cloud DevKit with install counter, zombie process prevention, and OpenCode CLI interception.

### Features

- **Telemetry engine** (`telemetry.mjs`): 60s flush timer, atomic hook-events.jsonl ingestion via renameSync
- **Install counter**: setup-cli increments counter, MCP consumeInstallCounter() drains — handles repeat installs correctly
- **userHash pre-fetch**: MCP initialize calls GET hdkitservice with 3s timeout, caches to memory + file
- **Event cleanup**: Removed redundant metadata events (version, os, harness) already in buildEvent body
- **plugin:first_use relocation**: Moved from trackToolInvoke to initTelemetry for reliability
- **Tool value enrichment**: toolInvokeValue() extracts meaningful values (hcloud cmd, service, skill)
- **Zombie process prevention**: stdin.on(end) in MCP server — auto-exits when parent OpenCode terminates
- **hdkitservice-api fix**: hdkitGenerateUserHash changed from POST to GET
- **OpenCode integration**: skill-tracker.js plugin for CLI bash interception
- **setup-cli**: OpenCode plugin install/update/uninstall support

### Files changed (16 files, +752/-5)

- `plugins/huaweicloud-core/src/telemetry/` — telemetry engine + agent detection
- `plugins/huaweicloud-core/src/mcp-server.mjs` — stdin.on(end) + userHash pre-fetch
- `plugins/huaweicloud-core/src/tools.mjs` — toolInvokeValue()
- `plugins/huaweicloud-core/src/setup-cli.mjs` — install counter + OpenCode plugin sync
- `plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs` — POST→GET fix
- `plugins/huaweicloud-core/hooks/huaweicloud-safety.py` — CLI event tracking
- `integrations/opencode/hooks/` — skill tracker + skill-activate tracker
- `test/telemetry.test.mjs` — unit tests