### PR TITLE
fix(sandbox): git archive prefix, symlink resolve, permission hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 Help AI coding agents use Huawei Cloud safely and accurately — a single integration that gives agents cloud knowledge, CLI tooling, and safety guardrails.
 
-Supports OpenCode, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes, OpenClaw, and AtomCode.
+Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes, OpenClaw, and AtomCode.
 
 ## Prerequisites
 
@@ -33,6 +33,23 @@ npx --yes huaweicloud-devkit update --target opencode
 npx --yes huaweicloud-devkit uninstall --target opencode
 rm -rf ~/.npm/_npx/  # Linux/macOS only; Windows path TBD
 ```
+
+### Codex
+
+```bash
+npx --yes huaweicloud-devkit install --target codex
+```
+
+**Restart the Codex session** after installation.
+
+```bash
+npx --yes huaweicloud-devkit doctor --target codex
+npx --yes huaweicloud-devkit status --target codex
+npx --yes huaweicloud-devkit update --target codex
+npx --yes huaweicloud-devkit uninstall --target codex
+```
+
+> **Requires Codex CLI** — the `codex` command must be in PATH. If Codex is installed via WindowsApps (Microsoft Store), use `--target codex-desktop` instead. Run `codex --version` to verify CLI availability.
 
 ### CodeArts Agent
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -8,7 +8,7 @@
 
 帮助 AI 编码助手安全、准确地使用华为云——一站式集成云知识、CLI 工具和安全护栏。
 
-支持 OpenCode、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes、OpenClaw、AtomCode。
+支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes、OpenClaw、AtomCode。
 
 ## 前置条件
 
@@ -33,6 +33,23 @@ npx --yes huaweicloud-devkit update --target opencode
 npx --yes huaweicloud-devkit uninstall --target opencode
 rm -rf ~/.npm/_npx/  # 仅 Linux/macOS；Windows 路径待确认
 ```
+
+### Codex
+
+```bash
+npx --yes huaweicloud-devkit install --target codex
+```
+
+安装后**重启 Codex 会话**。
+
+```bash
+npx --yes huaweicloud-devkit doctor --target codex
+npx --yes huaweicloud-devkit status --target codex
+npx --yes huaweicloud-devkit update --target codex
+npx --yes huaweicloud-devkit uninstall --target codex
+```
+
+> **需要 Codex CLI** — `codex` 命令必须在 PATH 中。若 Codex 通过 WindowsApps（Microsoft Store）安装，请使用 `--target codex-desktop` 替代。运行 `codex --version` 验证 CLI 可用性。
 
 ### CodeArts Agent（码道）
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -567,13 +567,22 @@ Build failures fall into two categories. Handle them differently:
 
 #### 4d: Fix Build Output Permissions
 
-After a successful build, fix directory traverse permissions on the build output. Build tools (webpack, vite, uni-app) may create directories with restrictive permissions that block nginx from traversing to `index.html`:
+After a successful build, fix directory traverse permissions on the build output. Build tools (webpack, vite, uni-app) may create directories with restrictive permissions that block nginx from traversing to `index.html`. **Always resolve symlinks first** — `chmod` does not follow symlinks on Linux:
 
 ```bash
 # Fix directory execute permissions for nginx traverse
 REAL_OUTDIR="<outputDir>"   # use actual output dir from post-build verification
-find /workspace/<dirname> -path "*/${REAL_OUTDIR}" -prune -o -type d -exec chmod o+x {} \; 2>/dev/null || true
-chmod -R o+rX /workspace/<dirname> 2>/dev/null || true
+PROJECT_ROOT="/workspace/<dirname>"
+
+# Resolve symlinks — monorepo sub-apps may be symlinked
+REAL_ROOT=$(readlink -f "$PROJECT_ROOT" 2>/dev/null || echo "$PROJECT_ROOT")
+REL_OUTDIR=$(echo "$REAL_OUTDIR" | sed "s|$PROJECT_ROOT/||")
+REAL_OUTDIR="${REAL_ROOT}/${REL_OUTDIR}"
+
+# Fix permissions on resolved real paths
+find "$REAL_ROOT" -path "*/${REAL_OUTDIR}" -prune -o -type d -exec chmod o+x {} \; 2>/dev/null || true
+chmod -R o+rX "$REAL_ROOT" 2>/dev/null || true
+chmod -R +x "$REAL_ROOT/node_modules/.bin" 2>/dev/null || true
 ```
 
 This prevents the most common deployment failure: nginx 500 with `stat() ... Permission denied` caused by missing `o+x` on intermediate directories.

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -301,7 +301,15 @@ async function createTarGz(localDir, exclude = []) {
 
   const hasGit = existsSync(join(localDir, '.git'));
   if (hasGit) {
-    await execFileAsync('git', ['-C', localDir, 'archive', '--format=tar.gz', `--output=${archivePath}`, 'HEAD']);
+    await execFileAsync('git', [
+      '-C',
+      localDir,
+      'archive',
+      '--format=tar.gz',
+      `--prefix=${basename(localDir)}/`,
+      `--output=${archivePath}`,
+      'HEAD',
+    ]);
   } else {
     const args = [];
     for (const pattern of exclude) {
@@ -651,7 +659,15 @@ export async function uploadProjectWithSession(
     try {
       await execWithSession(
         workspaceId,
-        `chmod -R o+rX "${targetParentDir}/${projectName}" 2>/dev/null; find "${targetParentDir}/${projectName}" -type d -exec chmod o+x {} \\; 2>/dev/null || true`,
+        [
+          `REAL_PATH=$(readlink -f "${targetParentDir}/${projectName}" 2>/dev/null || echo "${targetParentDir}/${projectName}")`,
+          `if [ ! -d "$REAL_PATH" ] && [ -d "${targetParentDir}" ]; then`,
+          `  REAL_PATH="${targetParentDir}/${projectName}"`,
+          `fi`,
+          `chmod -R o+rX "$REAL_PATH" 2>/dev/null || true`,
+          `find "$REAL_PATH" -type d -exec chmod o+x {} \\; 2>/dev/null || true`,
+          `find "$REAL_PATH" -type f -path "*/node_modules/.bin/*" -exec chmod +x {} \\; 2>/dev/null || true`,
+        ].join('\n'),
         username,
         15000,
       );
@@ -689,6 +705,13 @@ export async function deployNginx(
 
   const projectPath = `/workspace/${project}`;
   const outputPath = outputDir.startsWith('/') ? outputDir : `${projectPath}/${outputDir}`;
+
+  const resolveScript = `REAL_PROJECT=$(readlink -f "${projectPath}" 2>/dev/null || echo "${projectPath}")
+REAL_OUTPUT="${outputPath}"
+if [ "\${REAL_PROJECT}" != "${projectPath}" ]; then
+  REL_OUTPUT=$(echo "${outputDir}" | sed "s|${projectPath}/||")
+  REAL_OUTPUT="\${REAL_PROJECT}/\${REL_OUTPUT}"
+fi`;
 
   const templates = {
     spa: `server {
@@ -744,12 +767,15 @@ export async function deployNginx(
   }
 
   const cmd = [
+    resolveScript,
     `sudo mkdir -p /etc/nginx/conf.d`,
     `sudo tee /etc/nginx/conf.d/app.conf > /dev/null << 'NGINX_EOF'`,
     config,
     `NGINX_EOF`,
-    `chmod -R o+rX "${projectPath}" 2>/dev/null || true`,
-    `find "${projectPath}" -type d -exec chmod o+x {} \\; 2>/dev/null || true`,
+    `# Resolve symlinks for chmod (chmod does not follow symlinks on Linux)`,
+    `chmod -R o+rX "$REAL_PROJECT" 2>/dev/null || true`,
+    `find "$REAL_PROJECT" -type d -exec chmod o+x {} \\; 2>/dev/null || true`,
+    `find "$REAL_PROJECT" -type f -path "*/node_modules/.bin/*" -exec chmod +x {} \\; 2>/dev/null || true`,
     `sudo nginx -s reload 2>/dev/null || sudo nginx`,
   ].join('\n');
 


### PR DESCRIPTION
## Summary

Fixes three sandbox toolchain issues discovered during monorepo deployment:

### P0: git archive missing directory prefix
`git archive --format=tar.gz HEAD` produces entries without a project root prefix (`package.json`, `src/index.js`). On extraction, files scatter flat across `workspace/` instead of landing in `workspace/projectName/`.
- **Fix**: add `--prefix=projectName/` to `git archive` command

### P0: upload_project post-extract symlink/chmod gap
`chmod` does not follow symlinks on Linux. Monorepo sub-app paths may be symlinks, leaving real directories with restrictive permissions — nginx returns 403.
- **Fix**: resolve symlinks with `readlink -f` before chmod; add `node_modules/.bin` executable fix

### P1: deploy\_nginx symlink chmod gap
Same symlink issue — `deploy_nginx` ran chmod on symlink paths without resolving to real paths.
- **Fix**: resolve `REAL_PROJECT` and `REAL_OUTPUT` with `readlink -f` before chmod in the shell script

### SKILL.md Step 4d
Added `readlink -f` symlink resolution example for manual permission fixes.

### Files changed
- `src/sandbox/session-manager.mjs`: 3 fixes (git archive prefix, upload chmod, deploy\_nginx chmod)
- `skills/huawei-sandbox/SKILL.md`: Step 4d symlink resolution example