### PR TITLE
docs(sandbox): scope GitCode SSL workaround to one-shot clone (#374)

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -357,13 +357,13 @@ Use the detected `PKG_MGR` for all package installations below.
 
 **Architecture awareness**: the sandbox runs Linux aarch64 (ARM64). Native binaries built on x64 (Windows/macOS Intel) will not execute. Always install dependencies and build inside the sandbox. For projects with native addons (Taro `@swc/core`, Prisma, `esbuild`, `node-gyp`), local x64 pre-build + upload of `dist/` output is a viable alternative when sandbox builds fail.
 
-**GitCode SSL**: if `git clone` from GitCode fails with SSL certificate errors:
+**GitCode SSL**: if `git clone` from GitCode fails with SSL certificate errors, use a one-shot override (do NOT set it globally — that would disable cert verification for every repo):
 
 ```bash
-git config --global http.sslVerify false
+git -c http.sslVerify=false clone <repo-url>
 ```
 
-Then retry the clone. This is a known sandbox environment limitation.
+Then retry the clone. This bypasses SSL verification only for this single clone.
 
 #### 3b: Install nginx (before project upload)
 


### PR DESCRIPTION
## Motivation

`huawei-sandbox/SKILL.md` 里对 GitCode clone 的 SSL 证书错误的 workaround 是：

```bash
git config --global http.sslVerify false
```

`--global` 会把证书校验**永久、全局**关掉（作用于沙箱里此后所有 git 仓库），是安全反模式。

## Change

改为**一次性**写法，只豁免这一次 clone：

```bash
git -c http.sslVerify=false clone <repo-url>
```

`-c` 仅对单条命令生效，不写 `~/.gitconfig`，不污染后续仓库。

## Verification

- `npm run lint:md`：0 issues
- `npm test`：192 全绿

Related: #374（仅做其中「SSL workaround 安全化」这一条；端口冲突已实现、外部访问已由 DevBridge 隧道覆盖，未改）
