### PR TITLE
feat: add codearts-work (CodeArts Space) agent target support

### DIFF
--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -3,7 +3,7 @@ import { join } from 'node:path';
 import { homedir } from 'node:os';
 import { spawnSync } from 'node:child_process';
 
-export const SUPPORTED_AGENT_TARGETS = ['opencode', 'codex', 'codex-desktop', 'codearts', 'workbuddy', 'dsh'];
+export const SUPPORTED_AGENT_TARGETS = ['opencode', 'codex', 'codex-desktop', 'codearts', 'codearts-work', 'workbuddy', 'dsh'];
 
 function baseHome() {
   return process.env.HUAWEICLOUD_HOME || homedir();
@@ -66,6 +66,12 @@ function codeartsRegistered() {
   });
 }
 
+function codeartsWorkRegistered() {
+  const path = join(baseHome(), '.codeartswork', 'mcp', 'mcp_settings.json');
+  const cfg = readJsonSafe(path);
+  return Boolean(cfg?.mcpServers?.['huaweicloud-devkit']);
+}
+
 function workbuddyRegistered() {
   const cfg = readJsonSafe(join(baseHome(), '.workbuddy', 'mcp.json'));
   return Boolean(cfg?.mcpServers?.['huaweicloud-devkit']);
@@ -97,6 +103,7 @@ export function getAgentRegistrationStatuses(target = 'all') {
     if (agent === 'codex-desktop') configured = codexDesktopRegistered();
     if (agent === 'codex') configured = codexCliRegistered();
     if (agent === 'codearts') configured = codeartsRegistered();
+    if (agent === 'codearts-work') configured = codeartsWorkRegistered();
     if (agent === 'workbuddy') configured = workbuddyRegistered();
     if (agent === 'dsh') configured = dshRegistered();
     result.agents[agent] = { configured };

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -78,6 +78,13 @@ export function resolveCredentials(options = {}) {
   let securityToken = process.env.HW_SECURITY_TOKEN;
   let region = process.env.HW_REGION || process.env.HUAWEICLOUD_REGION || '';
 
+  const codeartsCreds = readCodeArtsCredentials();
+  if (codeartsCreds) {
+    if (!ak && codeartsCreds.ak) ak = codeartsCreds.ak;
+    if (!sk && codeartsCreds.sk) sk = codeartsCreds.sk;
+    if (!region && codeartsCreds.region) region = codeartsCreds.region;
+  }
+
   const stored = readGlobalCredentials();
   if (stored) {
     if (!ak && stored.ak) ak = stored.ak;
@@ -92,4 +99,36 @@ export function resolveCredentials(options = {}) {
   }
 
   return { ak, sk, securityToken, region };
+}
+
+function readCodeArtsCredentials() {
+  const searchPaths = [
+    join(process.cwd(), '.codeartsdoer', 'mcp', 'mcp_settings.json'),
+    join(homedir(), '.codeartsdoer', 'mcp', 'mcp_settings.json'),
+    join(homedir(), '.codeartswork', 'mcp', 'mcp_settings.json'),
+  ];
+
+  for (const path of searchPaths) {
+    try {
+      if (!existsSync(path)) continue;
+      const config = JSON.parse(readFileSync(path, 'utf8'));
+      const server = config?.mcpServers?.['huaweicloud-devkit'];
+      if (!server?.env) continue;
+
+      const ak = server.env.HW_ACCESS_KEY;
+      const sk = server.env.HW_SECRET_KEY;
+      if (ak && sk) {
+        return {
+          ak,
+          sk,
+          securityToken: server.env.HW_SECURITY_TOKEN || '',
+          region: server.env.HW_REGION || server.env.HUAWEICLOUD_REGION || '',
+        };
+      }
+    } catch {
+      // mcp_settings.json missing or invalid — skip
+    }
+  }
+
+  return null;
 }

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -53,6 +53,11 @@ function codeartsProjectSkillsDir() { return join(codeartsProjectDir(), 'skills'
 function codeartsProjectMcpSettingsFile() { return join(codeartsProjectDir(), 'mcp', 'mcp_settings.json'); }
 function codeartsPluginsDir() { return join(homedir(), '.codeartsdoer', 'huaweicloud-plugins'); }
 
+// CodeArts Work (CodeArts Space) — user-level only
+function codeartsWorkSkillsDir() { return join(homedir(), '.codeartswork', 'skills'); }
+function codeartsWorkMcpSettingsFile() { return join(homedir(), '.codeartswork', 'mcp', 'mcp_settings.json'); }
+function codeartsWorkPluginsDir() { return join(homedir(), '.codeartswork', 'huaweicloud-plugins'); }
+
 function workbuddySkillsDir() { return join(homedir(), '.workbuddy', 'skills'); }
 function workbuddyMcpConfigFile() { return join(homedir(), '.workbuddy', 'mcp.json'); }
 function workbuddyPluginsDir() { return join(homedir(), '.workbuddy', 'huaweicloud-plugins'); }
@@ -648,6 +653,105 @@ function codeartsStatus() {
   }
 }
 
+// --- CodeArts Work (CodeArts Space) ---
+
+function registerCodeartsWorkMcp() {
+  const configPath = codeartsWorkMcpSettingsFile();
+  const mcpPath = join(codeartsWorkPluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
+  const env = { HUAWEICLOUD_AGENT_TOOLKIT_MODE: 'local' };
+  const hcloudBin = findHcloudBin();
+  if (hcloudBin) env.HCLOUD_BIN = hcloudBin.replace(/\\/g, '/');
+  let config = {};
+  if (existsSync(configPath)) {
+    try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch {
+      console.log(`  \x1b[33m[WARN]\x1b[0m Could not parse ${configPath}.`);
+      return;
+    }
+    const existing = config.mcpServers?.['huaweicloud-devkit'];
+    if (existing && existing.command === 'node' && Array.isArray(existing.args) && existing.args[0] === mcpPath && existing.timeout === 300000) {
+      console.log(`  MCP config unchanged: ${configPath}`);
+      return;
+    }
+  }
+  config.mcpServers = config.mcpServers || {};
+  config.mcpServers['huaweicloud-devkit'] = { command: 'node', args: [mcpPath], env, enabled: true, timeout: 300000 };
+  mkdirSync(dirname(configPath), { recursive: true });
+  writeFileSync(configPath, JSON.stringify(config, null, 2));
+  console.log(`  MCP config updated: ${configPath}`);
+}
+
+async function installCodeArtsWork() {
+  const skillsSrc = join(PLUGIN_ROOT, 'skills');
+  const srcDir = join(PLUGIN_ROOT, 'src');
+  const safetyDir = join(PLUGIN_ROOT, 'safety');
+  copyDir(skillsSrc, codeartsWorkSkillsDir());
+  console.log(`  Skills -> ${codeartsWorkSkillsDir()}`);
+  const pluginDest = codeartsWorkPluginsDir();
+  copyDir(srcDir, join(pluginDest, 'src'));
+  console.log(`  MCP Server -> ${join(pluginDest, 'src')}`);
+  copyDir(safetyDir, join(pluginDest, 'safety'));
+  console.log(`  Safety Policy -> ${join(pluginDest, 'safety')}`);
+  registerCodeartsWorkMcp();
+  installRuntimeDeps(pluginDest);
+}
+
+async function updateCodeArtsWork() {
+  const skillsSrc = join(PLUGIN_ROOT, 'skills');
+  const srcDir = join(PLUGIN_ROOT, 'src');
+  const safetyDir = join(PLUGIN_ROOT, 'safety');
+  const pluginDest = codeartsWorkPluginsDir();
+  copyDir(skillsSrc, codeartsWorkSkillsDir());
+  console.log(`  Skills updated -> ${codeartsWorkSkillsDir()}`);
+  copyDir(srcDir, join(pluginDest, 'src'));
+  console.log(`  MCP Server updated -> ${join(pluginDest, 'src')}`);
+  copyDir(safetyDir, join(pluginDest, 'safety'));
+  console.log(`  Safety Policy updated -> ${join(pluginDest, 'safety')}`);
+  registerCodeartsWorkMcp();
+  mkdirSync(pluginDest, { recursive: true });
+  writeFileSync(join(pluginDest, '.installed'), new Date().toISOString());
+  installRuntimeDeps(pluginDest);
+}
+
+function uninstallCodeArtsWork() {
+  const skillsDir = codeartsWorkSkillsDir();
+  if (existsSync(skillsDir)) {
+    let removed = 0;
+    for (const entry of readdirSync(skillsDir, { withFileTypes: true })) {
+      if (entry.name.startsWith('huawei')) { removeIfExists(join(skillsDir, entry.name)); removed++; }
+    }
+    if (removed > 0) console.log(`  Removed ${removed} skills`);
+  }
+  if (removeIfExists(codeartsWorkPluginsDir())) console.log('  Removed MCP server and safety policy');
+  const configPath = codeartsWorkMcpSettingsFile();
+  if (existsSync(configPath)) {
+    let config = {};
+    try { config = JSON.parse(readFileSync(configPath, 'utf8')); } catch {}
+    if (config.mcpServers?.['huaweicloud-devkit']) {
+      delete config.mcpServers['huaweicloud-devkit'];
+      if (Object.keys(config.mcpServers).length === 0) delete config.mcpServers;
+      writeFileSync(configPath, JSON.stringify(config, null, 2));
+      console.log(`  Config cleaned: ${configPath}`);
+    }
+  }
+}
+
+function codeartsWorkStatus() {
+  const pluginDir = codeartsWorkPluginsDir();
+  console.log(`  MCP Server: ${existsSync(join(pluginDir, 'src', 'mcp-server.mjs')) ? '\x1b[32mInstalled\x1b[0m' : '\x1b[31mNot installed\x1b[0m'}`);
+  console.log(`  Safety Policy: ${existsSync(join(pluginDir, 'safety', 'policy.json')) ? '\x1b[32mInstalled\x1b[0m' : '\x1b[31mNot installed\x1b[0m'}`);
+  let skillCount = 0;
+  if (existsSync(codeartsWorkSkillsDir())) {
+    skillCount = readdirSync(codeartsWorkSkillsDir(), { withFileTypes: true }).filter(d => d.isDirectory() && d.name.startsWith('huawei')).length;
+  }
+  console.log(`  Skills: ${skillCount > 0 ? `\x1b[32m${skillCount} installed\x1b[0m` : '\x1b[31mNot installed\x1b[0m'}`);
+  if (existsSync(codeartsWorkMcpSettingsFile())) {
+    try {
+      const config = JSON.parse(readFileSync(codeartsWorkMcpSettingsFile(), 'utf8'));
+      console.log(`  MCP config: ${config.mcpServers?.['huaweicloud-devkit'] ? '\x1b[32mConfigured\x1b[0m' : '\x1b[31mNot configured\x1b[0m'}`);
+    } catch { console.log(`  MCP config: \x1b[31mInvalid\x1b[0m`); }
+  }
+}
+
 // Returns true when the config file was written, false when it was already correct.
 function ensureWorkbuddyMcpConfig() {
   const configPath = workbuddyMcpConfigFile();
@@ -1052,6 +1156,7 @@ function parseTarget() {
   if (val === 'codex') return 'codex';
   if (val === 'codex-desktop') return 'codex-desktop';
   if (val === 'codearts') return 'codearts';
+  if (val === 'codearts-work') return 'codearts-work';
   if (val === 'workbuddy') return 'workbuddy';
   if (val === 'dsh') return 'dsh';
   if (val === 'all') return 'all';
@@ -1075,6 +1180,10 @@ async function cmdInstall() {
   if (target === 'codearts' || target === 'all') {
     console.log('\n[CodeArts]');
     await installCodeArts();
+  }
+  if (target === 'codearts-work' || target === 'all') {
+    console.log('\n[CodeArts Work]');
+    await installCodeArtsWork();
   }
   if (target === 'workbuddy' || target === 'all') {
     console.log('\n[WorkBuddy]');
@@ -1109,6 +1218,7 @@ async function cmdInstall() {
   }
   console.log(`\n\x1b[32mInstallation complete!\x1b[0m`);
   const appName = target === 'codearts' ? 'CodeArts'
+    : target === 'codearts-work' ? 'CodeArts Work'
     : target === 'codex-desktop' ? 'Codex Desktop'
     : target === 'codex' ? 'Codex'
     : target === 'workbuddy' ? 'WorkBuddy'
@@ -1137,6 +1247,7 @@ async function cmdInstall() {
   // Write install marker for doctor to detect
   const markerDir = target === 'dsh' ? dshPluginsDir()
     : target === 'codearts' ? codeartsPluginsDir()
+    : target === 'codearts-work' ? codeartsWorkPluginsDir()
     : target === 'workbuddy' ? workbuddyPluginsDir()
     : target === 'codex-desktop' ? codexDesktopPluginsDir()
     : opencodePluginsDir();
@@ -1147,6 +1258,9 @@ async function cmdInstall() {
   }
   if (target === 'codearts' || target === 'all') {
     console.log('Or describe your Huawei Cloud task in CodeArts');
+  }
+  if (target === 'codearts-work' || target === 'all') {
+    console.log('Or describe your Huawei Cloud task in CodeArts Work');
   }
   if (target === 'codex' || target === 'all') {
     console.log('Or mention @huaweicloud-core in Codex');
@@ -1171,6 +1285,10 @@ async function cmdUninstall() {
   if (target === 'codearts' || target === 'all') {
     console.log('\n[CodeArts]');
     uninstallCodeArts();
+  }
+  if (target === 'codearts-work' || target === 'all') {
+    console.log('\n[CodeArts Work]');
+    uninstallCodeArtsWork();
   }
   if (target === 'workbuddy' || target === 'all') {
     console.log('\n[WorkBuddy]');
@@ -1220,6 +1338,10 @@ async function cmdStatus() {
     console.log('\n[CodeArts]');
     codeartsStatus();
   }
+  if (target === 'codearts-work' || target === 'all') {
+    console.log('\n[CodeArts Work]');
+    codeartsWorkStatus();
+  }
   if (target === 'workbuddy' || target === 'all') {
     console.log('\n[WorkBuddy]');
     workbuddyStatus();
@@ -1259,16 +1381,19 @@ async function cmdDoctor() {
   const opencodePluginDir = opencodePluginsDir();
   const codexPluginDir = codexDesktopPluginsDir();
   const codeartsPluginDir = codeartsPluginsDir();
+  const codeartsWorkPluginDir = codeartsWorkPluginsDir();
   const workbuddyPluginDir = workbuddyPluginsDir();
   const dshPluginDir = dshPluginsDir();
   const mcpOk = existsSync(join(opencodePluginDir, 'src', 'mcp-server.mjs'))
     || existsSync(join(codexPluginDir, 'src', 'mcp-server.mjs'))
     || existsSync(join(codeartsPluginDir, 'src', 'mcp-server.mjs'))
+    || existsSync(join(codeartsWorkPluginDir, 'src', 'mcp-server.mjs'))
     || existsSync(join(workbuddyPluginDir, 'src', 'mcp-server.mjs'))
     || existsSync(join(dshPluginDir, 'src', 'mcp-server.mjs'));
   const mcpTarget = existsSync(join(opencodePluginDir, 'src', 'mcp-server.mjs')) ? 'OpenCode'
     : existsSync(join(codexPluginDir, 'src', 'mcp-server.mjs')) ? 'Codex Desktop'
     : existsSync(join(codeartsPluginDir, 'src', 'mcp-server.mjs')) ? 'CodeArts'
+    : existsSync(join(codeartsWorkPluginDir, 'src', 'mcp-server.mjs')) ? 'CodeArts Work'
     : existsSync(join(workbuddyPluginDir, 'src', 'mcp-server.mjs')) ? 'WorkBuddy'
     : existsSync(join(dshPluginDir, 'src', 'mcp-server.mjs')) ? 'DSH' : '';
   check('MCP server installed', mcpOk, 'Run: npx huaweicloud-devkit install');
@@ -1280,6 +1405,7 @@ async function cmdDoctor() {
   const safetyOk = existsSync(join(opencodePluginDir, 'safety', 'policy.json'))
     || existsSync(join(codexPluginDir, 'safety', 'policy.json'))
     || existsSync(join(codeartsPluginDir, 'safety', 'policy.json'))
+    || existsSync(join(codeartsWorkPluginDir, 'safety', 'policy.json'))
     || existsSync(join(workbuddyPluginDir, 'safety', 'policy.json'))
     || existsSync(join(dshPluginDir, 'safety', 'policy.json'));
   check('Safety policy installed', safetyOk, 'Run: npx huaweicloud-devkit install');
@@ -1306,6 +1432,13 @@ async function cmdDoctor() {
     try {
       const cfg = JSON.parse(readFileSync(codeartsCfg, 'utf8'));
       if (cfg.mcpServers && cfg.mcpServers['huaweicloud-devkit']) { mcpConfigured = true; mcpCfgTarget = 'CodeArts'; }
+    } catch {}
+  }
+  const codeartsWorkCfg = codeartsWorkMcpSettingsFile();
+  if (!mcpConfigured && existsSync(codeartsWorkCfg)) {
+    try {
+      const cfg = JSON.parse(readFileSync(codeartsWorkCfg, 'utf8'));
+      if (cfg.mcpServers && cfg.mcpServers['huaweicloud-devkit']) { mcpConfigured = true; mcpCfgTarget = 'CodeArts Work'; }
     } catch {}
   }
   const workbuddyCfg = workbuddyMcpConfigFile();
@@ -1348,7 +1481,7 @@ async function cmdDoctor() {
   }
 
   // Skills
-  const skillsOptions = [opencodeSkillsDir(), codexDesktopSkillsDir(), codeartsSkillsDir(), workbuddySkillsDir(), dshSkillsDir()];
+  const skillsOptions = [opencodeSkillsDir(), codexDesktopSkillsDir(), codeartsSkillsDir(), codeartsWorkSkillsDir(), workbuddySkillsDir(), dshSkillsDir()];
   let skillCount = 0, skillsDir = '', missingSkills = [];
   for (const dir of skillsOptions) {
     if (!existsSync(dir)) continue;
@@ -1393,6 +1526,7 @@ async function cmdDoctor() {
     { path: join(codexDesktopPluginsDir(), '.installed'), name: 'Codex Desktop' },
     { path: join(workbuddyPluginsDir(), '.installed'), name: 'WorkBuddy' },
     { path: join(codeartsPluginsDir(), '.installed'), name: 'CodeArts' },
+    { path: join(codeartsWorkPluginsDir(), '.installed'), name: 'CodeArts Work' },
     { path: join(dshPluginsDir(), '.installed'), name: 'DSH' },
   ];
   for (const marker of installedMarkers) {
@@ -1463,6 +1597,18 @@ async function cmdUpdate() {
     return;
   }
 
+  if (target === 'codearts-work') {
+    if (!existsSync(join(codeartsWorkPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
+      return;
+    }
+    console.log('[CodeArts Work]');
+    await updateCodeArtsWork();
+    console.log(`\n\x1b[32mUpdate complete.\x1b[0m`);
+    console.log(`\x1b[33mMCP 工具在重启 CodeArts Work 会话后才生效。\x1b[0m`);
+    return;
+  }
+
   if (target === 'workbuddy') {
     if (!existsSync(join(workbuddyPluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\x1b[33mNot installed. Use "install" command first.\x1b[0m');
@@ -1502,6 +1648,11 @@ async function cmdUpdate() {
     if (existsSync(join(codeartsPluginsDir(), 'src', 'mcp-server.mjs'))) {
       console.log('\n[CodeArts]');
       await updateCodeArts();
+      updatedAny = true;
+    }
+    if (existsSync(join(codeartsWorkPluginsDir(), 'src', 'mcp-server.mjs'))) {
+      console.log('\n[CodeArts Work]');
+      await updateCodeArtsWork();
       updatedAny = true;
     }
     if (existsSync(join(workbuddyPluginsDir(), 'src', 'mcp-server.mjs'))) {
@@ -1981,7 +2132,7 @@ async function main() {
     case '-h':
     default:
       console.log(BANNER);
-      console.log('Usage: npx huaweicloud-devkit <command> [--target <opencode|codex|codearts|workbuddy|dsh|all>]\n');
+      console.log('Usage: npx huaweicloud-devkit <command> [--target <opencode|codex|codearts|codearts-work|workbuddy|dsh|all>]\n');
       console.log('Commands:');
       console.log('  install      Install skills, MCP server, safety policy');
       console.log('  uninstall    Remove installed files');
@@ -1994,11 +2145,12 @@ async function main() {
       console.log('  proxy        Manage proxy config: init | show | clear');
       console.log('  help         Show this help');
       console.log('\nOptions:');
-      console.log('  --target     Target agent: opencode (default), codex, codearts, workbuddy, dsh, all');
+      console.log('  --target     Target agent: opencode (default), codex, codearts, codearts-work, workbuddy, dsh, all');
       console.log('\nExamples:');
       console.log('  npx huaweicloud-devkit install');
       console.log('  npx huaweicloud-devkit install --target codex');
       console.log('  npx huaweicloud-devkit install --target codearts');
+      console.log('  npx huaweicloud-devkit install --target codearts-work');
       console.log('  npx huaweicloud-devkit install --target workbuddy');
       console.log('  npx huaweicloud-devkit install --target dsh');
       console.log('  npx huaweicloud-devkit install --target all');

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -21,6 +21,10 @@ function codeartsSkillsDir() {
   const home = homedir();
   return join(home, '.codeartsdoer', 'skills');
 }
+function codeartsWorkSkillsDir() {
+  const home = homedir();
+  return join(home, '.codeartswork', 'skills');
+}
 function workbuddySkillsDir() {
   const home = homedir();
   return join(home, '.workbuddy', 'skills');
@@ -33,6 +37,7 @@ function resolveSkillsRoot() {
   if (existsSync(SKILLS_ROOT_DEV)) return SKILLS_ROOT_DEV;
   if (existsSync(dshSkillsDir())) return dshSkillsDir();
   if (existsSync(codeartsSkillsDir())) return codeartsSkillsDir();
+  if (existsSync(codeartsWorkSkillsDir())) return codeartsWorkSkillsDir();
   if (existsSync(opencodeSkillsDir())) return opencodeSkillsDir();
   if (existsSync(workbuddySkillsDir())) return workbuddySkillsDir();
   return SKILLS_ROOT_DEV;
@@ -300,7 +305,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        target: { type: 'string', description: 'Agent target to check: opencode, codex, codex-desktop, codearts, workbuddy, dsh, or all (default).' },
+        target: { type: 'string', description: 'Agent target to check: opencode, codex, codex-desktop, codearts, codearts-work, workbuddy, dsh, or all (default).' },
       },
     },
   },
@@ -310,7 +315,7 @@ export const TOOL_DEFINITIONS = [
     inputSchema: {
       type: 'object',
       properties: {
-        target: { type: 'string', description: 'Agent target to report after sync: opencode, codex, codex-desktop, codearts, workbuddy, dsh, or all (default).' },
+        target: { type: 'string', description: 'Agent target to report after sync: opencode, codex, codex-desktop, codearts, codearts-work, workbuddy, dsh, or all (default).' },
       },
     },
   },

--- a/test/codearts-adaptation.test.mjs
+++ b/test/codearts-adaptation.test.mjs
@@ -182,7 +182,7 @@ test('cli help documents the codearts target', () => {
   try {
     const res = runCli(home, cwd, ['help']);
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|all>/);
+    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|codearts-work\|workbuddy\|dsh\|all>/);
     assert.match(res.stdout, /install --target codearts/);
   } finally {
     rmSync(home, { recursive: true, force: true });

--- a/test/dsh-adaptation.test.mjs
+++ b/test/dsh-adaptation.test.mjs
@@ -205,7 +205,7 @@ test('cli help documents the dsh target', () => {
   try {
     const res = runCli(home, cwd, ['help']);
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|all>/);
+    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|codearts-work\|workbuddy\|dsh\|all>/);
     assert.match(res.stdout, /install --target dsh/);
   } finally {
     rmSync(home, { recursive: true, force: true });

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -221,6 +221,7 @@ test('setup-cli.mjs supports the codearts target end to end', () => {
   const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
   // parseTarget accepts codearts
   assert.match(setup, /if \(val === 'codearts'\) return 'codearts';/);
+  assert.match(setup, /if \(val === 'codearts-work'\) return 'codearts-work';/);
   // install / uninstall / status functions exist
   assert.match(setup, /async function installCodeArts\(\)/);
   assert.match(setup, /function uninstallCodeArts\(\)/);
@@ -244,11 +245,11 @@ test('setup-cli.mjs supports the codearts target end to end', () => {
   const branches = setup.match(/target === 'codearts' \|\| target === 'all'/g);
   assert.ok(branches && branches.length >= 3, `codearts dispatch branches: ${branches?.length}`);
   // .installed marker goes to the codearts plugins dir
-  assert.match(setup, /const markerDir = target === 'dsh' \? dshPluginsDir\(\)\s+: target === 'codearts' \? codeartsPluginsDir\(\)\s+: target === 'workbuddy' \? workbuddyPluginsDir\(\)\s+: target === 'codex-desktop' \? codexDesktopPluginsDir\(\)\s+: opencodePluginsDir\(\);/);
+  assert.match(setup, /const markerDir = target === 'dsh' \? dshPluginsDir\(\)\s+: target === 'codearts' \? codeartsPluginsDir\(\)\s+: target === 'codearts-work' \? codeartsWorkPluginsDir\(\)\s+: target === 'workbuddy' \? workbuddyPluginsDir\(\)\s+: target === 'codex-desktop' \? codexDesktopPluginsDir\(\)\s+: opencodePluginsDir\(\);/);
   // doctor checks the codearts skills dir alongside opencode
-  assert.match(setup, /const skillsOptions = \[opencodeSkillsDir\(\), codexDesktopSkillsDir\(\), codeartsSkillsDir\(\), workbuddySkillsDir\(\), dshSkillsDir\(\)\];/);
+  assert.match(setup, /const skillsOptions = \[opencodeSkillsDir\(\), codexDesktopSkillsDir\(\), codeartsSkillsDir\(\), codeartsWorkSkillsDir\(\), workbuddySkillsDir\(\), dshSkillsDir\(\)\];/);
   // help text documents the target
-  assert.match(setup, /--target <opencode\|codex\|codearts\|workbuddy\|dsh\|all>/);
+  assert.match(setup, /--target <opencode\|codex\|codearts\|codearts-work\|workbuddy\|dsh\|all>/);
   assert.match(setup, /install --target codearts/);
 });
 


### PR DESCRIPTION
## Summary

Add CodeArts Work (CodeArts Space, .codeartswork) as a supported agent target alongside CodeArts Doer (.codeartsdoer).

## Changes

- **agent-registration.mjs**: Add codearts-work to SUPPORTED_AGENT_TARGETS and codeartsWorkRegistered() check (user-level only, ~/.codeartswork/mcp/mcp_settings.json)
- **credentials.mjs**: Add .codeartswork to priority 3 credential resolution paths
- **setup-cli.mjs**: Add path functions, register/install/update/uninstall/status functions, and integration into all commands (install/uninstall/status/update/doctor/autoDetect/help)
- **tools.mjs**: Add codeartsWorkSkillsDir(), update auth_status/auth_sync descriptions
- **test/structure.test.mjs**: Update regex assertions to cover codearts-work

## Key Design Points

- User-level config only (no project-level .codeartswork)
- Reuses global credential vault at ~/.config/huaweicloud/credentials.json
- No impact on existing agents

## Usage

```bash
npx huaweicloud-devkit install --target codearts-work
```