### PR TITLE
fix(sandbox): nginx cleanup wildcard, try_files fix, reload pgrep, config_name

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -100,7 +100,7 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 
    ```bash
    # Remove stale nginx configs from previous deployments
-   sudo rm -f /etc/nginx/conf.d/app.conf /etc/nginx/conf.d/*.conf.bak 2>/dev/null
+   sudo rm -f /etc/nginx/conf.d/*.conf /etc/nginx/conf.d/*.conf.bak 2>/dev/null
    # Remove stale DevBridge tunnels
    devbridge delete-all 2>/dev/null || true
    # Reload nginx to apply

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -692,7 +692,7 @@ export async function uploadProjectWithSession(
 
 export async function deployNginx(
   workspaceId,
-  { nginxType, port, project, outputDir, nodePort, publicPort },
+  { nginxType, port, project, outputDir, nodePort, publicPort, configName },
   username = 'root',
   timeoutMs = 30000,
 ) {
@@ -720,7 +720,7 @@ fi`;
     index index.html;
 
     location / {
-        try_files $uri $uri/ /index.html;
+        try_files $uri /index.html;
     }
 
     location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2|ttf|eot)$ {
@@ -769,14 +769,14 @@ fi`;
   const cmd = [
     resolveScript,
     `sudo mkdir -p /etc/nginx/conf.d`,
-    `sudo tee /etc/nginx/conf.d/app.conf > /dev/null << 'NGINX_EOF'`,
+    `sudo tee /etc/nginx/conf.d/${configName || 'app'}.conf > /dev/null << 'NGINX_EOF'`,
     config,
     `NGINX_EOF`,
     `# Resolve symlinks for chmod (chmod does not follow symlinks on Linux)`,
     `chmod -R o+rX "$REAL_PROJECT" 2>/dev/null || true`,
     `find "$REAL_PROJECT" -type d -exec chmod o+x {} \\; 2>/dev/null || true`,
     `find "$REAL_PROJECT" -type f -path "*/node_modules/.bin/*" -exec chmod +x {} \\; 2>/dev/null || true`,
-    `sudo nginx -s reload 2>/dev/null || sudo nginx`,
+    `if pgrep -x nginx > /dev/null 2>&1; then sudo nginx -s reload 2>/dev/null; else sudo nginx; fi`,
   ].join('\n');
 
   const result = await execOneShot(workspaceId, cmd, username, timeoutMs);

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -611,6 +611,11 @@ export const TOOL_DEFINITIONS = [
         },
         node_port: { type: 'number', description: 'Node.js app port for SSR (required when nginx_type=proxy).' },
         public_port: { type: 'number', description: 'Public listen port for SSR proxy (optional, defaults to port).' },
+        config_name: {
+          type: 'string',
+          description:
+            'Config file name (without .conf suffix). Defaults to app. Use distinct names (e.g. admin, docs) for multi-app deployments to avoid config overwrites.',
+        },
         workspace_id: {
           type: 'string',
           description:
@@ -910,6 +915,7 @@ export async function callTool(name, args = {}) {
           outputDir: args.output_dir,
           nodePort: args.node_port,
           publicPort: args.public_port,
+          configName: args.config_name,
         },
         sandboxUser7,
         sandboxTimeout7,


### PR DESCRIPTION
## Summary

Fixes four nginx-related issues discovered during monorepo deployment testing.

### 1. Cleanup script only removes app.conf
`rm -f /etc/nginx/conf.d/app.conf` misses `admin.conf`, `docs.conf` from previous multi-app deployments, causing port conflicts.
- **Fix**: `rm -f /etc/nginx/conf.d/*.conf /etc/nginx/conf.d/*.conf.bak`

### 2. try_files redirect loop with `$uri/`
SPA template `try_files $uri $uri/ /index.html` + `index index.html` causes internal redirect cycle on some nginx versions (500).
- **Fix**: `try_files $uri /index.html` (removed `$uri/`)

### 3. nginx reload fails after master was killed
Port check kills nginx master, then `nginx -s reload` fails with "No such process".
- **Fix**: `pgrep -x nginx && nginx -s reload || nginx` (cold start fallback)

### 4. Multi-app nginx config overwrites
`deploy_nginx` always writes to `app.conf`, overwriting previous app configs.
- **Fix**: optional `config_name` parameter, writes to `{config_name}.conf` instead

### Files changed
- `skills/huawei-sandbox/SKILL.md`: cleanup wildcard
- `src/sandbox/session-manager.mjs`: try_files fix, reload pgrep, config_name
- `src/tools.mjs`: config_name schema + handler