### PR TITLE
fix(sandbox): use valid devbridge list command (#382)

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -253,7 +253,7 @@ fi
 
 ```bash
 # Step A: List all tunnels (both active and stale)
-devbridge ls --all
+devbridge list -j
 # Step B: Remove all stale tunnels
 devbridge delete-all
 # Step C: Retry tunnel creation
@@ -265,6 +265,7 @@ This eliminates the most common deployment failure — historical tunnels from p
 
 - The public URL has the form `https://<id>-<port>.cn-north-4-bridge.myhuaweicloud.com` (from the `Tunnel URL:` line).
 - **Return this URL to the developer as the deployment result link.** Keep the host process running (do not close the session before handing over the URL).
+- Tunnel `description` (`-d`) accepts only Chinese characters, letters, and digits (0-64). Symbols such as `-`/`_`/spaces are rejected (`Invalid tunnel description`).
 - Internal docs: https://huaweicloud.github.io/devspace-devbridge/
 
 **No local downgrade**: if the tunnel tooling cannot be installed in the sandbox, STOP and report a generic error ("无法生成访问地址") without technical detail. Never install it on the developer's local machine — a local install would defeat the purpose of sandbox deployment.
@@ -751,7 +752,7 @@ Follow the standard [Expose the deployed app](#expose-the-deployed-app-public-ur
 
 Use `exec_with_session` to background DevBridge. For SSR, DevBridge tunnels the nginx public port (not the Node port directly).
 
-**Pre-flight**: always run `devbridge delete-all` before creating a new tunnel to prevent `10006: quota exceeded` from accumulated stale tunnels. If you still get quota error, list tunnels with `devbridge ls --all`, delete stale ones, and retry.
+**Pre-flight**: always run `devbridge delete-all` before creating a new tunnel to prevent `10006: quota exceeded` from accumulated stale tunnels. If you still get quota error, list tunnels with `devbridge list -j`, delete stale ones, and retry.
 
 Extract the tunnel URL from DevBridge output. The public URL has the form `https://<id>-<port>.cn-north-4-bridge.myhuaweicloud.com`. **Return this URL to the developer as the deployment result.**
 

--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -836,7 +836,7 @@ fi`;
   try {
     const tunnelCheck = await execOneShot(
       workspaceId,
-      'devbridge ls 2>/dev/null | grep -q "Tunnel URL" && echo "ACTIVE" || echo "INACTIVE"',
+      'devbridge list -j 2>/dev/null | grep -q \'"tunnelId"\' && echo "ACTIVE" || echo "INACTIVE"',
       username,
       10000,
     );
@@ -912,7 +912,7 @@ export async function deployCheck(
     `fi`,
     ``,
     `TOTAL=$((TOTAL+1))`,
-    `if devbridge ls 2>/dev/null | grep -q "Tunnel URL"; then`,
+    `if devbridge list -j 2>/dev/null | grep -q '"tunnelId"'; then`,
     `  echo "devbridge_tunnel:PASS"`,
     `  PASS=$((PASS+1))`,
     `else`,
@@ -920,8 +920,9 @@ export async function deployCheck(
     `fi`,
     ``,
     `TOTAL=$((TOTAL+1))`,
-    `TUNNEL_URL=$(devbridge ls 2>/dev/null | grep -oP "Tunnel URL: \\Khttps://[^ ]+")`,
-    `if [ -n "$TUNNEL_URL" ]; then`,
+    `TUNNEL_ID=$(devbridge list -j 2>/dev/null | grep -oP '"tunnelId":\\s*"\\K[^"]+' | head -1)`,
+    `TUNNEL_URL="https://\${TUNNEL_ID}-${port}.cn-north-4-bridge.myhuaweicloud.com"`,
+    `if [ -n "$TUNNEL_ID" ] && [ -n "$TUNNEL_URL" ]; then`,
     `  HTTP_CODE=$(curl -s -o /dev/null -w "%{http_code}" --max-time 10 "$TUNNEL_URL" 2>/dev/null || echo "000")`,
     `  if [ "$HTTP_CODE" = "200" ] || [ "$HTTP_CODE" = "304" ]; then`,
     `    echo "tunnel_url_accessible:PASS ($TUNNEL_URL -> $HTTP_CODE)"`,

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -175,6 +175,17 @@ test('web/static-site deployment intent offers target options with sandbox first
   assert.match(discovery, /do NOT default to OBS/);
 });
 
+test('devbridge uses the valid `list` command, not the non-existent `ls`', () => {
+  const sandbox = readFileSync(join(pluginRoot, 'skills', 'huawei-sandbox', 'SKILL.md'), 'utf8');
+  const sessionManager = readFileSync(join(pluginRoot, 'src', 'sandbox', 'session-manager.mjs'), 'utf8');
+
+  assert.doesNotMatch(sandbox, /devbridge ls\b/);
+  assert.match(sandbox, /devbridge list -j/);
+
+  assert.doesNotMatch(sessionManager, /devbridge ls\b/);
+  assert.match(sessionManager, /devbridge list -j/);
+});
+
 test('all plugin manifests are valid JSON', () => {
   const manifests = [
     join(pluginRoot, '.codex-plugin', 'plugin.json'),


### PR DESCRIPTION
## Problem

`huawei-sandbox` skill 与 `deploy_check`/`deploy_nginx` 调用了不存在的 `devbridge ls`（真实命令是 `list`）和 `--all`（`list` 只有 `-j/--json`），导致隧道活性检测和配额恢复指引一直是静默失效的。

## Verification（连沙箱实测 DevBridge v0.1.13）

- `devbridge ls` → `unknown command "ls"`（应 `list`）
- `devbridge list --all` → `--all` 不存在（应 `list -j`）
- `devbridge list` 输出是**表格**（`Tunnel ID | Name | Description | ...`），**没有** `Tunnel URL:` 字段——该字样只出现在 `devbridge host` 的输出里

因此原代码 `grep "Tunnel URL"` 永远配不上。

## Fix

1. `SKILL.md`：`devbridge ls --all` → `devbridge list -j`（两处）；补充 `description` 只接受中文/字母/数字（符号 `-`/`_`/空格会被拒）。
2. `session-manager.mjs`：
   - 隧道活性检测：`grep -q '"tunnelId"'`（解析 JSON）
   - 提取 URL：从 `list -j` 取 `tunnelId`，再拼 `https://<id>-<port>.cn-north-4-bridge.myhuaweicloud.com`
3. `test/structure.test.mjs`：断言不再出现 `devbridge ls`，且出现 `devbridge list -j`。

## Related issue

关于 #382 本体的「孤儿隧道无法删除」：连沙箱实测（kill -9 与沙箱重连两场景）均**无法复现** `port list`/`delete` 返回 10002——当前 v0.1.13 中记录虽残留但可正常 `delete`/`delete-all` 清理。本条 PR 只修 devkit 侧确认存在的命令错误。
