### PR TITLE
fix(sandbox): fix nginx config syntax error, harden SSR port separation, credential fallback

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/references/nginx-templates.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/references/nginx-templates.md
@@ -42,6 +42,7 @@ sudo tee /etc/nginx/conf.d/app.conf > /dev/null << 'NGINX_EOF'
 server {
     listen <publicPort>;
     server_name _;
+    large_client_header_buffers 4 32k;
 
     location / {
         proxy_pass http://127.0.0.1:<nodePort>;
@@ -54,6 +55,9 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
         proxy_cache_bypass $http_upgrade;
         proxy_read_timeout 60s;
+        proxy_buffer_size 128k;
+        proxy_buffers 4 256k;
+        proxy_busy_buffers_size 256k;
     }
 }
 NGINX_EOF

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -703,7 +703,9 @@ export async function deployNginx(
     throw new Error('sandbox deploy nginx: nginxType, port, project, and outputDir are required.');
   }
 
-  const effectiveNodePort = nginxType === 'proxy' ? nodePort || (publicPort || port) + 1 : undefined;
+  const listenPort = publicPort || port;
+  const effectiveNodePort =
+    nginxType === 'proxy' ? (nodePort && nodePort !== listenPort ? nodePort : listenPort + 1) : undefined;
 
   const projectPath = `/workspace/${project}`;
   const outputPath = outputDir.startsWith('/') ? outputDir : `${projectPath}/${outputDir}`;
@@ -731,8 +733,9 @@ fi`;
     }
 }`,
     proxy: `server {
-    listen ${publicPort || port};
+    listen ${listenPort};
     server_name _;
+    large_client_header_buffers 4 32k;
 
     location / {
         proxy_pass http://127.0.0.1:${effectiveNodePort};
@@ -748,7 +751,6 @@ fi`;
         proxy_buffer_size 128k;
         proxy_buffers 4 256k;
         proxy_busy_buffers_size 256k;
-        large_client_header_buffers 4 32k;
     }
 }`,
     static: `server {

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -962,7 +962,8 @@ export async function callTool(name, args = {}) {
       return connectResult;
     }
     case 'huaweicloud_sandbox_credentials': {
-      const credResult = await hdkitCredentials(args.session_id, args.dev_stage_id, args.enable_sts !== false);
+      const devStageId = args.dev_stage_id || getCurrentWorkspaceId();
+      const credResult = await hdkitCredentials(args.session_id, devStageId, args.enable_sts !== false);
       const sandboxWsIdCred = args.dev_stage_id || getCurrentWorkspaceId();
       if (sandboxWsIdCred) {
         try {


### PR DESCRIPTION
## Summary

Fixes 3 issues discovered during real CodeArts sandbox deployment testing with Next.js SSR.

### Issues fixed

**1. nginx config syntax error** — \large_client_header_buffers\ was placed inside \location / {}\ block in the previous fix. Nginx only allows this directive at \server {}\ or \http {}\ level. Moved to \server\ block after \server_name\.

**2. EADDRINUSE port still burning** — Previous \effectiveNodePort\ logic used \
odePort || ...\ fallback, which failed when the agent explicitly passed \
ode_port: 3000\ (same as port). Changed to: \
odePort && nodePort !== listenPort ? nodePort : listenPort + 1\ — even explicit equal values trigger auto-increment.

**3. credentials missing dev_stage_id** — \sandbox_credentials\ handler passed \rgs.dev_stage_id\ directly to API without fallback. Added \getCurrentWorkspaceId()\ as fallback (already set by \sandbox_connect\).

### Files changed
- \session-manager.mjs\ — move buffer, harden port logic
- \	ools.mjs\ — credential fallback
- \
ginx-templates.md\ — sync proxy template