### PR TITLE
fix: use CodeArts Work native MCP format (mcp key, array command, environment)

### DIFF
--- a/plugins/huaweicloud-core/src/auth/agent-registration.mjs
+++ b/plugins/huaweicloud-core/src/auth/agent-registration.mjs
@@ -82,7 +82,7 @@ function codeartsRegistered() {
 function codeartsWorkRegistered() {
   const path = join(baseHome(), '.codeartswork', 'mcp', 'mcp_settings.json');
   const cfg = readJsonSafe(path);
-  return Boolean(cfg?.mcpServers?.['huaweicloud-devkit']);
+  return Boolean(cfg?.mcp?.['huaweicloud-devkit']);
 }
 
 function workbuddyRegistered() {

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -164,16 +164,16 @@ function readCodeArtsCredentials() {
     try {
       if (existsSync(path)) {
         const config = JSON.parse(readFileSync(path, 'utf8'));
-        const server = config?.mcpServers?.['huaweicloud-devkit'];
-        if (server?.env) {
-          const ak = server.env.HW_ACCESS_KEY;
-          const sk = server.env.HW_SECRET_KEY;
+        const server = config?.mcp?.['huaweicloud-devkit'];
+        if (server?.environment) {
+          const ak = server.environment.HW_ACCESS_KEY;
+          const sk = server.environment.HW_SECRET_KEY;
           if (ak && sk) {
             return {
               ak,
               sk,
-              securityToken: server.env.HW_SECURITY_TOKEN || '',
-              region: server.env.HW_REGION || server.env.HUAWEICLOUD_REGION || '',
+              securityToken: server.environment.HW_SECURITY_TOKEN || '',
+              region: server.environment.HW_REGION || server.environment.HUAWEICLOUD_REGION || '',
             };
           }
         }

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -1264,36 +1264,37 @@ function codeartsStatus() {
 function registerCodeartsWorkMcp() {
   const configPath = codeartsWorkMcpSettingsFile();
   const mcpPath = join(codeartsWorkPluginsDir(), 'src', 'mcp-server.mjs').replace(/\\/g, '/');
-  const env = { HUAWEICLOUD_AGENT_TOOLKIT_MODE: 'local' };
+  const environment = { HUAWEICLOUD_AGENT_TOOLKIT_MODE: 'local' };
   const hcloudBin = findHcloudBin();
-  if (hcloudBin) env.HCLOUD_BIN = hcloudBin.replace(/\\/g, '/');
+  if (hcloudBin) environment.HCLOUD_BIN = hcloudBin.replace(/\\/g, '/');
   let config = {};
   if (existsSync(configPath)) {
     try {
       config = JSON.parse(readFileSync(configPath, 'utf8'));
     } catch {
       console.log(
-        `  \x1b[33m[WARN]\x1b[0m Could not parse ${configPath}. Skipping MCP config write; ensure "mcpServers.huaweicloud-devkit" points to ${mcpPath}.`,
+        `  \x1b[33m[WARN]\x1b[0m Could not parse ${configPath}. Skipping MCP config write; ensure "mcp.huaweicloud-devkit" points to ${mcpPath}.`,
       );
       return;
     }
-    const existing = config.mcpServers?.['huaweicloud-devkit'];
+    const existing = config.mcp?.['huaweicloud-devkit'];
     if (
       existing &&
-      existing.command === 'node' &&
-      Array.isArray(existing.args) &&
-      existing.args[0] === mcpPath &&
+      existing.type === 'local' &&
+      Array.isArray(existing.command) &&
+      existing.command[0] === 'node' &&
+      existing.command[1] === mcpPath &&
       existing.timeout === 300000
     ) {
       console.log(`  MCP config unchanged: ${configPath}`);
       return;
     }
   }
-  config.mcpServers = config.mcpServers || {};
-  config.mcpServers['huaweicloud-devkit'] = {
-    command: 'node',
-    args: [mcpPath],
-    env,
+  config.mcp = config.mcp || {};
+  config.mcp['huaweicloud-devkit'] = {
+    type: 'local',
+    command: ['node', mcpPath],
+    environment,
     enabled: true,
     timeout: 300000,
   };
@@ -1361,9 +1362,9 @@ function uninstallCodeArtsWork() {
     try {
       config = JSON.parse(readFileSync(configPath, 'utf8'));
     } catch {}
-    if (config.mcpServers?.['huaweicloud-devkit']) {
-      delete config.mcpServers['huaweicloud-devkit'];
-      if (Object.keys(config.mcpServers).length === 0) delete config.mcpServers;
+    if (config.mcp?.['huaweicloud-devkit']) {
+      delete config.mcp['huaweicloud-devkit'];
+      if (Object.keys(config.mcp).length === 0) delete config.mcp;
       writeFileSync(configPath, JSON.stringify(config, null, 2));
       console.log(`  Config cleaned: ${configPath}`);
     }
@@ -1391,7 +1392,7 @@ function codeartsWorkStatus() {
     try {
       const config = JSON.parse(readFileSync(codeartsWorkMcpSettingsFile(), 'utf8'));
       console.log(
-        `  MCP config: ${config.mcpServers?.['huaweicloud-devkit'] ? '\x1b[32mConfigured\x1b[0m' : '\x1b[31mNot configured\x1b[0m'}`,
+        `  MCP config: ${config.mcp?.['huaweicloud-devkit'] ? '\x1b[32mConfigured\x1b[0m' : '\x1b[31mNot configured\x1b[0m'}`,
       );
     } catch {
       console.log(`  MCP config: \x1b[31mInvalid\x1b[0m`);
@@ -2948,7 +2949,7 @@ async function cmdDoctor() {
   if (!mcpConfigured && existsSync(codeartsWorkCfg)) {
     try {
       const cfg = JSON.parse(readFileSync(codeartsWorkCfg, 'utf8'));
-      if (cfg.mcpServers && cfg.mcpServers['huaweicloud-devkit']) {
+      if (cfg.mcp && cfg.mcp['huaweicloud-devkit']) {
         mcpConfigured = true;
         mcpCfgTarget = 'CodeArts Work';
       }

--- a/test/auth-credentials.test.mjs
+++ b/test/auth-credentials.test.mjs
@@ -102,6 +102,7 @@ test('auth sync writes OBS and reports all agent registration targets', () => {
     assert.ok(sync.agents.codex !== undefined);
     assert.ok(sync.agents['codex-desktop'] !== undefined);
     assert.ok(sync.agents.codearts !== undefined);
+    assert.ok(sync.agents['codearts-work'] !== undefined);
     assert.ok(sync.agents.workbuddy !== undefined);
     assert.ok(sync.agents.dsh !== undefined);
   });

--- a/test/codearts-adaptation.test.mjs
+++ b/test/codearts-adaptation.test.mjs
@@ -230,12 +230,13 @@ test('codearts-work install writes correct mcp_settings.json', () => {
 
     const config = mcpConfig(join(home, '.codeartswork', 'mcp', 'mcp_settings.json'));
     assert.ok(config, 'mcp_settings.json exists');
-    const server = config.mcpServers['huaweicloud-devkit'];
+    const server = config.mcp['huaweicloud-devkit'];
     assert.ok(server, 'huaweicloud-devkit entry exists');
-    assert.equal(server.command, 'node');
+    assert.equal(server.type, 'local');
     assert.equal(server.enabled, true);
     assert.equal(server.timeout, 300000);
-    assert.match(server.args[0], /huaweicloud-plugins.src.mcp-server/);
+    assert.equal(server.command[0], 'node');
+    assert.match(server.command[1], /huaweicloud-plugins.src.mcp-server/);
   } finally {
     rmSync(home, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });
@@ -273,7 +274,7 @@ test('codearts-work uninstall removes skills, plugins, and MCP config', () => {
     assert.ok(!existsSync(join(home, '.codeartswork', 'huaweicloud-plugins')), 'plugins dir removed');
 
     const config = mcpConfig(join(home, '.codeartswork', 'mcp', 'mcp_settings.json'));
-    assert.ok(!config?.mcpServers?.['huaweicloud-devkit'], 'MCP config cleaned');
+    assert.ok(!config?.mcp?.['huaweicloud-devkit'], 'MCP config cleaned');
   } finally {
     rmSync(home, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });

--- a/test/codearts-adaptation.test.mjs
+++ b/test/codearts-adaptation.test.mjs
@@ -198,3 +198,98 @@ test('cli help documents the codearts target', () => {
     rmSync(cwd, { recursive: true, force: true });
   }
 });
+
+// --- CodeArts Work integration tests ---
+
+test('codearts-work install copies skills, MCP server, and safety policy', () => {
+  const home = mkdtempSync(join(tmpdir(), 'codearts-work-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'codearts-work-proj-'));
+  try {
+    const res = runCli(home, cwd, ['install', '--target', 'codearts-work']);
+    assert.equal(res.status, 0, res.stderr);
+
+    const userSkills = countSkills(join(home, '.codeartswork', 'skills'));
+    assert.ok(userSkills >= 6, `user skills (${userSkills})`);
+
+    const pluginDir = join(home, '.codeartswork', 'huaweicloud-plugins');
+    assert.ok(existsSync(join(pluginDir, 'src', 'mcp-server.mjs')), 'MCP server');
+    assert.ok(existsSync(join(pluginDir, 'safety', 'policy.json')), 'safety policy');
+    assert.ok(existsSync(join(pluginDir, '.installed')), '.installed marker');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('codearts-work install writes correct mcp_settings.json', () => {
+  const home = mkdtempSync(join(tmpdir(), 'codearts-work-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'codearts-work-proj-'));
+  try {
+    const res = runCli(home, cwd, ['install', '--target', 'codearts-work']);
+    assert.equal(res.status, 0, res.stderr);
+
+    const config = mcpConfig(join(home, '.codeartswork', 'mcp', 'mcp_settings.json'));
+    assert.ok(config, 'mcp_settings.json exists');
+    const server = config.mcpServers['huaweicloud-devkit'];
+    assert.ok(server, 'huaweicloud-devkit entry exists');
+    assert.equal(server.command, 'node');
+    assert.equal(server.enabled, true);
+    assert.equal(server.timeout, 300000);
+    assert.match(server.args[0], /huaweicloud-plugins.src.mcp-server/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('codearts-work status reports installed skills and configured MCP', () => {
+  const home = mkdtempSync(join(tmpdir(), 'codearts-work-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'codearts-work-proj-'));
+  try {
+    const install = runCli(home, cwd, ['install', '--target', 'codearts-work']);
+    assert.equal(install.status, 0, install.stderr);
+
+    const res = runCli(home, cwd, ['status', '--target', 'codearts-work']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Installed/);
+    assert.match(res.stdout, /Configured/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('codearts-work uninstall removes skills, plugins, and MCP config', () => {
+  const home = mkdtempSync(join(tmpdir(), 'codearts-work-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'codearts-work-proj-'));
+  try {
+    const install = runCli(home, cwd, ['install', '--target', 'codearts-work']);
+    assert.equal(install.status, 0, install.stderr);
+
+    const res = runCli(home, cwd, ['uninstall', '--target', 'codearts-work']);
+    assert.equal(res.status, 0, res.stderr);
+
+    assert.equal(countSkills(join(home, '.codeartswork', 'skills')), 0, 'skills removed');
+    assert.ok(!existsSync(join(home, '.codeartswork', 'huaweicloud-plugins')), 'plugins dir removed');
+
+    const config = mcpConfig(join(home, '.codeartswork', 'mcp', 'mcp_settings.json'));
+    assert.ok(!config?.mcpServers?.['huaweicloud-devkit'], 'MCP config cleaned');
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('codearts-work appears in help output', () => {
+  const home = mkdtempSync(join(tmpdir(), 'codearts-work-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'codearts-work-proj-'));
+  try {
+    const res = runCli(home, cwd, ['help']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /--target <opencode\|codex\|codearts\|codearts-work\|workbuddy/);
+    assert.match(res.stdout, /install --target codearts-work/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Problem

DevKit wrote CodeArts Work MCP config using Claude Desktop style \`mcpServers\` key, but CodeArts Work only reads from the \`mcp\` key. This caused the connector to never appear in CodeArts Work's "My Installations" list.

## Root Cause

CodeArts Work's native MCP format:

\`\`\`json
{
  "mcp": {
    "connector-id": {
      "type": "local",
      "command": ["node", "path/to/mcp-server.mjs"],
      "environment": { "KEY": "val" },
      "enabled": true,
      "timeout": 300000
    }
  }
}
\`\`\`

DevKit was writing to \`mcpServers\` key with \`command\` string + \`args\` array + \`env\` object format, which CodeArts Work ignores.

## Changes

- registerCodeartsWorkMcp: write to \`config.mcp\` with \`type\`/\`command\` array/\`environment\` format
- codeartsWorkRegistered: read from \`config.mcp\`
- readCodeArtsCredentials: read env vars from \`environment\` field
- uninstallCodeartsWork/status/doctor: use \`mcp\` key
- test: update assertions for new format

## Tests

All 189 tests pass, 0 failures.