### PR TITLE
fix(sandbox): default config_name to project name to prevent multi-app overwrites

### DIFF
--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -820,7 +820,7 @@ fi`;
   const cmd = [
     resolveScript,
     `sudo mkdir -p /etc/nginx/conf.d`,
-    `sudo tee /etc/nginx/conf.d/${configName || 'app'}.conf > /dev/null << 'NGINX_EOF'`,
+    `sudo tee /etc/nginx/conf.d/${configName || project}.conf > /dev/null << 'NGINX_EOF'`,
     config,
     `NGINX_EOF`,
     `# Resolve symlinks for chmod (chmod does not follow symlinks on Linux)`,

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -614,7 +614,7 @@ export const TOOL_DEFINITIONS = [
         config_name: {
           type: 'string',
           description:
-            'Config file name (without .conf suffix). Defaults to app. Use distinct names (e.g. admin, docs) for multi-app deployments to avoid config overwrites.',
+            'Config file name (without .conf suffix). Defaults to the project name, ensuring each project gets its own config. Override with distinct names (e.g. admin, docs) for sub-app deployments.',
         },
         workspace_id: {
           type: 'string',


### PR DESCRIPTION
deploy_nginx now defaults config_name to the project name instead of 'app', so each project automatically gets <project>.conf without manual config_name overrides.