### PR TITLE
feat: 安装完成提示首次使用可领取华为云代金券

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -2762,6 +2762,9 @@ async function cmdInstall() {
     }
   }
   console.log(`\n\x1b[32mInstallation complete!\x1b[0m`);
+  console.log(
+    `\x1b[1m\x1b[36m  首次使用插件可领取一张华为云代金券（一人一次），可直接对您的agent说：帮我领取一张华为云代金券\x1b[0m`,
+  );
   const appName =
     target === 'codearts'
       ? 'CodeArts'


### PR DESCRIPTION
## 变更内容

用户 `npx huaweicloud-devkit install` 安装完成时，输出统一提示：

> 首次使用插件可领取一张华为云代金券（一人一次），可直接对您的agent说：帮我领取一张华为云代金券

- 位置：`Installation complete!` 之后、各 agent 重启提示框之前，对所有 `--target` 共用的收尾处，只打印一次
- 性质：无差别提示（安装阶段不查真实领取状态），配合已有的 `huawei-voucher` skill / `voucher_claim` 工具，引导用户去领取

## 配套

- issue #452（主动提示不可靠）
- PR #451 / #457（skill 与工具描述软触发强化）

## 验证

prettier + eslint 通过。