### PR TITLE
fix: prevent MCP server silent exit on Windows when stdin is closed

### DIFF
--- a/plugins/huaweicloud-core/src/mcp-server.mjs
+++ b/plugins/huaweicloud-core/src/mcp-server.mjs
@@ -49,6 +49,13 @@ for (const base of [pluginRoot, packageRoot]) {
 let buffer = Buffer.alloc(0);
 let useContentLengthFraming = true;
 
+// Prevent process exit on Windows when stdin is closed by the parent process.
+// Node.js event loop exits when no active handles remain; stdin 'data' listener
+// is the only handle.  On Windows, Hermes may close the stdin pipe after the
+// initial handshake, causing the process to exit silently (code 0).
+// A lightweight non-unref timer ensures the loop stays alive.
+setInterval(() => {}, 3600000);
+
 stdin.on('data', (chunk) => {
   buffer = Buffer.concat([buffer, chunk]);
   readFrames();


### PR DESCRIPTION
## Problem

On Windows 11, MCP server exits silently (exit code 0) immediately after starting.

## Root Cause

The MCP server is purely event-driven. The only event-loop handle is stdin data listener. On Windows, Hermes closes the stdin pipe after the initial handshake. With no active handles, Node.js terminates the process.

## Impact

All 35 MCP tools are unavailable. Hermes log shows restart loop with 3-minute exponential backoff.

## Fix

Add a non-unref setInterval(1h) timer at module scope to keep the event loop alive.

## Tests

- npm run validate: 28 skills
- MCP server tests: 3/3 PASS