### PR TITLE
feat(cli): save large hcloud output to file and return path (#4)

### DIFF
--- a/plugins/huaweicloud-core/src/hcloud-cli.mjs
+++ b/plugins/huaweicloud-core/src/hcloud-cli.mjs
@@ -1,5 +1,5 @@
 import { spawn } from 'node:child_process';
-import { existsSync } from 'node:fs';
+import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
 import { homedir } from 'node:os';
 import { join } from 'node:path';
 
@@ -9,6 +9,20 @@ import { getProxySettings } from './proxy/proxy-config.mjs';
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_FORCE_KILL_AFTER_MS = 2_000;
 const DEFAULT_MAX_RETRIES = 1;
+const LARGE_OUTPUT_THRESHOLD = 50_000;
+const OUTPUT_DIR = join('/tmp', 'huaweicloud-devkit');
+
+function saveLargeOutput(rawStdout) {
+  if (rawStdout.length <= LARGE_OUTPUT_THRESHOLD) return null;
+  try {
+    mkdirSync(OUTPUT_DIR, { recursive: true });
+    const filePath = join(OUTPUT_DIR, `output-${Date.now()}.json`);
+    writeFileSync(filePath, rawStdout, { encoding: 'utf8' });
+    return filePath;
+  } catch {
+    return null;
+  }
+}
 
 export function planHcloudCommand(args, options = {}) {
   const normalizedArgs = Array.isArray(args) ? args.map(String) : [];
@@ -112,6 +126,13 @@ function runHcloudOnce(plan, options) {
       clearTimeout(timer);
       clearTimeout(forceTimer);
       clearTimeout(settleTimer);
+      if (result.stdout && String(result.stdout).length > LARGE_OUTPUT_THRESHOLD) {
+        const outputFile = saveLargeOutput(stdout);
+        if (outputFile) {
+          result.outputFile = outputFile;
+          result.stdout = String(result.stdout).slice(0, 2000) + `\n...(truncated, full output saved to ${outputFile})`;
+        }
+      }
       resolve(result);
     }
 


### PR DESCRIPTION
## Problem

When `run_readonly_command` returns large output (e.g. RDS ListFlavors = 158KB), the platform truncates it. The agent only gets a file path reference and must run additional bash + python3 commands to parse the JSON.

## Solution

When hcloud command output exceeds 50KB, the full raw output is saved to `/tmp/huaweicloud-devkit/output-{timestamp}.json` and the returned `stdout` is truncated to 2000 chars with a note pointing to the file path.

This lets the agent use its Grep tool directly:
```bash
grep spec_code /tmp/huaweicloud-devkit/output-1788251371106.json
```

## Behavior
- Small output (< 50KB): no change
- Large output (>= 50KB): file saved, `outputFile` field added to result, stdout truncated
- File path pattern: `/tmp/huaweicloud-devkit/output-{timestamp}.json`
- Runs on user local machine, no additional security risk