### PR TITLE
fix(waf-aad): correct invalid AAD and WAF CLI operations in skill (#356)

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-waf-aad/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-waf-aad/SKILL.md
@@ -29,8 +29,8 @@ Domain expertise for WAF and Anti-DDoS. Covers WAF policy/rules, AAD protection,
 
 | Task                | Operation                                                       |
 | ------------------- | --------------------------------------------------------------- |
-| List WAF instances  | `ListInstances --cli-region=<r> --project_id=<p>`               |
-| List policies       | `ListPolicies --cli-region=<r> --project_id=<p>`                |
+| List WAF instances  | `ListCompositeHosts --cli-region=<r> --project_id=<p>`          |
+| List policies       | `ListPolicy --cli-region=<r> --project_id=<p>`                  |
 | Create custom rule  | `BatchCreateCustomRule --cli-region=<r> --project_id=<p>`       |
 | Create IP blacklist | `BatchCreateWhiteblackipRule --cli-region=<r> --project_id=<p>` |
 | Create CC rule      | `BatchCreateCcRule --cli-region=<r> --project_id=<p>`           |
@@ -39,8 +39,11 @@ Domain expertise for WAF and Anti-DDoS. Covers WAF policy/rules, AAD protection,
 ### AAD
 
 ```bash
-hcloud AAD ListInstances --cli-region=<r> --project_id=<p>
-hcloud AAD CreateInstance --cli-region=<r> --project_id=<p>
+# List AAD instances (requires --cli-region=cn-north-4 or ap-southeast-1)
+hcloud AAD ListInstance --cli-region=<r> --project_id=<p>
+
+# List DDoS attack events
+hcloud AAD ListDDoSAttackEvent --cli-region=<r> --project_id=<p>
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

Fix issue #356: Two AAD operations are invalid, and additionally two WAF operations in the same skill file are also incorrect.

## Changes

### AAD
- `ListInstances` -> `ListInstance` (ListInstances does not exist in KooCLI)
- Removed `CreateInstance` (operation does not exist)
- Added `ListDDoSAttackEvent` as replacement workflow

### WAF (discovered during fix)
- `ListInstances` -> `ListCompositeHosts` (ListInstances does not exist for WAF)
- `ListPolicies` -> `ListPolicy` (ListPolicies does not exist)

## Verification

All operations verified with `hcloud --help` on KooCLI v7.2.12:

```
hcloud AAD ListInstance --help              ✓
hcloud AAD ListDDoSAttackEvent --help       ✓
hcloud WAF ListCompositeHosts --help        ✓
hcloud WAF ListPolicy --help                ✓
```

Closes #356