### PR TITLE
fix(ecs): add security group reuse warning to Critical Warnings

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
@@ -28,13 +28,14 @@ If these do not exist, load the `huawei-vpc` skill first and create them before 
 
 ## Critical Warnings
 
-| Trap                          | Why                                                                         |
-| ----------------------------- | --------------------------------------------------------------------------- |
-| Flavor not in region          | Not all flavors available everywhere. Check with ECS ListFlavors first      |
-| Security group denies all     | New SGs deny ALL inbound. Must explicitly add rules                         |
-| EIP bills when idle           | Unattached EIP still incurs charges                                         |
-| Stopped instance still bills  | Pay-per-use instances bill when stopped (unless shutdown-no-billing flavor) |
-| Disk survives instance delete | Deleting instance does NOT delete system disk by default                    |
+| Trap                            | Why                                                                                                                                              |
+| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Flavor not in region            | Not all flavors available everywhere. Check with ECS ListFlavors first                                                                           |
+| Security group denies all       | New SGs deny ALL inbound. Must explicitly add rules                                                                                              |
+| Reusing existing security group | Existing SGs may have 0.0.0.0/0 rules. Before referencing, run hcloud VPC ListSecurityGroupRules --security_group_id=<id> to audit inbound rules |
+| EIP bills when idle             | Unattached EIP still incurs charges                                                                                                              |
+| Stopped instance still bills    | Pay-per-use instances bill when stopped (unless shutdown-no-billing flavor)                                                                      |
+| Disk survives instance delete   | Deleting instance does NOT delete system disk by default                                                                                         |
 
 ## Flavor Selection Guide
 


### PR DESCRIPTION
## Fix for #443

Add Critical Warning to huawei-ecs skill: when reusing an existing security group, agent must first audit its inbound rules with `ListSecurityGroupRules` to detect permissive 0.0.0.0/0 rules.

## Before

Agent references existing SG via `--security_group_id=xxx` without checking rules. `hook_check_command` cannot catch 0.0.0.0/0 exposure because command text doesn not contain CIDR info.

## After

Agent reads the new Critical Warning and proactively runs `hcloud VPC ListSecurityGroupRules` before referencing an existing SG, alerts user if permissive rules are found.

Closes #443