### PR TITLE
fix(ecs): change preflight SG check from hard-deny to require_user_confirmation

### DIFF
--- a/plugins/huaweicloud-core/src/hcloud-cli.mjs
+++ b/plugins/huaweicloud-core/src/hcloud-cli.mjs
@@ -123,9 +123,10 @@ function applyPreflightFindings(classification, sgFindings) {
   if (hasDeny) {
     return {
       ...classification,
-      decision: 'deny',
+      decision: 'warn',
       risk: 'public_exposure',
       reason: sgFindings[0].message,
+      requireUserConfirmation: true,
     };
   }
   return classification;
@@ -140,6 +141,7 @@ export function planHcloudCommand(args, options = {}) {
   if (sgFindings.length > 0) {
     for (const f of sgFindings) warnings.push(f);
   }
+  const finalClassification = applyPreflightFindings(classification, sgFindings);
   const paramValidation = validateRequiredParams(normalizedArgs);
   if (paramValidation.missing.length > 0) {
     warnings.push('Missing required parameters: ' + paramValidation.missing.join(', '));
@@ -153,10 +155,10 @@ export function planHcloudCommand(args, options = {}) {
     command: redactOutput(command),
     executableBlock: redactOutput(command),
     warnings,
-    classification: applyPreflightFindings(classification, sgFindings),
+    classification: finalClassification,
     sgFindings,
     approvalToken: createApprovalToken(normalizedArgs),
-    safeToRun: classification.decision === 'allow',
+    safeToRun: finalClassification.decision === 'allow',
   };
 }
 

--- a/test/issue-443-fix.test.mjs
+++ b/test/issue-443-fix.test.mjs
@@ -55,7 +55,21 @@ console.log(JSON.stringify({
     );
 
     assert.ok(plan.sgFindings.length > 0, 'B1+B2 fix: should have sg findings');
-    assert.equal(plan.classification.decision, 'deny', 'B1+B2 fix: should deny ECS on dangerous SG reuse');
+    assert.equal(
+      plan.classification.requireUserConfirmation,
+      true,
+      'B1+B2 fix: should require user confirmation, not hard-deny',
+    );
+    assert.notEqual(
+      plan.classification.decision,
+      'deny',
+      'B1+B2 fix: must not hard-deny, user should be able to confirm and proceed',
+    );
+    assert.equal(
+      plan.safeToRun,
+      false,
+      'B1+B2 fix: safeToRun should be false to prevent agent from executing without user confirmation',
+    );
     assert.match(plan.sgFindings[0].message, /22/);
     assert.match(plan.sgFindings[0].message, /77216397/);
   } finally {
@@ -161,7 +175,8 @@ console.log(JSON.stringify({
     );
 
     assert.ok(plan.sgFindings.length > 0, 'old format should still work');
-    assert.equal(plan.classification.decision, 'deny');
+    assert.equal(plan.classification.requireUserConfirmation, true, 'old format: should require user confirmation');
+    assert.notEqual(plan.classification.decision, 'deny', 'old format: must not hard-deny');
   } finally {
     process.env.HCLOUD_BIN = oldEnv;
     try {


### PR DESCRIPTION
## Summary

Follow-up to #464. The earlier fix used `decision=deny` which hard-blocks execution even when the user explicitly approves via `approvedByUser=true`. This changes to a three-tier model.

## Problem

```
deny   -> hard block, user confirmation is ignored  (too strict)
warn   -> agent can auto-execute without asking user (too loose)
```

## Fix

### `applyPreflightFindings`

Changed `decision` from `deny` to `warn`, added `requireUserConfirmation=true` flag:

```js
return {
  ...classification,
  decision: "warn",
  risk: "public_exposure",
  reason: sgFindings[0].message,
  requireUserConfirmation: true,
};
```

### Fixed `safeToRun` calculation

The original code used `classification.decision` (pre-preflight) instead of the post-preflight result. Now uses `finalClassification`:

```js
safeToRun: finalClassification.decision === "allow",
```

## Three-tier safety model

| Tier | Decision | Behavior |
|------|----------|----------|
| Hard block | `deny` | assertAllowed throws, cannot execute (irreversible ops) |
| User confirmation | `warn` + `requireUserConfirmation:true` | safeToRun=false, agent must present warning to user, approvedByUser=true can proceed |
| Safe | `allow` | safeToRun=true, can auto-execute |