### PR TITLE
feat(sandbox): deploy_nginx tool, QR integration, permission auto-fix

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -629,11 +629,11 @@ Use `exec_with_session` to background DevBridge. For SSR, DevBridge tunnels the 
 
 **Pre-flight**: always run `devbridge delete-all` before creating a new tunnel to prevent `10006: quota exceeded` from accumulated stale tunnels. If you still get quota error, list tunnels with `devbridge ls --all`, delete stale ones, and retry.
 
-### Step 8: Return URL
+Extract the tunnel URL from DevBridge output. The public URL has the form `https://<id>-<port>.cn-north-4-bridge.myhuaweicloud.com`. **Return this URL to the developer as the deployment result.**
 
-Extract the tunnel URL from DevBridge output and return it to the developer.
+#### Cross-platform H5 QR code
 
-**For cross-platform H5 apps** (Taro, uni-app), also generate a QR code for mobile scanning:
+**If `detect_framework` returned `type: "cross-platform"` (Taro, uni-app)**, after exposing the tunnel, generate a QR code for mobile scanning:
 
 ```bash
 TUNNEL_URL="<extracted-tunnel-url>"
@@ -646,6 +646,26 @@ echo "Desktop URL: $TUNNEL_URL"
 ```
 
 **Do NOT use `qrencode -t ANSI256`** — terminal ANSI/ASCII QR codes have low precision and phone cameras cannot scan them. Also, never save the QR image outside the nginx root (e.g., `/workspace/qr.png`) — it must be inside the output directory so it is served by nginx alongside the app.
+
+**After generating the QR code**, return both URLs to the developer:
+
+```
+桌面访问: <tunnel-url>
+手机扫码: <tunnel-url>/qr.png
+```
+
+#### Deployment Completion Check
+
+Before reporting success, verify these items based on the framework type from `detect_framework`:
+
+| Framework Type              | Must Return               |
+| --------------------------- | ------------------------- |
+| `cross-platform`            | Desktop URL + QR code URL |
+| `spa` / `ssg` / `static`    | Desktop URL               |
+| `ssr`                       | Desktop URL               |
+| `monorepo` (cross-platform) | Desktop URL + QR code URL |
+
+**If the framework is cross-platform and the QR code was not generated, the deployment is incomplete — go back and generate it before reporting success.**
 
 ## References
 
@@ -673,6 +693,7 @@ echo "Desktop URL: $TUNNEL_URL"
 | Node.js >= 22 required               | Sandbox terminal uses built-in WebSocket (globalThis.WebSocket); if Node.js is missing, install it from the Huawei Cloud mirror (see "Node.js in the sandbox")                                                                          |
 | Sandbox restart kills processes      | After sandbox restarts, all user processes (nginx, Node.js, Python servers) are stopped. Re-run startup commands and verify ports are listening before proceeding.                                                                      |
 | Cross-platform binaries incompatible | The sandbox runs Linux. Native binaries built on Windows/macOS (e.g., Prisma client, `node_modules/.prisma/`, platform-specific native addons) will not execute. Always install and build dependencies inside the sandbox, not locally. |
+| Cross-platform needs QR code         | When `detect_framework` returns `type: "cross-platform"` (Taro, uni-app), generating a QR code image is **mandatory** — the deployment is incomplete without it. Check the Deployment Completion Check table in Step 7.                 |
 
 ## Node.js in the sandbox
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -52,6 +52,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 | `huaweicloud_sandbox_exec_one_shot`     | One-shot execution (fresh connection; best for long/heavy commands)         |
 | `huaweicloud_sandbox_upload_file`       | Upload a local file into the sandbox (chunked base64 write + md5 verify)    |
 | `huaweicloud_sandbox_upload_project`    | Upload a local project directory to sandbox (HTTP tunnel, tar.gz + extract) |
+| `huaweicloud_sandbox_deploy_nginx`      | Deploy nginx config with permissions fix and reload in one call             |
 | `huaweicloud_sandbox_close_session`     | Close a persistent terminal session                                         |
 
 ### Tool Selection Guide
@@ -590,17 +591,33 @@ If the port cannot be freed (different user/process), increment to the next avai
 
 #### Configure Nginx
 
-Check `references/nginx-templates.md` for the correct template based on `nginxType`:
+Use `huaweicloud_sandbox_deploy_nginx` to write the correct template, fix directory permissions, and reload nginx — all in one call:
 
-| nginxType | Template                | When                        |
-| --------- | ----------------------- | --------------------------- |
-| `spa`     | Template 1 (try_files)  | SPA, SSG, cross-platform H5 |
-| `proxy`   | Template 2 (proxy_pass) | SSR (Next.js, Nuxt)         |
-| `static`  | Template 3 (plain root) | Hugo, Hexo, static sites    |
+```json
+{
+  "nginx_type": "<nginxType>",
+  "port": <port>,
+  "project": "<dirname>",
+  "output_dir": "<outputDir>",
+  "node_port": <nodePort>,
+  "public_port": <publicPort>
+}
+```
 
-Replace `<port>`, `<project>`, `<outputDir>` (and `<nodePort>`/`<publicPort>` for SSR) with detected values.
+- `nginx_type` — `spa` (SPA/SSG/cross-platform), `proxy` (SSR), or `static` (Hugo/Hexo) from `detect_framework`
+- `port` — listen port from framework detection
+- `project` — project dir name under `/workspace`
+- `output_dir` — build output dir relative to `/workspace/<project>`
+- `node_port` — Node.js app port (required only when `nginx_type=proxy`)
+- `public_port` — public listen port for SSR proxy (optional, defaults to `port`)
 
-Write the config with `sudo tee`, then reload nginx. If nginx fails, fall back to Python HTTP server (see `references/nginx-templates.md`).
+The tool automatically handles:
+
+- Writing the correct nginx template (SPA try_files, SSR reverse proxy, or static)
+- Fixing `o+x` directory traverse permissions on the project path
+- Reloading nginx
+
+If the tool returns `ok: false`, nginx may not be installed — fall back to Python HTTP server (see `references/nginx-templates.md`).
 
 **Verify nginx is serving** — curl-check the app before proceeding to DevBridge:
 
@@ -610,7 +627,7 @@ curl -s -o /dev/null -w "nginx status: %{http_code}\n" http://localhost:<port>
 
 If the status code is not 2xx/3xx:
 
-- **403** — likely file permissions: run `chmod -R o+rX /workspace/<project>/<outputDir>` and re-test
+- **403** — run `chmod -R o+rX /workspace/<project>/<outputDir>` and re-test
 - **000 (connection refused)** — nginx not listening: check `sudo nginx -t` for config errors
 - **Other** — check nginx error log: `sudo tail -20 /var/log/nginx/error.log`
 

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -674,6 +674,98 @@ export async function uploadProjectWithSession(
   };
 }
 
+export async function deployNginx(
+  workspaceId,
+  { nginxType, port, project, outputDir, nodePort, publicPort },
+  username = 'root',
+  timeoutMs = 30000,
+) {
+  if (!workspaceId) {
+    throw new Error('sandbox deploy nginx: workspace_id is required.');
+  }
+  if (!nginxType || !port || !project || !outputDir) {
+    throw new Error('sandbox deploy nginx: nginxType, port, project, and outputDir are required.');
+  }
+
+  const projectPath = `/workspace/${project}`;
+  const outputPath = outputDir.startsWith('/') ? outputDir : `${projectPath}/${outputDir}`;
+
+  const templates = {
+    spa: `server {
+    listen ${port};
+    root ${outputPath};
+    index index.html;
+
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1h;
+        add_header Cache-Control "public, immutable";
+    }
+}`,
+    proxy: `server {
+    listen ${publicPort || port};
+    server_name _;
+
+    location / {
+        proxy_pass http://127.0.0.1:${nodePort};
+        proxy_http_version 1.1;
+        proxy_set_header Upgrade $http_upgrade;
+        proxy_set_header Connection 'upgrade';
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_cache_bypass $http_upgrade;
+        proxy_read_timeout 60s;
+    }
+}`,
+    static: `server {
+    listen ${port};
+    root ${outputPath};
+    index index.html;
+
+    location / {
+        autoindex off;
+    }
+
+    location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
+        expires 1h;
+        add_header Cache-Control "public, immutable";
+    }
+}`,
+  };
+
+  const config = templates[nginxType];
+  if (!config) {
+    throw new Error(`sandbox deploy nginx: unknown nginxType "${nginxType}". Must be one of: spa, proxy, static`);
+  }
+
+  const escapedConfig = config.replace(/'/g, "'\\''");
+  const cmd = [
+    `sudo mkdir -p /etc/nginx/conf.d`,
+    `sudo tee /etc/nginx/conf.d/app.conf > /dev/null << 'NGINX_EOF'`,
+    config,
+    `NGINX_EOF`,
+    `chmod -R o+rX "${projectPath}" 2>/dev/null || true`,
+    `find "${projectPath}" -type d -exec chmod o+x {} \\; 2>/dev/null || true`,
+    `sudo nginx -s reload 2>/dev/null || sudo nginx`,
+  ].join('\n');
+
+  const result = await execOneShot(workspaceId, cmd, username, timeoutMs);
+  return {
+    ok: result.exitCode === 0,
+    nginxType,
+    port: nginxType === 'proxy' ? publicPort || port : port,
+    outputPath,
+    projectPath,
+    exitCode: result.exitCode,
+    stdout: result.stdout,
+  };
+}
+
 export async function closeSession(workspaceId, username) {
   const key = `${workspaceId}:${username}`;
   const session = sessions.get(key);

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -743,7 +743,6 @@ export async function deployNginx(
     throw new Error(`sandbox deploy nginx: unknown nginxType "${nginxType}". Must be one of: spa, proxy, static`);
   }
 
-  const escapedConfig = config.replace(/'/g, "'\\''");
   const cmd = [
     `sudo mkdir -p /etc/nginx/conf.d`,
     `sudo tee /etc/nginx/conf.d/app.conf > /dev/null << 'NGINX_EOF'`,

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -16,6 +16,7 @@ import {
   closeSession,
   uploadFileWithSession,
   uploadProjectWithSession,
+  deployNginx,
   getCurrentWorkspaceId,
   setWorkspaceId,
 } from './sandbox/session-manager.mjs';
@@ -588,6 +589,38 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'huaweicloud_sandbox_deploy_nginx',
+    description:
+      'Deploy an nginx configuration on the sandbox and reload. Takes nginxType, port, project, outputDir from framework detection and writes the correct template (SPA try_files, SSR reverse proxy, or static). Also fixes directory traverse permissions on the project path. Use this instead of manually constructing nginx config — it handles permissions, template selection, and reload in one call.',
+    inputSchema: {
+      type: 'object',
+      required: ['nginx_type', 'port', 'project', 'output_dir'],
+      properties: {
+        nginx_type: {
+          type: 'string',
+          description:
+            'Nginx config type from framework detection: spa (try_files fallback for SPA/SSG/cross-platform), proxy (reverse proxy for SSR), or static (plain root for Hugo/Hexo).',
+          enum: ['spa', 'proxy', 'static'],
+        },
+        port: { type: 'number', description: 'Listen port (from framework detection).' },
+        project: { type: 'string', description: 'Project directory name under /workspace, e.g. movie-ticket.' },
+        output_dir: {
+          type: 'string',
+          description: 'Build output directory relative to /workspace/<project>, e.g. dist/build/h5.',
+        },
+        node_port: { type: 'number', description: 'Node.js app port for SSR (required when nginx_type=proxy).' },
+        public_port: { type: 'number', description: 'Public listen port for SSR proxy (optional, defaults to port).' },
+        workspace_id: {
+          type: 'string',
+          description:
+            'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.',
+        },
+        username: { type: 'string', description: 'Login username (default: root)' },
+        timeout_ms: { type: 'number', description: 'Execution timeout in milliseconds (default: 30000)' },
+      },
+    },
+  },
+  {
     name: 'huaweicloud_sandbox_check_user',
     description:
       'Check if the current user has completed real-name verification and signed the required agreements. Returns 200 {realnameVerified, agreementSigned} when all good; throws 403 HDKIT_NOT_REALNAME / HDKIT_NOT_AGREEMENT / HDKIT_NOT_REALNAME_AND_AGREEMENT to indicate what is missing. Never signs anything itself.',
@@ -823,6 +856,33 @@ export async function callTool(name, args = {}) {
           exclude: args.exclude,
           extract: args.extract,
         },
+      );
+    }
+    case 'huaweicloud_sandbox_deploy_nginx': {
+      if (!args.nginx_type || !args.port || !args.project || !args.output_dir) {
+        throw new Error('nginx_type, port, project, and output_dir are required.');
+      }
+      const sandboxWsId7 = args.workspace_id || getCurrentWorkspaceId();
+      if (!sandboxWsId7) {
+        throw new Error(
+          'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
+            'or set HW_WORKSPACE_ID environment variable before starting the agent.',
+        );
+      }
+      const sandboxUser7 = args.username || 'root';
+      const sandboxTimeout7 = args.timeout_ms || 30000;
+      return await deployNginx(
+        sandboxWsId7,
+        {
+          nginxType: args.nginx_type,
+          port: args.port,
+          project: args.project,
+          outputDir: args.output_dir,
+          nodePort: args.node_port,
+          publicPort: args.public_port,
+        },
+        sandboxUser7,
+        sandboxTimeout7,
       );
     }
     case 'huaweicloud_sandbox_check_user':


### PR DESCRIPTION
## Summary

Three sandbox deploy improvements from structured workflow testing:

### 1. QR code merged into expose flow (not standalone step)
- Merged Step 8 (Return URL) into Step 7 (Expose via DevBridge)
- QR generation is now conditional on \	ype === cross-platform\ from framework detection
- Added Deployment Completion Check table — cross-platform without QR = incomplete
- Added QR code trap to Critical Warnings

### 2. New \huaweicloud_sandbox_deploy_nginx\ tool
- Replaces manual nginx config construction (agent no longer reads nginx-templates.md)
- Accepts \
ginxType\/\port\/\project\/\outputDir\ from \detect_framework\
- Automatically selects correct template (spa/proxy/static), fixes permissions, reloads nginx
- Reduces agent token consumption and eliminates template mismatch errors

### 3. Permission auto-fix
- \upload_project\ already runs \chmod -R o+rX\ + \ind -type d -exec chmod o+x\ after extraction
- \deploy_nginx\ also fixes directory traverse permissions on the project path

### Files changed
- \src/sandbox/session-manager.mjs\: new \deployNginx()\ function
- \src/tools.mjs\: tool definition + handler + import
- \skills/huawei-sandbox/SKILL.md\: workflow updates, tool table, QR/checklist