### PR TITLE
docs(sandbox): find real build output dir across the whole project (#247)

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-sandbox/SKILL.md
@@ -510,11 +510,11 @@ grep -r "outDir\|outputDir\|dest\|distDir" /workspace/<dirname>/.vitepress/confi
 
 If a custom outDir is found, use that instead of the framework-detected default for all subsequent checks.
 
-**Post-build output verification**: after a successful build, verify the actual `index.html` location. Framework-returned `outputDir` may be inaccurate (e.g., uni-app v3 framework: `dist`, actual: `dist/build/h5`):
+**Post-build output verification**: after a successful build, verify the actual `index.html` location. Framework-returned `outputDir` may be inaccurate — either a subdirectory (e.g., uni-app v3: `dist` → `dist/build/h5`) or a completely different top-level path (e.g., Vite `build.outDir` pointing to `portal/public`). Search the whole project (skipping `node_modules`), not just `<outputDir>`:
 
 ```bash
-# Find the real index.html after build
-REAL_INDEX=$(find /workspace/<dirname>/<outputDir> -name "index.html" -type f 2>/dev/null | head -1)
+# Find the real index.html after build (search whole project, not just the default outputDir)
+REAL_INDEX=$(find /workspace/<dirname> -path '*/node_modules' -prune -o -name index.html -type f -print 2>/dev/null | head -1)
 if [ -n "$REAL_INDEX" ] && [ -f "$REAL_INDEX" ]; then
   REAL_OUTDIR=$(dirname "$REAL_INDEX")
   echo "Actual output dir: $REAL_OUTDIR"


### PR DESCRIPTION
## Problem

沙箱部署时，构建产物校验只在一个固定目录内搜索 `index.html`：

```bash
find /workspace/<dirname>/<outputDir> -name index.html
```

当项目用自定义产物目录（如 Vite `build.outDir: 'portal/public'`，指向另一个顶层目录）时，这个 `find` 找不到真实 `index.html`，导致 app 从错误目录起服务、显示文件列表。参见 #247。

## Change

把构建后校验改为**从项目根搜索（跳过 node_modules）**，无论产物落在 `dist`、`portal/public` 还是任意嵌套目录都能定位到真实 `index.html`：

```bash
find /workspace/<dirname> -path '*/node_modules' -prune -o -name index.html -type f -print
```

并同步把说明文字补充为「可能是子目录（uni-app → dist/build/h5）或完全不同的顶层路径（Vite build.outDir → portal/public）」。

## Not included

- 未改 `detect_framework` 的 Vite `build.outDir` 解析（vite.config 是可执行 JS，正则只碰字面量、很脆；构建后 `find` 才是权威兜底）。

## Verification

- `npm run lint:md`：0 issues
- `npm test`：全绿
