### PR TITLE
fix(iam): correct 8 invalid CLI operations and parameters in skill (#354)

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-iam/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-iam/SKILL.md
@@ -42,14 +42,14 @@ Domain expertise for Huawei Cloud Identity and Access Management (IAM). Covers u
 
 ## Common Workflows
 
-| Task                     | Command                                                                                        | Steps                         |
-| ------------------------ | ---------------------------------------------------------------------------------------------- | ----------------------------- |
-| List users               | hcloud IAM ListUsers                                                                           | references/iam-ops.md         |
-| Create group             | hcloud IAM CreateGroup --group.name=<name>                                                     | references/iam-ops.md         |
-| Create custom policy     | hcloud IAM CreateCustomPolicy --policy.name=<n> --policy.document=<json>                       | references/policy-examples.md |
-| Create agency            | hcloud IAM CreateAgency --agency.name=<n> --agency.domain_id=<id> --agency.trust_policy=<json> | references/agency.md          |
-| Get temporary credential | hcloud STS GetTemporaryCredential --agency_name=<n> --domain_id=<id> --duration_seconds=3600   | references/sts.md             |
-| Attach policy            | hcloud IAM AttachGroupPolicy --group_id=<id> --policy_id=<id>                                  | references/iam-ops.md         |
+| Task                     | Command                                                                                                                     | Steps                         |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------- | ----------------------------- |
+| List users               | hcloud IAM KeystoneListUsers --cli-region=<r>                                                                               | references/iam-ops.md         |
+| Create group             | hcloud IAM CreateGroupV5 --group_name=<name>                                                                                | references/iam-ops.md         |
+| Create custom policy     | hcloud IAM CreateCloudServiceCustomPolicy --role.display_name=<n> --role.type=<type> --role.policy.Statement.1.Effect=Allow | references/policy-examples.md |
+| Create agency            | hcloud IAM CreateAgency --agency.name=<n> --agency.domain_id=<id> --agency.trust_domain_name=<domain>                       | references/agency.md          |
+| Get temporary credential | hcloud STS AssumeAgency --agency_urn=<urn> --agency_session_name=<n> --duration_seconds=3600                                | references/sts.md             |
+| Attach policy to group   | hcloud IAM AttachGroupPolicyV5 --group_id=<id> --policy_id=<id>                                                             | references/iam-ops.md         |
 
 ## Policy Examples (Least Privilege)
 
@@ -88,10 +88,10 @@ FunctionGraph needs an agency to access VPC resources (RDS, DCS, etc.):
 
 ```bash
 # 1. Create agency with FunctionGraph trust
-hcloud IAM CreateAgency --agency_name=<name> --trust_domain_name=functiongraph
+hcloud IAM CreateAgency --agency.name=<name> --agency.trust_domain_name=functiongraph
 
-# 2. Attach VPC Administrator role
-hcloud IAM GrantRoleToAgency --agency_name=<name> --role_id=<role-id>
+# 2. Grant role to agency
+hcloud IAM AssociateAgencyWithDomainPermission --agency_id=<id> --role_id=<role-id>
 
 # 3. Use in CreateFunction
 hcloud FunctionGraph CreateFunction ... --app_xrole=<agency-name>


### PR DESCRIPTION
## Summary

Fix issue #354: 8 CLI operations and parameters in the IAM skill are incorrect per KooCLI v7.2.12.

## Changes

### Operation name fixes

| # | Original (broken) | Corrected | KooCLI Service |
|---|---|---|---|
| 1 | `ListUsers` | `KeystoneListUsers` | IAM |
| 2 | `CreateGroup` | `CreateGroupV5` | IAM |
| 3 | `CreateCustomPolicy` | `CreateCloudServiceCustomPolicy` | IAM |
| 4 | `GrantRoleToAgency` | `AssociateAgencyWithDomainPermission` | IAM |
| 5 | `AttachGroupPolicy` | `AttachGroupPolicyV5` | IAM |
| 6 | `GetTemporaryCredential` | `AssumeAgency` | STS |

### Parameter fixes

| # | Original parameter | Corrected |
|---|---|---|
| 7 | `--agency.trust_policy=<json>` | `--agency.trust_domain_name=<domain>` (trust_policy param does not exist) |
| 8 | `--agency_name=<n>`, `--trust_domain_name=...` | `--agency.name=<n>`, `--agency.trust_domain_name=...` (KooCLI 7.x dot notation) |
| | `--agency_name` in GrantRoleToAgency | `--agency_id=<id>` in AssociateAgencyWithDomainPermission |
| | `--group.name` in CreateGroup | `--group_name` in CreateGroupV5 |
| | `--domain_id` in STS GetTemporaryCredential | `--agency_urn` + `--agency_session_name` in STS AssumeAgency |

## Verification

All 8 operations verified with `hcloud --help` on KooCLI v7.2.12.

Closes #354