### PR TITLE
fix: include atomcode in skills root and report openclaw auth status

### DIFF
--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -186,6 +186,11 @@ function atomcodeRegistered() {
   return Boolean(cfg?.mcpServers?.['huaweicloud-devkit']);
 }
 
+function openclawRegistered() {
+  const cfg = readJsonSafe(join(baseHome(), '.agents', 'huaweicloud-plugins', '.mcp.json'));
+  return Boolean(cfg?.mcpServers?.['huaweicloud-devkit']);
+}
+
 function hermesHome() {
   if (process.env.HERMES_HOME) return process.env.HERMES_HOME;
   // Hermes on Windows stores under LOCALAPPDATA, not ~/.hermes
@@ -220,6 +225,7 @@ export function getAgentRegistrationStatuses(target = 'all') {
     if (agent === 'dsh') configured = dshRegistered();
     if (agent === 'officeace') configured = officeaceRegistered();
     if (agent === 'hermes') configured = hermesRegistered();
+    if (agent === 'openclaw') configured = openclawRegistered();
     if (agent === 'atomcode') configured = atomcodeRegistered();
     result.agents[agent] = { configured };
   }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -106,6 +106,11 @@ function hermesSkillsDir() {
   return join(home, '.hermes', 'skills');
 }
 
+function atomcodeSkillsDir() {
+  const home = process.env.ATOMCODE_HOME || homedir();
+  return join(home, '.atomcode', 'skills');
+}
+
 function codexDesktopSkillsDir() {
   return join(homedir(), '.agents', 'skills');
 }
@@ -139,6 +144,7 @@ function resolveSkillsRoot() {
       workbuddySkillsDir(),
       officeaceSkillsRoot(),
       hermesSkillsDir(),
+      atomcodeSkillsDir(),
       codexDesktopSkillsDir(),
     ]) || SKILLS_ROOT_DEV
   );

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -501,6 +501,21 @@ test('tools.mjs resolves skills from the hermes directory', () => {
   assert.match(tools, /hermesSkillsDir\(\)/);
 });
 
+test('tools.mjs resolves skills from the atomcode directory', () => {
+  const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
+  assert.match(tools, /function atomcodeSkillsDir\(\)/);
+  assert.match(tools, /process\.env\.ATOMCODE_HOME/);
+  assert.match(tools, /return join\(home, '\.atomcode', 'skills'\)/);
+  assert.match(tools, /atomcodeSkillsDir\(\)/);
+});
+
+test('agent-registration reports openclaw registration status', () => {
+  const registration = readFileSync(join(pluginRoot, 'src', 'auth', 'agent-registration.mjs'), 'utf8');
+  assert.match(registration, /function openclawRegistered\(\)/);
+  assert.match(registration, /agent === 'openclaw'/);
+  assert.match(registration, /'\.agents', 'huaweicloud-plugins', '\.mcp\.json'/);
+});
+
 test('official Huawei Cloud Icons library is integrated', () => {
   const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
   assert.match(tools, /name: 'huaweicloud_get_service_icon'/);


### PR DESCRIPTION
## Problem

多 agent 枚举有两处遗漏：

1. **atomcode 技能根未接入**：`installAtomCode` 把 skills 拷到 `~/.atomcode/skills`，但 MCP 服务端的 `tools.mjs` `resolveSkillsRoot()` 候选目录里没有 atomcode，导致 `huaweicloud_retrieve_skill` / `huaweicloud_search_docs` 对 AtomCode 用户返回空（skill 装了但不可见）。
2. **openclaw 认证状态未接入**：`agent-registration.mjs` 的 `getAgentRegistrationStatuses` 没有 `openclaw` 分派分支，`huaweicloud_auth_status` 永远把 openclaw 报成 `configured: false`。

## Change

- `tools.mjs`：新增 `atomcodeSkillsDir()`（`ATOMCODE_HOME || ~/.atomcode/skills`），加入 `resolveSkillsRoot()` 候选。
- `agent-registration.mjs`：新增 `openclawRegistered()`（读 `~/.agents/huaweicloud-plugins/.mcp.json`），并在 `getAgentRegistrationStatuses` 补 `openclaw` 分支。
- `structure.test.mjs`：新增 atomcode 技能根、openclaw 注册状态断言防回归。

## Verification

- `npm test`：194 全绿
- `npm run validate`、`lint:js`、`format:check` 通过
