### PR TITLE
docs: add Huawei Cloud npm mirror recommendation for China users

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,14 @@ Supports OpenCode, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce,
 
 - Node.js >= 22
 
+> **China mainland users**: If you experience slow downloads or connection issues with the default npm registry, configure the Huawei Cloud npm mirror:
+>
+> ```bash
+> npm config set registry https://mirrors.huaweicloud.com/repository/npm/
+> ```
+>
+> Restore the default registry: `npm config delete registry`
+
 ## Quick Start
 
 > If `--target` is omitted, the installer auto-detects agents on your machine. When multiple agents are detected, **all of them** will be installed. Specify `--target` to control which agent receives the install.

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -14,6 +14,14 @@
 
 - Node.js >= 22
 
+> **国内用户**：使用默认 npm 镜像时可能遇到下载缓慢或连接失败的问题，建议配置华为云 npm 镜像：
+>
+> ```bash
+> npm config set registry https://mirrors.huaweicloud.com/repository/npm/
+> ```
+>
+> 恢复默认镜像：`npm config delete registry`
+
 ## 快速开始
 
 > 省略 `--target` 时，安装器会自动检测机器上的 agent，检测到多个时**全部安装**。建议始终指定 `--target` 以明确安装目标。


### PR DESCRIPTION
Cherry-pick of #756affe to main branch.\n\nAdd npm mirror configuration tip in both README.md and README.zh-CN.md under Prerequisites section.