### PR TITLE
fix(ecs): fix preflightSecurityGroupCheck regex and query parameter format (#443)

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md
@@ -28,14 +28,14 @@ If these do not exist, load the `huawei-vpc` skill first and create them before 
 
 ## Critical Warnings
 
-| Trap                            | Why                                                                                                                                              |
-| ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Flavor not in region            | Not all flavors available everywhere. Check with ECS ListFlavors first                                                                           |
-| Security group denies all       | New SGs deny ALL inbound. Must explicitly add rules                                                                                              |
-| Reusing existing security group | Existing SGs may have 0.0.0.0/0 rules. Before referencing, run hcloud VPC ListSecurityGroupRules --security_group_id=<id> to audit inbound rules |
-| EIP bills when idle             | Unattached EIP still incurs charges                                                                                                              |
-| Stopped instance still bills    | Pay-per-use instances bill when stopped (unless shutdown-no-billing flavor)                                                                      |
-| Disk survives instance delete   | Deleting instance does NOT delete system disk by default                                                                                         |
+| Trap                            | Why                                                                                                                                                |
+| ------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Flavor not in region            | Not all flavors available everywhere. Check with ECS ListFlavors first                                                                             |
+| Security group denies all       | New SGs deny ALL inbound. Must explicitly add rules                                                                                                |
+| Reusing existing security group | Existing SGs may have 0.0.0.0/0 rules. Before referencing, run hcloud VPC ListSecurityGroupRules --security_group_id.1=<id> to audit inbound rules |
+| EIP bills when idle             | Unattached EIP still incurs charges                                                                                                                |
+| Stopped instance still bills    | Pay-per-use instances bill when stopped (unless shutdown-no-billing flavor)                                                                        |
+| Disk survives instance delete   | Deleting instance does NOT delete system disk by default                                                                                           |
 
 ## Flavor Selection Guide
 

--- a/plugins/huaweicloud-core/src/hcloud-cli.mjs
+++ b/plugins/huaweicloud-core/src/hcloud-cli.mjs
@@ -58,16 +58,19 @@ function preflightSecurityGroupCheck(normalizedArgs) {
 
   const sgIds = [];
   for (const arg of normalizedArgs) {
-    const m = arg.match(/^--security_group_id(\.\d+)?=(.+)/);
-    if (m) sgIds.push(m[2]);
+    const m = arg.match(/^(?:--security_group_id(?:\.\d+)?|--server\.security_groups(?:\.\d+)?\.id)=(.+)/);
+    if (m) sgIds.push(m[1]);
   }
   if (sgIds.length === 0) return [];
 
+  const regionArg = normalizedArgs.find((a) => a.startsWith('--cli-region='));
   const findings = [];
   for (const sgId of sgIds) {
     try {
       const hcloudBin = process.env.HCLOUD_BIN || 'hcloud';
-      const r = spawnSync(hcloudBin, ['VPC', 'ListSecurityGroupRules', `--security_group_id=${sgId}`], {
+      const spawnArgs = ['VPC', 'ListSecurityGroupRules', `--security_group_id.1=${sgId}`];
+      if (regionArg) spawnArgs.push(regionArg);
+      const r = spawnSync(hcloudBin, spawnArgs, {
         shell: false,
         windowsHide: true,
         stdio: 'pipe',

--- a/test/issue-443-fix.test.mjs
+++ b/test/issue-443-fix.test.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict';
+import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { randomBytes } from 'node:crypto';
+import test from 'node:test';
+
+function mkShim(dir, nodeScript) {
+  const shim = join(dir, 'hcloud-shim');
+  writeFileSync(shim, `#!/bin/bash\nexec ${process.execPath} ${nodeScript} "$@"`, 'utf8');
+  chmodSync(shim, 0o755);
+  return shim;
+}
+
+test('preflightSecurityGroupCheck catches dangerous SG via --server.security_groups.N.id (B1+B2 fix)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hwc-test-'));
+  const script = join(dir, `fake-${randomBytes(4).toString('hex')}.mjs`);
+
+  writeFileSync(
+    script,
+    `
+console.log(JSON.stringify({
+  request_id: "req-1",
+  security_group_rules: [{
+    id: "rule-abc",
+    direction: "ingress",
+    remote_ip_prefix: "0.0.0.0/0",
+    multiport: "22",
+    protocol: "tcp",
+    security_group_id: "sg-123"
+  }]
+}));
+`,
+    'utf8',
+  );
+
+  const shim = mkShim(dir, script);
+  const oldEnv = process.env.HCLOUD_BIN;
+  process.env.HCLOUD_BIN = shim;
+
+  try {
+    const { planHcloudCommand } = await import('../plugins/huaweicloud-core/src/hcloud-cli.mjs');
+
+    const plan = planHcloudCommand(
+      [
+        'ECS',
+        'CreateServers',
+        '--cli-region=cn-north-4',
+        '--server.security_groups.1.id=77216397-2c1b-4d96-b1e7-0e57a3176498',
+        '--server.flavorRef=ac7.large.2',
+        '--server.imageRef=img',
+        '--server.nics.1.subnet_id=sub',
+      ],
+      { allowWrites: true },
+    );
+
+    assert.ok(plan.sgFindings.length > 0, 'B1+B2 fix: should have sg findings');
+    assert.equal(plan.classification.decision, 'deny', 'B1+B2 fix: should deny ECS on dangerous SG reuse');
+    assert.match(plan.sgFindings[0].message, /22/);
+    assert.match(plan.sgFindings[0].message, /77216397/);
+  } finally {
+    process.env.HCLOUD_BIN = oldEnv;
+    try {
+      require('node:fs').rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+test('preflightSecurityGroupCheck passes when SG has only egress rules', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hwc-test-'));
+  const script = join(dir, `fake-${randomBytes(4).toString('hex')}.mjs`);
+
+  writeFileSync(
+    script,
+    `
+console.log(JSON.stringify({
+  request_id: "req-3",
+  security_group_rules: [{
+    id: "rule-safe",
+    direction: "egress",
+    remote_ip_prefix: "0.0.0.0/0",
+    protocol: "tcp",
+    multiport: "22",
+    security_group_id: "sg-789"
+  }]
+}));
+`,
+    'utf8',
+  );
+
+  const shim = mkShim(dir, script);
+  const oldEnv = process.env.HCLOUD_BIN;
+  process.env.HCLOUD_BIN = shim;
+
+  try {
+    const { planHcloudCommand } = await import('../plugins/huaweicloud-core/src/hcloud-cli.mjs');
+
+    const plan = planHcloudCommand(
+      [
+        'ECS',
+        'CreateServers',
+        '--cli-region=cn-north-4',
+        '--server.security_groups.1.id=sg-789',
+        '--server.flavorRef=ac7.large.2',
+        '--server.imageRef=img',
+        '--server.nics.1.subnet_id=sub',
+      ],
+      { allowWrites: true },
+    );
+
+    assert.equal(plan.sgFindings.length, 0, 'egress rules should be ignored');
+    assert.equal(plan.classification.decision, 'allow');
+  } finally {
+    process.env.HCLOUD_BIN = oldEnv;
+    try {
+      require('node:fs').rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});
+
+test('preflightSecurityGroupCheck still works with --security_group_id (backward compatible)', async () => {
+  const dir = mkdtempSync(join(tmpdir(), 'hwc-test-'));
+  const script = join(dir, `fake-${randomBytes(4).toString('hex')}.mjs`);
+
+  writeFileSync(
+    script,
+    `
+console.log(JSON.stringify({
+  request_id: "req-4",
+  security_group_rules: [{
+    id: "rule-old",
+    direction: "ingress",
+    remote_ip_prefix: "0.0.0.0/0",
+    multiport: "3306",
+    protocol: "tcp",
+    security_group_id: "sg-old"
+  }]
+}));
+`,
+    'utf8',
+  );
+
+  const shim = mkShim(dir, script);
+  const oldEnv = process.env.HCLOUD_BIN;
+  process.env.HCLOUD_BIN = shim;
+
+  try {
+    const { planHcloudCommand } = await import('../plugins/huaweicloud-core/src/hcloud-cli.mjs');
+
+    const plan = planHcloudCommand(
+      [
+        'ECS',
+        'CreateServers',
+        '--cli-region=cn-north-4',
+        '--security_group_id=sg-old',
+        '--server.flavorRef=ac7.large.2',
+        '--server.imageRef=img',
+        '--server.nics.1.subnet_id=sub',
+      ],
+      { allowWrites: true },
+    );
+
+    assert.ok(plan.sgFindings.length > 0, 'old format should still work');
+    assert.equal(plan.classification.decision, 'deny');
+  } finally {
+    process.env.HCLOUD_BIN = oldEnv;
+    try {
+      require('node:fs').rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  }
+});


### PR DESCRIPTION
## Summary

Fix two bugs in `preflightSecurityGroupCheck()` (introduced in #462) that prevent it from detecting dangerous security group rules when ECS CreateServers uses the `--server.security_groups.N.id` parameter.

## Bugs Fixed

### B1: Extraction regex doesn't match ECS parameter format

`/^--security_group_id(\.\d+)?=(.+)/` only matches VPC-style parameters. ECS CreateServers in KooCLI 7.x uses `--server.security_groups.N.id` (confirmed via `hcloud ECS CreateServers --help`).

**Fix**: Extend regex to also match `--server.security_groups(?:\.\d+)?\.id`.

### B2: ListSecurityGroupRules parameter format is wrong

VPC `ListSecurityGroupRules` `--security_group_id` is an `array<string>` parameter requiring `--security_group_id.1=<id>` (confirmed via `hcloud VPC ListSecurityGroupRules --help`). The flat format `--security_group_id=<id>` is rejected with `[USE_ERROR]不正确的参数`.

**Fix**: Use `--security_group_id.1=${sgId}` array format.

### Bonus: missing --cli-region

**Fix**: Extract `--cli-region` from the ECS command and forward it to the VPC query.

## Changes

| File | Change |
|---|---|
| `plugins/huaweicloud-core/src/hcloud-cli.mjs` | Fix regex, query format, add region forwarding |
| `plugins/huaweicloud-core/skills/huawei-ecs/SKILL.md` | Fix documented `ListSecurityGroupRules` format |
| `test/issue-443-fix.test.mjs` | 3 new tests: ECS nested format, egress exemption, backward compat |

## Verified

- `hcloud ECS CreateServers --help` confirms parameter is `--server.security_groups.[N].id`
- `hcloud VPC ListSecurityGroupRules --security_group_id.1=fake-id` accepts the parameter
- All 86 core tests pass, no regressions
- New test cases: ECS `--server.security_groups.N.id` -> deny, egress-only -> allow, old format -> still works

Closes #443