### PR TITLE
fix(sandbox): graceful nginx restart with orphan worker recovery

### DIFF
--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -784,7 +784,7 @@ fi`;
     `chmod -R o+rX "$REAL_PROJECT" 2>/dev/null || true`,
     `find "$REAL_PROJECT" -type d -exec chmod o+x {} \\; 2>/dev/null || true`,
     `find "$REAL_PROJECT" -type f -path "*/node_modules/.bin/*" -exec chmod +x {} \\; 2>/dev/null || true`,
-    `if pgrep -x nginx > /dev/null 2>&1; then sudo nginx -s reload 2>/dev/null; else sudo nginx; fi`,
+    `if pgrep -x nginx > /dev/null 2>&1; then sudo nginx -s reload 2>/dev/null || { sudo killall -9 nginx 2>/dev/null; sleep 1; sudo nginx; }; else sudo nginx; fi`,
   ].join('\n');
 
   const result = await execOneShot(workspaceId, cmd, username, timeoutMs);


### PR DESCRIPTION
## Problem

deploy_nginx returns ok=false when orphan nginx workers from a previous session still occupy port 80 and the master process is already dead. nginx -s reload fails silently because there's no master to receive the signal.

## Fix

Restore reload-first strategy for multi-app compatibility (config_name parameter preserves multiple conf files), fall back to killall+restart only when reload fails — which means orphan workers are present.

\\\diff
- if pgrep -x nginx; then sudo nginx -s reload; else sudo nginx; fi
+ if pgrep -x nginx; then
+   sudo nginx -s reload || { sudo killall -9 nginx; sleep 1; sudo nginx; }
+ else
+   sudo nginx
+ fi
\\\

## Tested

- Taro H5 cross-platform deployment on sandbox (HCE OS aarch64)
- nginx config written correctly, reload failed due to orphan workers, killall+restart recovered