### PR TITLE
fix(auth): sync KooCLI hcloud config on auth sync

### DIFF
--- a/plugins/huaweicloud-core/src/auth/service.mjs
+++ b/plugins/huaweicloud-core/src/auth/service.mjs
@@ -54,9 +54,42 @@ export function syncAuth(target = 'all') {
     };
   }
 
+  let hcloud = { ok: false, message: 'KooCLI not installed' };
+  if (hcloudInstalled()) {
+    const bin = process.env.HCLOUD_BIN || 'hcloud';
+    const r = spawnSync(
+      bin,
+      [
+        'configure',
+        'set',
+        `--cli-access-key=${credentials.ak}`,
+        `--cli-secret-key=${credentials.sk}`,
+        `--cli-region=${credentials.region || ''}`,
+      ],
+      {
+        shell: false,
+        windowsHide: true,
+        stdio: 'pipe',
+        timeout: 30000,
+      },
+    );
+    if (r.status === 0) {
+      hcloud = { ok: true, message: 'KooCLI config synced' };
+    } else {
+      hcloud = {
+        ok: false,
+        message: 'KooCLI config sync failed',
+        error: String(r.stderr || '')
+          .trim()
+          .slice(0, 240),
+      };
+    }
+  }
+
   return {
     ok: true,
     obs: { configured: true, path: obs.path, endpoint: obs.endpoint },
+    hcloud,
     credentialsConfigured: true,
     agents: getAgentRegistrationStatuses(target).agents,
     note: 'OBS credentials were synced from the global credential vault. Agent MCP registration is managed by "npx huaweicloud-devkit install --target <agent>".',


### PR DESCRIPTION
## Summary

Fix: `auth sync` was not syncing KooCLI (`~/.hcloud/config.json`), only OBS.

## Problem

`syncAuth()` in `service.mjs` only called `writeObsConfig()`. After `auth init` or `auth sync`, the devkit vault and OBS config were updated, but KooCLI's `~/.hcloud/config.json` was left stale. Users had to manually run `hcloud configure set` to sync.

## Fix

Added `hcloud configure set` call via `spawnSync` in `syncAuth()`, same logic as `configureHcloud()` in `setup-cli.mjs`. Now `auth sync` updates all three stores: vault, OBS, and hcloud.

## Return value change

Added `hcloud` field to syncAuth() return:
```json
{
  "hcloud": { "ok": true, "message": "KooCLI config synced" }
}
```
Backward compatible — existing callers only check `result.ok`.

## Verification

```bash
# Before: hcloud configure show returns old region
> npx huaweicloud-devkit auth init  # set cn-north-1
> hcloud configure show
# region: cn-north-4 (stale!)

# After: hcloud configure show returns new region
> npx huaweicloud-devkit auth sync
> hcloud configure show
# region: cn-north-1 (synced!)
```