### PR TITLE
fix(detect): handle unquoted outDir in VitePress config

### DIFF
--- a/plugins/huaweicloud-core/src/detect-framework.mjs
+++ b/plugins/huaweicloud-core/src/detect-framework.mjs
@@ -244,7 +244,7 @@ function readVitepressOutDir(projectPath) {
     if (!existsSync(configPath)) continue;
     try {
       const content = readFileSync(configPath, 'utf8');
-      const match = content.match(/outDir\s*:\s*['"]([^'"]+)['"]/);
+      const match = content.match(/outDir\s*:\s*['"`]?([^'"`\s,}]+)['"`]?/);
       if (match) return match[1];
     } catch {}
   }


### PR DESCRIPTION
## Problem (#371)

detect_framework for VitePress returns default outputDir when project config has custom outDir without quotes.

## Root Cause

Regex in readVitepressOutDir required quotes around the value.

## Fix

Make quotes optional, support backticks, and handle bare values.

## Files changed
- src/detect-framework.mjs - 1 line
