### PR TITLE
fix(safety): relax delete cascade rules + improve approvedCommand validation

### DIFF
--- a/plugins/huaweicloud-core/safety/rules/cloud-risk-rules.json
+++ b/plugins/huaweicloud-core/safety/rules/cloud-risk-rules.json
@@ -214,7 +214,7 @@
           },
           {
             "field": "text",
-            "regex": "(\\s--force|\\s-f\\s|\\s--recursive|\\s-r\\s|delete_publicip\\s*[=:]\\s*true)"
+            "regex": "(\\s--force|\\s-f\\s|\\s--recursive|\\s-r\\s)"
           }
         ]
       },
@@ -241,6 +241,27 @@
       },
       "message": "This hcloud command will delete, detach, or remove cloud resources. The operation may be irreversible.",
       "remediation": "List the resources to be affected first, confirm with the user, and require explicit approval before executing any destructive operation."
+    },
+    {
+      "id": "hwc-destructive-delete-cascade",
+      "title": "Cascading cloud resource deletion",
+      "category": "destructive",
+      "severity": "warn",
+      "stages": ["command"],
+      "match": {
+        "all": [
+          {
+            "field": "text",
+            "regex": "(Delete|BatchDelete|Remove|\\brm\\b|delete)"
+          },
+          {
+            "field": "text",
+            "regex": "(delete_publicip\\s*[=:]\\s*true|delete_volume\\s*[=:]\\s*true)"
+          }
+        ]
+      },
+      "message": "This delete command will also remove associated resources (EIP, volume). Check that these should be deleted together.",
+      "remediation": "Confirm with the user whether to delete the associated resources, or set delete_publicip/delete_volume to false to keep them."
     },
     {
       "id": "hwc-sandbox-missing-ttl",

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -1326,7 +1326,14 @@ async function runApprovedCommand(args = {}) {
   }
   const providedArgs = Array.isArray(args.args) ? args.args.map(String) : [];
   if (JSON.stringify(storedArgs) !== JSON.stringify(providedArgs)) {
-    throw new Error('Provided args do not match the approved plan. Use the exact args from the plan.');
+    const redactedStored = redactSecrets(storedArgs);
+    const redactedProvided = redactSecrets(providedArgs);
+    if (JSON.stringify(redactedStored) !== JSON.stringify(redactedProvided)) {
+      throw new Error(
+        'Provided args do not match the approved plan. Use the exact args from the plan. ' +
+          'If the plan shows <redacted> for passwords or secrets, replace <redacted> with the actual values in approvedCommand.',
+      );
+    }
   }
   const strictPlan = planHcloudCommand(providedArgs, { allowWrites: false });
   const result = await runHcloud(providedArgs, {


### PR DESCRIPTION
## Fixes for #245

### 1. DeleteServers false positive �� relaxed to warn

Moved delete_publicip=true and delete_volume=true from the deny rule (hwc-destructive-delete-force) to a new warn-only rule (hwc-destructive-delete-cascade). Only actual --force/--recursive flags now trigger a denial. ECS cleanup commands like:

hcloud ECS DeleteServers --servers.1.id=xxx --delete_publicip=true

are now allowed (with user approval) and only produce a warning about cascading resource deletion.

### 2. ResetServerPassword parameter mismatch

This is a KooCLI --help documentation bug. The --help output documents --server.password but the actual API accepts --reset-password.new_password. Not a DevKit issue.

### 3. approvedCommand validation with redacted passwords

The comparison now normalizes both the stored and provided args by redacting credential values before comparing. This means:
- Agent can pass args with real passwords (stored in the approval token) �� matches correctly
- Agent can also pass args with <redacted> placeholders �� also matches (after normalization)
- Only structural differences (wrong flags, missing args) will trigger the mismatch error

Error message improved to explain the <redacted> placeholder behavior.
