### PR TITLE
fix: batch fixes for deploy issues #370 #371 #367 #366 #365 #376

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -95,7 +95,7 @@ Setup is a **plugin-side preflight** — the developer should be asked a questio
 2. **Real-name verification only** (`HDKIT_NOT_REALNAME`): tell the developer once, "Huawei Cloud requires real-name verification before using the sandbox — please complete it in the Huawei Cloud console (实名认证)." and stop — do not retry `connect` in a loop
 3. **Sign agreement only** (`HDKIT_NOT_AGREEMENT`): **STOP and do NOT sign on your own.** Ask the developer: "Huawei Cloud sandbox requires signing the latest developer service agreement. May I sign it for you?" Then **wait for the developer to explicitly agree** (e.g. "签署" / "确认" / "sign it"). Only after explicit consent call `huaweicloud_sandbox_sign_agreement` and return its result (`signed`/`signedCount`) to the developer. **Never sign a legal agreement on the developer's behalf without their explicit, unambiguous consent.** Do not expose the underlying sandbox/DevBridge service as a separate entity the developer must understand or sign up for
 4. **Both missing** (`HDKIT_NOT_REALNAME_AND_AGREEMENT`): present **both** requirements together in one message — the real-name verification steps (console, step 2) **and** the agreement-signing request (step 3, wait for explicit consent) — so the developer can complete both at once
-5. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`
+5. **Connect**: `huaweicloud_sandbox_connect` — returns `session_id`, `dev_stage_id`, `connection_id`, `connection_address`. The `source` parameter identifies the calling agent (valid values: `'CLI'`, `'WEb'`, `'VSCODE'`, `'CURSO'`, `'WEBIDE'`, etc. — case-sensitive). The `git` parameter (with `repo_url`, `repo_name`, `target_path`) is accepted but does NOT auto-clone the repository — always clone manually.
 6. **Cleanup previous deployments** (after first connect to a sandbox): nginx configs, DevBridge tunnels, and stale web processes from previous deployments can cause port conflicts and quota errors. Run cleanup immediately after connect:
 
    ```bash
@@ -207,7 +207,7 @@ fi
 export PATH=$PATH:$HOME/.huawei/bin   # installer only writes ~/.bashrc; session shells do not re-source it
 ```
 
-**Login** (non-interactive; credentials injected by `huaweicloud_sandbox_credentials` are available at `/tmp/hw_creds.sh`):
+**Login** (non-interactive; credentials from `huaweicloud_sandbox_credentials` are available via `/tmp/hw_creds.sh`). If `source /tmp/hw_creds.sh` returns empty, the credentials injection has expired (sandbox session reconnection resets them) — re-run `huaweicloud_sandbox_credentials` first:
 
 ```bash
 source /tmp/hw_creds.sh 2>/dev/null
@@ -353,6 +353,16 @@ if command -v apt-get >/dev/null 2>&1; then echo "PKG_MGR=apt"; elif command -v 
 ```
 
 Use the detected `PKG_MGR` for all package installations below.
+
+**Architecture awareness**: the sandbox runs Linux aarch64 (ARM64). Native binaries built on x64 (Windows/macOS Intel) will not execute. Always install dependencies and build inside the sandbox. For projects with native addons (Taro `@swc/core`, Prisma, `esbuild`, `node-gyp`), local x64 pre-build + upload of `dist/` output is a viable alternative when sandbox builds fail.
+
+**GitCode SSL**: if `git clone` from GitCode fails with SSL certificate errors:
+
+```bash
+git config --global http.sslVerify false
+```
+
+Then retry the clone. This is a known sandbox environment limitation.
 
 #### 3b: Install nginx (before project upload)
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -427,6 +427,15 @@ echo "NODE_ENV=${NODE_ENV:-development}"
 
 This must run via `exec_with_session` so the exported variables persist for subsequent build commands in the same session.
 
+**Prisma / ORM compatibility**: Prisma CLI (`prisma generate`, `prisma db push`, `prisma migrate`) only reads `.env` by default, NOT `.env.local` or `.env.development`. If the project uses `.env.local` for `DATABASE_URL`, link it before any Prisma command:
+
+```bash
+# Prisma requires .env (not .env.local) — symlink if needed
+if [ -f .env.local ] && [ ! -f .env ]; then ln -sf .env.local .env 2>/dev/null || cp .env.local .env; fi
+# Then re-source
+set -a && source .env 2>/dev/null; set +a
+```
+
 #### 4b: Install Dependencies
 
 Use `exec_one_shot` for install (no shared state needed). Skip if `node_modules` already exists:
@@ -448,6 +457,18 @@ Node v24+ uses musl-based binaries on some sandbox images, which may break nativ
 - Try `npm install --force` or `npm install --legacy-peer-deps`
 - For rollup 4 projects, consider `npm install rollup@3` as fallback
 - If webpack/rollup native addon errors persist, add `--ignore-scripts` then manually rebuild: `npm rebuild`
+
+**Prisma / database initialization**: if `prisma/schema.prisma` exists in the project, initialize the database after install and before build. Prisma Client generation (`prisma generate`) is usually handled by `postinstall`, but `prisma db push` (SQLite) or `prisma migrate deploy` (PostgreSQL/MySQL) must be run manually:
+
+```bash
+cd /workspace/<dirname>
+if [ -f prisma/schema.prisma ]; then
+  echo "Prisma schema detected — initializing database..."
+  npx prisma db push --skip-generate 2>/dev/null || npx prisma migrate deploy 2>/dev/null || echo "WARN: skip db init"
+fi
+```
+
+> `--skip-generate` avoids redundant generation when `postinstall` already ran `prisma generate`. For SQLite, `DATABASE_URL="file:./dev.db"` must be set in `.env`/`.env.local` before this step.
 
 #### 4c: Build
 

--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -729,7 +729,21 @@ If the status code is not 2xx/3xx:
 ### Step 6: Start the App [REQUIRED]
 
 - **Static (SPA/SSG/cross-platform)**: nginx is already serving. Skip.
-- **SSR**: `PORT=<nodePort>` prefix is REQUIRED before `<serveCmd>`. nginx `proxy_pass` targets `<nodePort>`, not `<port>` — the two must differ. `deployNginx` returns `nodePort` in its result (defaults to `<port> + 1` for proxy type). Start with `PORT=<nodePort> <serveCmd>` via `exec_with_session` to run the Node process in background.
+- **SSR**: `PORT=<nodePort>` prefix is REQUIRED before `<serveCmd>`. nginx `proxy_pass` targets `<nodePort>`, not `<port>` — the two must differ. `deployNginx` returns `nodePort` in its result (defaults to `<port> + 1` for proxy type).
+
+  **Runtime environment variables**: SSR apps often need `DATABASE_URL`, `NEXTAUTH_URL`, `NEXTAUTH_SECRET`, etc. at runtime. Before starting, verify env vars from Step 4a are still loaded, and re-source `.env` if the shell session was reset:
+
+  ```bash
+  cd /workspace/<dirname>
+  # Re-load env vars (SSR apps need them at runtime, not just build time)
+  if [ -f .env ]; then set -a && source .env 2>/dev/null; set +a; echo "Loaded .env"; fi
+  if [ -f .env.local ]; then set -a && source .env.local 2>/dev/null; set +a; echo "Loaded .env.local"; fi
+  # Verify critical vars
+  echo "DATABASE_URL=${DATABASE_URL:-<NOT SET>}"
+  echo "NEXTAUTH_URL=${NEXTAUTH_URL:-<NOT SET>}"
+  ```
+
+  Then start with `PORT=<nodePort> <serveCmd>` via `exec_with_session` to run the Node process in background.
 
 ### Step 7: Expose via DevBridge [REQUIRED — deployment incomplete without this]
 

--- a/plugins/huaweicloud-core/src/detect-framework.mjs
+++ b/plugins/huaweicloud-core/src/detect-framework.mjs
@@ -157,10 +157,13 @@ function readPkg(projectPath) {
   }
 }
 
-function detectPackageManager(projectPath) {
+function detectPackageManager(projectPath, pkg) {
   if (existsSync(join(projectPath, 'pnpm-lock.yaml'))) return 'pnpm';
   if (existsSync(join(projectPath, 'yarn.lock'))) return 'yarn';
   if (existsSync(join(projectPath, 'package-lock.json'))) return 'npm';
+  if (existsSync(join(projectPath, 'bun.lockb'))) return 'bun';
+  const declared = (pkg?.packageManager || '').split('@')[0];
+  if (declared && ['pnpm', 'yarn', 'npm', 'bun'].includes(declared)) return declared;
   return 'npm';
 }
 
@@ -234,10 +237,24 @@ function frameworkResult(fw, pm, projectPath) {
   return patchCommands({ ...fw, packageManager: pm, rootDir: projectPath }, pm);
 }
 
+function readVitepressOutDir(projectPath) {
+  const configFiles = ['config.mts', 'config.ts', 'config.mjs', 'config.js'];
+  for (const cf of configFiles) {
+    const configPath = join(projectPath, '.vitepress', cf);
+    if (!existsSync(configPath)) continue;
+    try {
+      const content = readFileSync(configPath, 'utf8');
+      const match = content.match(/outDir\s*:\s*['"]([^'"]+)['"]/);
+      if (match) return match[1];
+    } catch {}
+  }
+  return null;
+}
+
 export function detectFramework(projectPath) {
   const pkg = readPkg(projectPath);
   const deps = collectDeps(pkg);
-  const pm = detectPackageManager(projectPath);
+  const pm = detectPackageManager(projectPath, pkg);
 
   if (
     existsSync(join(projectPath, 'pnpm-workspace.yaml')) ||
@@ -287,7 +304,12 @@ export function detectFramework(projectPath) {
   }
 
   if (existsSync(join(projectPath, '.vitepress'))) {
-    return frameworkResult(FRAMEWORKS.vitepress, pm, projectPath);
+    const outDir = readVitepressOutDir(projectPath);
+    return frameworkResult(
+      outDir ? { ...FRAMEWORKS.vitepress, outputDir: outDir } : FRAMEWORKS.vitepress,
+      pm,
+      projectPath,
+    );
   }
 
   if (

--- a/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/hdkitservice-api.mjs
@@ -7,6 +7,12 @@ const HDKIT_BASE_URL =
 async function hdkitRequest(method, path, body, timeoutMs = 300000) {
   const { ak, sk, securitytoken } = getCredentials();
 
+  if (!ak || !sk) {
+    throw new Error(
+      'Huawei Cloud credentials are not configured. ' +
+        'Run "npx huaweicloud-devkit auth init" or set HW_ACCESS_KEY/HW_SECRET_KEY.',
+    );
+  }
   const headers = {
     'Content-Type': 'application/json',
     'X-HW-AK': ak,
@@ -49,10 +55,12 @@ async function hdkitRequest(method, path, body, timeoutMs = 300000) {
   }
 
   if (!resp.ok) {
-    const err = new Error(data.message || `hdkitservice error: ${data.code || resp.status}`);
-    err.code = data.code;
+    const code = data.code || `HTTP_${resp.status}`;
+    const trace = data.traceId ? ` [trace: ${data.traceId}]` : '';
+    const err = new Error(`${code}: ${data.message || 'hdkitservice error'}${trace}`);
+    err.code = code;
     err.status = resp.status;
-    err.traceId = data.traceId; // 后端实际返回驼峰 traceId
+    err.traceId = data.traceId;
     throw err;
   }
 

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -791,6 +791,21 @@ fi`;
     throw new Error(`sandbox deploy nginx: unknown nginxType "${nginxType}". Must be one of: spa, proxy, static`);
   }
 
+  const targetPort = nginxType === 'proxy' ? publicPort || port : port;
+
+  let portWarning;
+  try {
+    const portCheck = await execOneShot(
+      workspaceId,
+      `ss -tlnp 2>/dev/null | grep -q ":${targetPort} " && echo "IN_USE" || echo "FREE"`,
+      username,
+      10000,
+    );
+    if (String(portCheck.stdout || '').includes('IN_USE')) {
+      portWarning = `Port ${targetPort} is in use — nginx may fail to bind. Use a different port or free it first (sudo fuser -k ${targetPort}/tcp).`;
+    }
+  } catch {}
+
   const cmd = [
     resolveScript,
     `sudo mkdir -p /etc/nginx/conf.d`,
@@ -820,16 +835,17 @@ fi`;
   return {
     ok: result.exitCode === 0,
     nginxType,
-    port: nginxType === 'proxy' ? publicPort || port : port,
+    port: targetPort,
     nodePort: effectiveNodePort || undefined,
     outputPath,
     projectPath,
     exitCode: result.exitCode,
     stdout: result.stdout,
     nextStep: 'expose_via_devbridge',
-    warning: !tunnelActive
-      ? 'No active DevBridge tunnel — deployment is incomplete. Proceed to Step 7 to expose the app.'
-      : undefined,
+    warning:
+      (!tunnelActive
+        ? 'No active DevBridge tunnel — deployment is incomplete. Proceed to Step 7 to expose the app.'
+        : portWarning) || undefined,
   };
 }
 

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -694,13 +694,30 @@ export async function deployNginx(
   workspaceId,
   { nginxType, port, project, outputDir, nodePort, publicPort, configName },
   username = 'root',
-  timeoutMs = 30000,
+  timeoutMs = 60000,
 ) {
   if (!workspaceId) {
     throw new Error('sandbox deploy nginx: workspace_id is required.');
   }
   if (!nginxType || !port || !project || !outputDir) {
     throw new Error('sandbox deploy nginx: nginxType, port, project, and outputDir are required.');
+  }
+
+  const nginxCheck = await execOneShot(
+    workspaceId,
+    'command -v nginx >/dev/null 2>&1 && echo "INSTALLED" || echo "MISSING"',
+    username,
+    10000,
+  );
+  if (!String(nginxCheck.stdout || '').includes('INSTALLED')) {
+    throw new Error(
+      'sandbox deploy nginx: nginx is not installed. Install it first:\n' +
+        '  Detect OS: source /etc/os-release && echo $ID\n' +
+        '  apt: sudo apt-get update -qq && sudo apt-get install -y -qq nginx\n' +
+        '  yum: sudo yum install -y nginx\n' +
+        '  dnf: sudo dnf install -y nginx\n' +
+        'Alternatively, skip nginx and use Python HTTP server (see nginx-templates.md).',
+    );
   }
 
   const listenPort = publicPort || port;

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -721,6 +721,32 @@ export async function deployNginx(
   }
 
   const listenPort = publicPort || port;
+  const basePort = nginxType === 'proxy' ? listenPort : port;
+
+  let targetPort = basePort;
+  let portWarning;
+  const maxPortAttempts = 10;
+  for (let offset = 0; offset < maxPortAttempts; offset += 1) {
+    targetPort = basePort + offset;
+    try {
+      const portCheck = await execOneShot(
+        workspaceId,
+        `ss -tlnp 2>/dev/null | grep -q ":${targetPort} " && echo "IN_USE" || echo "FREE"`,
+        username,
+        10000,
+      );
+      if (!String(portCheck.stdout || '').includes('IN_USE')) break;
+      if (offset === 0) {
+        portWarning = `Port ${basePort} is in use — auto-assigned port ${targetPort}`;
+      }
+    } catch {}
+    if (offset === maxPortAttempts - 1) {
+      throw new Error(
+        `sandbox deploy nginx: all ports ${basePort}-${basePort + maxPortAttempts - 1} are in use. Free a port and try again.`,
+      );
+    }
+  }
+
   const effectiveNodePort =
     nginxType === 'proxy' ? (nodePort && nodePort !== listenPort ? nodePort : listenPort + 1) : undefined;
 
@@ -736,7 +762,7 @@ fi`;
 
   const templates = {
     spa: `server {
-    listen ${port};
+    listen ${targetPort};
     root ${outputPath};
     index index.html;
 
@@ -771,7 +797,7 @@ fi`;
     }
 }`,
     static: `server {
-    listen ${port};
+    listen ${targetPort};
     root ${outputPath};
     index index.html;
 
@@ -790,21 +816,6 @@ fi`;
   if (!config) {
     throw new Error(`sandbox deploy nginx: unknown nginxType "${nginxType}". Must be one of: spa, proxy, static`);
   }
-
-  const targetPort = nginxType === 'proxy' ? publicPort || port : port;
-
-  let portWarning;
-  try {
-    const portCheck = await execOneShot(
-      workspaceId,
-      `ss -tlnp 2>/dev/null | grep -q ":${targetPort} " && echo "IN_USE" || echo "FREE"`,
-      username,
-      10000,
-    );
-    if (String(portCheck.stdout || '').includes('IN_USE')) {
-      portWarning = `Port ${targetPort} is in use — nginx may fail to bind. Use a different port or free it first (sudo fuser -k ${targetPort}/tcp).`;
-    }
-  } catch {}
 
   const cmd = [
     resolveScript,

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -552,7 +552,7 @@ export const TOOL_DEFINITIONS = [
             'Workspace ID from huaweicloud_sandbox_connect return value. Required - must be passed explicitly when HW_WORKSPACE_ID is not set.',
         },
         username: { type: 'string', description: 'Login username (default: root)' },
-        timeout_ms: { type: 'number', description: 'Per-command execution timeout in milliseconds (default: 120000)' },
+        timeout_ms: { type: 'number', description: 'Execution timeout in milliseconds (default: 60000)' },
       },
     },
   },
@@ -905,7 +905,7 @@ export async function callTool(name, args = {}) {
         );
       }
       const sandboxUser7 = args.username || 'root';
-      const sandboxTimeout7 = args.timeout_ms || 30000;
+      const sandboxTimeout7 = args.timeout_ms || 60000;
       return await deployNginx(
         sandboxWsId7,
         {

--- a/test/hdkitservice-api.test.mjs
+++ b/test/hdkitservice-api.test.mjs
@@ -28,7 +28,7 @@ test('hdkitservice connect parses backend traceId (camelCase) on error', async (
       (error) => error,
     );
     assert.ok(err, 'expected hdkitConnect to reject');
-    assert.equal(err.message, '服务内部错误');
+    assert.equal(err.message, 'HDKIT_INTERNAL: 服务内部错误 [trace: trace-123]');
     assert.equal(err.code, 'HDKIT_INTERNAL');
     assert.equal(err.status, 500);
     assert.equal(err.traceId, 'trace-123');


### PR DESCRIPTION
Fixes for 7 deploy issues. detect-framework: pnpm packageManager fallback, VitePress outDir detection. session-manager: nginx pre-check, timeout 30s-60s. hdkitservice-api: credential check + error code/traceId. SKILL.md: Prisma .env.local compat + db push.