### PR TITLE
fix(sandbox): auto-generate QR code in deploy_check for cross-platform projects

### DIFF
--- a/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/session-manager.mjs
@@ -940,7 +940,24 @@ if [ -f "${outputPath}/qr.png" ]; then
   echo "qr_code:PASS"
   PASS=$((PASS+1))
 else
-  echo "qr_code:FAIL (no QR code — generate one for cross-platform H5 apps)"
+  ${
+    isCrossPlatform
+      ? `
+  if [ -n "$TUNNEL_URL" ]; then
+    curl -s "https://api.qrserver.com/v1/create-qr-code/?size=300x300&data=$(python3 -c "import urllib.parse, sys; print(urllib.parse.quote(sys.argv[1]))" "$TUNNEL_URL" 2>/dev/null)" -o "${outputPath}/qr.png" 2>/dev/null
+    chmod o+r "${outputPath}/qr.png" 2>/dev/null || true
+    if [ -f "${outputPath}/qr.png" ] && [ -s "${outputPath}/qr.png" ]; then
+      echo "qr_code:PASS (auto-generated)"
+      PASS=$((PASS+1))
+    else
+      echo "qr_code:FAIL (QR generation failed)"
+    fi
+  else
+    echo "qr_code:FAIL (no tunnel URL for QR generation)"
+  fi
+`
+      : `echo "qr_code:FAIL (no QR code — generate one for cross-platform H5 apps)"`
+  }
 fi
 `}`,
     `echo "SCORE:\${PASS}/\${TOTAL}"`,


### PR DESCRIPTION
When frameworkType=cross-platform and qr.png is missing but tunnel URL exists, deploy_check now auto-generates the QR code via qrserver API. Non-cross-platform projects only check existence without auto-generation.