### PR TITLE
feat: add codearts-work (CodeArts Space) agent target support

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -21,7 +21,7 @@ body:
     id: environment
     attributes:
       label: Environment
-      description: OS and agent (Codex / OpenCode / Claude Code / Cursor)
+      description: OS and agent (Codex / OpenCode / Claude Code / Cursor / CodeArts / CodeArts Work / WorkBuddy / DSH)
       placeholder: 'e.g. Windows 11, Codex 0.4'
     validations:
       required: true

--- a/README.md
+++ b/README.md
@@ -68,6 +68,23 @@ npx --yes huaweicloud-devkit uninstall --target codearts
 
 > **Sandbox mode**: CodeArts defaults to sandbox mode which blocks KooCLI. `install-hcloud` detects this and shows how to resolve it — install KooCLI outside the sandbox terminal, or disable sandbox mode in CodeArts settings (Settings → Chats → Agents Terminal Command Running Mode → Auto Running).
 
+### CodeArts Work
+
+```bash
+npx --yes huaweicloud-devkit install --target codearts-work
+```
+
+**Restart the session** after installation.
+
+```bash
+npx --yes huaweicloud-devkit doctor --target codearts-work
+npx --yes huaweicloud-devkit status --target codearts-work
+npx --yes huaweicloud-devkit update --target codearts-work
+npx --yes huaweicloud-devkit uninstall --target codearts-work
+```
+
+> **CodeArts Work** (CodeArts Space, appId: `com.codearts.work`) uses user-level config at `%USERPROFILE%\.codeartswork\`. No project-level `.codeartswork` directory is created.
+
 ### WorkBuddy
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -68,6 +68,23 @@ npx --yes huaweicloud-devkit uninstall --target codearts
 
 > **沙箱模式**：码道默认沙箱模式会阻止 KooCLI 运行。`install-hcloud` 自动检测并给出指引——请在码道外终端安装使用 KooCLI，或在码道设置中关闭沙箱模式（设置 → 对话流 → 智能体 终端命令运行模式 → 自动运行）。
 
+### CodeArts Work（码道工作空间）
+
+```bash
+npx --yes huaweicloud-devkit install --target codearts-work
+```
+
+安装后**重启会话**。
+
+```bash
+npx --yes huaweicloud-devkit doctor --target codearts-work
+npx --yes huaweicloud-devkit status --target codearts-work
+npx --yes huaweicloud-devkit update --target codearts-work
+npx --yes huaweicloud-devkit uninstall --target codearts-work
+```
+
+> **CodeArts Work**（工作空间，appId: `com.codearts.work`）使用用户级配置 `%USERPROFILE%\.codeartswork\`，不创建项目级目录。
+
 ### WorkBuddy
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -49,6 +49,8 @@
     "agent",
     "codex",
     "opencode",
+    "codearts",
+    "codearts-work",
     "officeace",
     "office-claw",
     "workbuddy",

--- a/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
@@ -125,13 +125,13 @@ hcloud <Service> <Op> --cli-debug=true
 
 Credentials are resolved in this order (highest priority first):
 
-| Priority | Source                  | Mechanism                                                  | Persistence                     |
-| -------- | ----------------------- | ---------------------------------------------------------- | ------------------------------- |
-| 1        | Runtime credentials     | `huaweicloud_auth_init` tool                               | Memory (cleared on MCP restart) |
-| 2        | Environment variables   | `HW_ACCESS_KEY` / `HW_SECRET_KEY`                          | MCP process lifetime            |
-| 3        | CodeArts project config | `.codeartsdoer/mcp/mcp_settings.json` (project, then user) | File                            |
-| 4        | Global config file      | `~/.config/huaweicloud/credentials.json`                   | Permanent                       |
-| 5        | KooCLI profile          | `~/.hcloud/config.json` (KooCLI only)                      | Permanent                       |
+| Priority | Source                   | Mechanism                                                                                              | Persistence                     |
+| -------- | ------------------------ | ------------------------------------------------------------------------------------------------------ | ------------------------------- |
+| 1        | Runtime credentials      | `huaweicloud_auth_init` tool                                                                           | Memory (cleared on MCP restart) |
+| 2        | Environment variables    | `HW_ACCESS_KEY` / `HW_SECRET_KEY`                                                                      | MCP process lifetime            |
+| 3        | CodeArts / CodeArts Work | `.codeartsdoer/mcp/mcp_settings.json` (project → user) or `.codeartswork/mcp/mcp_settings.json` (user) | File                            |
+| 4        | Global config file       | `~/.config/huaweicloud/credentials.json`                                                               | Permanent                       |
+| 5        | KooCLI profile           | `~/.hcloud/config.json` (KooCLI only)                                                                  | Permanent                       |
 
 When switching accounts within the same Agent session, use `huaweicloud_auth_init` to set runtime credentials. This overrides all other sources for the current MCP process.
 

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -2867,17 +2867,19 @@ async function cmdDoctor() {
       ? 'Codex Desktop'
       : existsSync(join(codeartsPluginDir, 'src', 'mcp-server.mjs'))
         ? 'CodeArts'
-        : existsSync(join(workbuddyPluginDir, 'src', 'mcp-server.mjs'))
-          ? 'WorkBuddy'
-          : existsSync(join(dshPluginDir, 'src', 'mcp-server.mjs'))
-            ? 'DSH'
-            : existsSync(join(officeacePluginDir, 'src', 'mcp-server.mjs'))
-              ? 'OfficeAce'
-              : existsSync(join(hermesPluginDir, 'src', 'mcp-server.mjs'))
-                ? 'Hermes Agent'
-                : existsSync(join(atomcodePluginDir, 'src', 'mcp-server.mjs'))
-                  ? 'AtomCode'
-                  : '';
+        : existsSync(join(codeartsWorkPluginDir, 'src', 'mcp-server.mjs'))
+          ? 'CodeArts Work'
+          : existsSync(join(workbuddyPluginDir, 'src', 'mcp-server.mjs'))
+            ? 'WorkBuddy'
+            : existsSync(join(dshPluginDir, 'src', 'mcp-server.mjs'))
+              ? 'DSH'
+              : existsSync(join(officeacePluginDir, 'src', 'mcp-server.mjs'))
+                ? 'OfficeAce'
+                : existsSync(join(hermesPluginDir, 'src', 'mcp-server.mjs'))
+                  ? 'Hermes Agent'
+                  : existsSync(join(atomcodePluginDir, 'src', 'mcp-server.mjs'))
+                    ? 'AtomCode'
+                    : '';
   check('MCP server installed', mcpOk, 'Run: npx huaweicloud-devkit install');
 
   if (mcpOk) {
@@ -2888,6 +2890,7 @@ async function cmdDoctor() {
     opencodePluginDir,
     codexPluginDir,
     codeartsPluginDir,
+    codeartsWorkPluginDir,
     workbuddyPluginDir,
     dshPluginDir,
     officeacePluginDir,
@@ -2938,6 +2941,16 @@ async function cmdDoctor() {
       if (cfg.mcpServers && cfg.mcpServers['huaweicloud-devkit']) {
         mcpConfigured = true;
         mcpCfgTarget = 'CodeArts';
+      }
+    } catch {}
+  }
+  const codeartsWorkCfg = codeartsWorkMcpSettingsFile();
+  if (!mcpConfigured && existsSync(codeartsWorkCfg)) {
+    try {
+      const cfg = JSON.parse(readFileSync(codeartsWorkCfg, 'utf8'));
+      if (cfg.mcpServers && cfg.mcpServers['huaweicloud-devkit']) {
+        mcpConfigured = true;
+        mcpCfgTarget = 'CodeArts Work';
       }
     } catch {}
   }


### PR DESCRIPTION
Add CodeArts Work (CodeArts Space) as a new agent target.

All tests pass. doctor now correctly checks undici, MCP config, and mcpTarget for codearts-work.