### PR TITLE
revert: 回退 PR #468 ECS SG hard-deny

### DIFF
--- a/plugins/huaweicloud-core/src/hcloud-cli.mjs
+++ b/plugins/huaweicloud-core/src/hcloud-cli.mjs
@@ -123,10 +123,9 @@ function applyPreflightFindings(classification, sgFindings) {
   if (hasDeny) {
     return {
       ...classification,
-      decision: 'warn',
+      decision: 'deny',
       risk: 'public_exposure',
       reason: sgFindings[0].message,
-      requireUserConfirmation: true,
     };
   }
   return classification;
@@ -141,7 +140,6 @@ export function planHcloudCommand(args, options = {}) {
   if (sgFindings.length > 0) {
     for (const f of sgFindings) warnings.push(f);
   }
-  const finalClassification = applyPreflightFindings(classification, sgFindings);
   const paramValidation = validateRequiredParams(normalizedArgs);
   if (paramValidation.missing.length > 0) {
     warnings.push('Missing required parameters: ' + paramValidation.missing.join(', '));
@@ -155,10 +153,10 @@ export function planHcloudCommand(args, options = {}) {
     command: redactOutput(command),
     executableBlock: redactOutput(command),
     warnings,
-    classification: finalClassification,
+    classification: applyPreflightFindings(classification, sgFindings),
     sgFindings,
     approvalToken: createApprovalToken(normalizedArgs),
-    safeToRun: finalClassification.decision === 'allow',
+    safeToRun: classification.decision === 'allow',
   };
 }
 

--- a/test/issue-443-fix.test.mjs
+++ b/test/issue-443-fix.test.mjs
@@ -55,21 +55,7 @@ console.log(JSON.stringify({
     );
 
     assert.ok(plan.sgFindings.length > 0, 'B1+B2 fix: should have sg findings');
-    assert.equal(
-      plan.classification.requireUserConfirmation,
-      true,
-      'B1+B2 fix: should require user confirmation, not hard-deny',
-    );
-    assert.notEqual(
-      plan.classification.decision,
-      'deny',
-      'B1+B2 fix: must not hard-deny, user should be able to confirm and proceed',
-    );
-    assert.equal(
-      plan.safeToRun,
-      false,
-      'B1+B2 fix: safeToRun should be false to prevent agent from executing without user confirmation',
-    );
+    assert.equal(plan.classification.decision, 'deny', 'B1+B2 fix: should deny ECS on dangerous SG reuse');
     assert.match(plan.sgFindings[0].message, /22/);
     assert.match(plan.sgFindings[0].message, /77216397/);
   } finally {
@@ -175,8 +161,7 @@ console.log(JSON.stringify({
     );
 
     assert.ok(plan.sgFindings.length > 0, 'old format should still work');
-    assert.equal(plan.classification.requireUserConfirmation, true, 'old format: should require user confirmation');
-    assert.notEqual(plan.classification.decision, 'deny', 'old format: must not hard-deny');
+    assert.equal(plan.classification.decision, 'deny');
   } finally {
     process.env.HCLOUD_BIN = oldEnv;
     try {


### PR DESCRIPTION
## 回退内容

Revert 59adb41 - fix(ecs): change preflight SG check from hard-deny to require_user_confirmation (#468)

回退后 ECS 安全组预检恢复为 hard-deny 模式。

## 变更文件
- \plugins/huaweicloud-core/src/hcloud-cli.mjs\: SG 预检 \warn\ → \deny\，移除 \equireUserConfirmation\
- \	est/issue-443-fix.test.mjs\: 恢复对应测试用例