### PR TITLE
feat(sandbox): deploy_check tool, deploy_nginx nextStep, REQUIRED markers

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -53,6 +53,7 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 | `huaweicloud_sandbox_upload_file`       | Upload a local file into the sandbox (chunked base64 write + md5 verify)    |
 | `huaweicloud_sandbox_upload_project`    | Upload a local project directory to sandbox (HTTP tunnel, tar.gz + extract) |
 | `huaweicloud_sandbox_deploy_nginx`      | Deploy nginx config with permissions fix and reload in one call             |
+| `huaweicloud_sandbox_deploy_check`      | Run deployment completeness check (nginx, DevBridge, URL, QR if needed)     |
 | `huaweicloud_sandbox_close_session`     | Close a persistent terminal session                                         |
 
 ### Tool Selection Guide
@@ -64,6 +65,8 @@ Domain expertise for Huawei Cloud Sandbox (DevStation) instances and workspace t
 | `curl`, health checks, quick tests | Either — `exec_one_shot` preferred | Stateless, fast                                              |
 | Server startup (background)        | `exec_with_session`                | Need to `nohup ... &` then check output in same session      |
 | Deployment scripts                 | `exec_one_shot+shot`               | Long script, fresh connection avoids session timeouts        |
+| nginx configuration                | `deploy_nginx`                     | Auto-generates correct template + permissions + reload       |
+| Deployment completeness check      | `deploy_check`                     | Verifies nginx, DevBridge, URL, QR before reporting success  |
 | Single file upload (<1MB)          | `upload_file`                      | Base64 chunked, reliable for small files                     |
 | Project directory upload (>1MB)    | `upload_project`                   | HTTP tunnel, much faster than base64 for multi-file projects |
 
@@ -633,12 +636,12 @@ If the status code is not 2xx/3xx:
 
 > If `curl` is unavailable, check port via `lsof -i :<port>` or `netstat -tlnp | grep :<port>`
 
-### Step 6: Start the App
+### Step 6: Start the App [REQUIRED]
 
 - **Static (SPA/SSG/cross-platform)**: nginx is already serving. Skip.
 - **SSR**: run `<serveCmd>` via `exec_with_session` to start the Node process in background.
 
-### Step 7: Expose via DevBridge
+### Step 7: Expose via DevBridge [REQUIRED — deployment incomplete without this]
 
 Follow the standard [Expose the deployed app](#expose-the-deployed-app-public-url) procedure. The app is already running on the detected port — only DevBridge tunnel setup is needed.
 
@@ -671,9 +674,30 @@ echo "Desktop URL: $TUNNEL_URL"
 手机扫码: <tunnel-url>/qr.png
 ```
 
-#### Deployment Completion Check
+#### Deployment Completion Check [REQUIRED]
 
-Before reporting success, verify these items based on the framework type from `detect_framework`:
+**Before reporting success, call `huaweicloud_sandbox_deploy_check`** to verify the deployment is complete:
+
+```json
+{
+  "port": <port>,
+  "project": "<dirname>",
+  "output_dir": "<outputDir>",
+  "framework_type": "<type>"
+}
+```
+
+The tool checks:
+
+- **nginx_serving** — nginx responds with 2xx/3xx on the app port
+- **output_dir** — build output directory exists and is non-empty
+- **devbridge_tunnel** — DevBridge tunnel is active
+- **tunnel_url_accessible** — tunnel URL returns 200/304
+- **qr_code** (cross-platform only) — QR image exists in output dir
+
+Returns `complete: true/false`, `score`, and `nextStep` to fix missing items.
+
+**If `complete` is false, follow `nextStep` to resolve before reporting success.** Do not return a deployment URL until `complete: true`.
 
 | Framework Type              | Must Return               |
 | --------------------------- | ------------------------- |
@@ -700,6 +724,8 @@ Before reporting success, verify these items based on the framework type from `d
 | CLI PATH                             | The installer only writes `~/.bashrc`; run `export PATH=$PATH:$HOME/.huawei/bin` in the session before using `devbridge`                                                                                                                |
 | Never install tunnel tooling locally | If the sandbox cannot install it, report a generic error and stop — installing on the developer's machine defeats sandbox deployment                                                                                                    |
 | Return the deployment URL            | Always hand the public URL from the host log to the developer as the final result                                                                                                                                                       |
+| Deploy is not just nginx             | Configuring nginx does NOT complete the deployment. Steps 7 (DevBridge expose) and deploy_check are REQUIRED — `deploy_nginx` returns `nextStep: expose_via_devbridge` as a reminder. Do not stop after nginx.                          |
+| Call deploy_check before success     | Always call `huaweicloud_sandbox_deploy_check` before reporting deployment success. A green nginx status does not mean the tunnel is accessible — verify end-to-end with the tool.                                                      |
 | Session state persists               | `exec_with_session` preserves `cd`, env vars, aliases between calls                                                                                                                                                                     |
 | Long commands prefer one-shot        | `exec_one_shot` creates a fresh connection per call — more stable for builds, installs, and scripts >30s. See [Tool Selection Guide](#tool-selection-guide).                                                                            |
 | Destructive commands blocked         | `rm -rf /`, `mkfs`, `dd if=`, fork bombs are denied by safety policy                                                                                                                                                                    |

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -754,6 +754,18 @@ export async function deployNginx(
   ].join('\n');
 
   const result = await execOneShot(workspaceId, cmd, username, timeoutMs);
+
+  let tunnelActive = false;
+  try {
+    const tunnelCheck = await execOneShot(
+      workspaceId,
+      'devbridge ls 2>/dev/null | grep -q "Tunnel URL" && echo "ACTIVE" || echo "INACTIVE"',
+      username,
+      10000,
+    );
+    tunnelActive = String(tunnelCheck.stdout || '').includes('ACTIVE');
+  } catch {}
+
   return {
     ok: result.exitCode === 0,
     nginxType,
@@ -762,6 +774,123 @@ export async function deployNginx(
     projectPath,
     exitCode: result.exitCode,
     stdout: result.stdout,
+    nextStep: 'expose_via_devbridge',
+    warning: !tunnelActive
+      ? 'No active DevBridge tunnel — deployment is incomplete. Proceed to Step 7 to expose the app.'
+      : undefined,
+  };
+}
+
+export async function deployCheck(
+  workspaceId,
+  { port, project, outputDir, frameworkType },
+  username = 'root',
+  timeoutMs = 30000,
+) {
+  if (!workspaceId) {
+    throw new Error('sandbox deploy check: workspace_id is required.');
+  }
+
+  const projectPath = `/workspace/${project}`;
+  const outputPath = outputDir.startsWith('/') ? outputDir : `${projectPath}/${outputDir}`;
+  const isCrossPlatform = frameworkType === 'cross-platform';
+
+  const checkScript = [
+    `echo "=== DEPLOY CHECK ==="`,
+    `PASS=0`,
+    `TOTAL=0`,
+    ``,
+    `TOTAL=$((TOTAL+1))`,
+    `if curl -s -o /dev/null -w "%{http_code}" http://localhost:${port} 2>/dev/null | grep -qE "^(2|3)"; then`,
+    `  echo "nginx_serving:PASS (port ${port})"`,
+    `  PASS=$((PASS+1))`,
+    `else`,
+    `  echo "nginx_serving:FAIL"`,
+    `fi`,
+    ``,
+    `TOTAL=$((TOTAL+1))`,
+    `if [ -d "${outputPath}" ] && ls -A "${outputPath}" 2>/dev/null | grep -q .; then`,
+    `  echo "output_dir:PASS (${outputPath})"`,
+    `  PASS=$((PASS+1))`,
+    `else`,
+    `  echo "output_dir:FAIL (${outputPath} empty or missing)"`,
+    `fi`,
+    ``,
+    `TOTAL=$((TOTAL+1))`,
+    `if devbridge ls 2>/dev/null | grep -q "Tunnel URL"; then`,
+    `  echo "devbridge_tunnel:PASS"`,
+    `  PASS=$((PASS+1))`,
+    `else`,
+    `  echo "devbridge_tunnel:FAIL"`,
+    `fi`,
+    ``,
+    `TOTAL=$((TOTAL+1))`,
+    `TUNNEL_URL=$(devbridge ls 2>/dev/null | grep -oP "Tunnel URL: \\Khttps://[^ ]+")`,
+    `if [ -n "$TUNNEL_URL" ]; then`,
+    `  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$TUNNEL_URL" 2>/dev/null || echo "000")`,
+    `  if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "304" ]; then`,
+    `    echo "tunnel_url_accessible:PASS ($TUNNEL_URL -> $HTTP_CODE)"`,
+    `    PASS=$((PASS+1))`,
+    `  else`,
+    `    echo "tunnel_url_accessible:FAIL ($TUNNEL_URL -> HTTP $HTTP_CODE)"`,
+    `  fi`,
+    `else`,
+    `  echo "tunnel_url_accessible:FAIL (no tunnel URL)"`,
+    `fi`,
+    ``,
+    `${
+      isCrossPlatform
+        ? `
+TOTAL=$((TOTAL+1))
+if [ -f "${outputPath}/qr.png" ]; then
+  echo "qr_code:PASS"
+  PASS=$((PASS+1))
+else
+  echo "qr_code:FAIL (cross-platform app missing QR code)"
+fi
+`
+        : ''
+    }`,
+    `echo "SCORE:\${PASS}/\${TOTAL}"`,
+    `[ "\${PASS}" = "\${TOTAL}" ] && echo "VERDICT:COMPLETE" || echo "VERDICT:INCOMPLETE"`,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  const result = await execOneShot(workspaceId, checkScript, username, timeoutMs);
+  const stdout = String(result.stdout || '');
+  const checks = {};
+  const lines = stdout.split('\n');
+  for (const line of lines) {
+    const m = line.match(/^(\w+):(PASS|FAIL)\b(.*)/);
+    if (m) checks[m[1]] = { status: m[2], detail: (m[3] || '').trim() };
+  }
+  const scoreMatch = stdout.match(/SCORE:(\d+)\/(\d+)/);
+  const complete = /VERDICT:COMPLETE/.test(stdout);
+
+  const missing = [];
+  if (!complete) {
+    for (const [key, val] of Object.entries(checks)) {
+      if (val.status === 'FAIL') missing.push(key);
+    }
+  }
+
+  return {
+    ok: true,
+    complete,
+    checkType: isCrossPlatform ? 'cross-platform' : 'standard',
+    checks,
+    score: scoreMatch ? { pass: parseInt(scoreMatch[1], 10), total: parseInt(scoreMatch[2], 10) } : null,
+    missingSteps: missing.length > 0 ? missing.join(', ') : undefined,
+    nextStep: !complete
+      ? missing.includes('devbridge_tunnel') || missing.includes('tunnel_url_accessible')
+        ? 'expose_via_devbridge'
+        : missing.includes('nginx_serving')
+          ? 'configure_nginx'
+          : missing.includes('qr_code')
+            ? 'generate_qr_code'
+            : 'review_checks'
+      : 'complete',
   };
 }
 

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -17,6 +17,7 @@ import {
   uploadFileWithSession,
   uploadProjectWithSession,
   deployNginx,
+  deployCheck,
   getCurrentWorkspaceId,
   setWorkspaceId,
 } from './sandbox/session-manager.mjs';
@@ -621,6 +622,35 @@ export const TOOL_DEFINITIONS = [
     },
   },
   {
+    name: 'huaweicloud_sandbox_deploy_check',
+    description:
+      'Run a deployment completeness check on the sandbox. Verifies nginx is serving, output directory exists, DevBridge tunnel is active and accessible, and QR code exists (cross-platform). Returns a score and nextStep to fix any missing items. Call this at the end of a deployment workflow to confirm everything is working before reporting success.',
+    inputSchema: {
+      type: 'object',
+      required: ['port', 'project', 'output_dir'],
+      properties: {
+        port: { type: 'number', description: 'App listen port (from framework detection).' },
+        project: { type: 'string', description: 'Project directory name under /workspace.' },
+        output_dir: {
+          type: 'string',
+          description: 'Build output directory relative to /workspace/<project>, e.g. dist/build/h5.',
+        },
+        framework_type: {
+          type: 'string',
+          description: 'Framework type from detect_framework. Set to cross-platform for QR code check.',
+          enum: ['spa', 'ssr', 'ssg', 'cross-platform', 'monorepo', 'static'],
+        },
+        workspace_id: {
+          type: 'string',
+          description:
+            'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.',
+        },
+        username: { type: 'string', description: 'Login username (default: root)' },
+        timeout_ms: { type: 'number', description: 'Execution timeout in milliseconds (default: 30000)' },
+      },
+    },
+  },
+  {
     name: 'huaweicloud_sandbox_check_user',
     description:
       'Check if the current user has completed real-name verification and signed the required agreements. Returns 200 {realnameVerified, agreementSigned} when all good; throws 403 HDKIT_NOT_REALNAME / HDKIT_NOT_AGREEMENT / HDKIT_NOT_REALNAME_AND_AGREEMENT to indicate what is missing. Never signs anything itself.',
@@ -883,6 +913,31 @@ export async function callTool(name, args = {}) {
         },
         sandboxUser7,
         sandboxTimeout7,
+      );
+    }
+    case 'huaweicloud_sandbox_deploy_check': {
+      if (!args.port || !args.project || !args.output_dir) {
+        throw new Error('port, project, and output_dir are required.');
+      }
+      const sandboxWsId8 = args.workspace_id || getCurrentWorkspaceId();
+      if (!sandboxWsId8) {
+        throw new Error(
+          'workspace_id is required. No sandbox connected — call huaweicloud_sandbox_connect first, ' +
+            'or set HW_WORKSPACE_ID environment variable before starting the agent.',
+        );
+      }
+      const sandboxUser8 = args.username || 'root';
+      const sandboxTimeout8 = args.timeout_ms || 30000;
+      return await deployCheck(
+        sandboxWsId8,
+        {
+          port: args.port,
+          project: args.project,
+          outputDir: args.output_dir,
+          frameworkType: args.framework_type,
+        },
+        sandboxUser8,
+        sandboxTimeout8,
       );
     }
     case 'huaweicloud_sandbox_check_user':


### PR DESCRIPTION
## Summary

Fixes a common deployment failure: agent reports success after nginx config but before DevBridge tunnel is created, leaving no public URL.

### 1. deploy_nginx return value enrichment
- Returns `nextStep: "expose_via_devbridge"` to explicitly indicate deployment is incomplete
- Auto-detects DevBridge tunnel state and returns `warning` if no active tunnel

### 2. New `huaweicloud_sandbox_deploy_check` tool
Validates deployment completeness end-to-end:
- `nginx_serving` — nginx responds with 2xx/3xx
- `output_dir` — build output exists and non-empty
- `devbridge_tunnel` — DevBridge tunnel is active
- `tunnel_url_accessible` — tunnel URL returns 200/304
- `qr_code` (cross-platform only) — QR image exists

Returns `complete: true/false`, `score`, `missingSteps`, and `nextStep` to guide remediation.

### 3. SKILL.md REQUIRED markers
- Step 6 (Start the App), Step 7 (Expose via DevBridge), Deployment Completion Check marked `[REQUIRED]`
- Added `deploy_check` to MCP Tools table and Tool Selection Guide
- Critical Warnings: added "Deploy is not just nginx" and "Call deploy_check before success" traps

### Files changed
- `src/sandbox/session-manager.mjs`: deployNginx nextStep/warning + new deployCheck()
- `src/tools.mjs`: tool definition + handler + import for deployCheck
- `skills/huawei-sandbox/SKILL.md`: REQUIRED markers, deploy_check docs, traps