### PR TITLE
fix(sandbox): add devbridge PATH to persistent session on connect

### DIFF
--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -1055,6 +1055,9 @@ export async function callTool(name, args = {}) {
         try {
           await execOneShot(devStageId, 'devbridge delete-all 2>/dev/null || true', 'root', 15000);
         } catch {}
+        try {
+          await execWithSession(devStageId, 'export PATH=$HOME/.huawei/bin${PATH:+:$PATH}', 'root', 10000);
+        } catch {}
         await transferGitRepo(args, devStageId, connectResult);
       }
       return connectResult;


### PR DESCRIPTION
Fix #246-2: devbridge installs to ~/.huawei/bin but the PATH is not available in non-interactive shells. After sandbox_connect, export PATH to make devbridge immediately usable.