### PR TITLE
fix(hcloud): add runtime path discovery to handle MCP processes without shell PATH

### DIFF
--- a/plugins/huaweicloud-core/src/hcloud-cli.mjs
+++ b/plugins/huaweicloud-core/src/hcloud-cli.mjs
@@ -1,4 +1,7 @@
 import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
 
 import { classifyHcloudArgs, redactSecrets, assertAllowed } from './safety-policy.mjs';
 import { getProxySettings } from './proxy/proxy-config.mjs';
@@ -53,10 +56,19 @@ export async function runHcloud(args, options = {}) {
   throw new Error('Unreachable retry state.');
 }
 
+function discoverHcloudPath() {
+  if (process.env.HCLOUD_BIN && existsSync(process.env.HCLOUD_BIN)) return process.env.HCLOUD_BIN;
+  const candidates =
+    process.platform === 'win32'
+      ? [join(homedir(), 'hcloud', 'hcloud.exe')]
+      : [join(homedir(), '.local', 'bin', 'hcloud'), join(homedir(), 'hcloud', 'hcloud')];
+  return candidates.find((c) => existsSync(c)) || null;
+}
+
 function runHcloudOnce(plan, options) {
   const timeoutMs = options.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const forceKillAfterMs = options.forceKillAfterMs ?? DEFAULT_FORCE_KILL_AFTER_MS;
-  const executable = options.executable || options.env?.HCLOUD_BIN || process.env.HCLOUD_BIN || 'hcloud';
+  const executable = options.executable || options.env?.HCLOUD_BIN || discoverHcloudPath() || 'hcloud';
   const executableArgs = Array.isArray(options.executableArgs) ? options.executableArgs.map(String) : [];
   const cwd = options.cwd || undefined;
 


### PR DESCRIPTION
## Problem

MCP server processes started by agents (opencode, codearts, etc.) run as non-interactive shells and do not source \.bashrc\. This means \~/.local/bin\ is missing from PATH, and \spawn('hcloud')\ fails with ENOENT even when KooCLI is correctly installed.

The current resolution chain in \unHcloudOnce\:
\\\
options.executable → options.env.HCLOUD_BIN → process.env.HCLOUD_BIN → 'hcloud'
\\\
When the first three are unset, \'hcloud'\ relies on system PATH which lacks \~/.local/bin\.

## Fix

Add \discoverHcloudPath()\ that probes common KooCLI install locations at runtime:

- Linux/macOS: \~/.local/bin/hcloud\, \~/hcloud/hcloud\
- Windows: \~/hcloud/hcloud.exe\

New resolution chain:
\\\
options.executable → options.env.HCLOUD_BIN → discoverHcloudPath() → 'hcloud'
\\\

This mirrors the logic already in \setup-cli.mjs\'s \indHcloudBin()\, but operates at MCP runtime so it works even when \HCLOUD_BIN\ env var was not injected into the MCP config.