### PR TITLE
fix(auth): prefer auth-init creds over injected STS env creds (#479)

### DIFF
--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -99,6 +99,23 @@ export function resolveCredentials(options = {}) {
     if (!region && stored.region) region = stored.region;
   }
 
+  // Sandbox/platform-injected temporary STS credentials (env vars carrying a
+  // security token) must not shadow the user's explicit permanent credentials
+  // from `auth init`. Prefer the stored file when both exist.
+  if (
+    process.env.HW_ACCESS_KEY &&
+    process.env.HW_SECRET_KEY &&
+    process.env.HW_SECURITY_TOKEN &&
+    stored &&
+    stored.ak &&
+    stored.sk
+  ) {
+    ak = stored.ak;
+    sk = stored.sk;
+    securityToken = stored.securityToken || '';
+    region = stored.region || region;
+  }
+
   if (!ak || !sk) {
     if (options.allowMissing) return null;
     throw new Error(

--- a/test/auth-credentials.test.mjs
+++ b/test/auth-credentials.test.mjs
@@ -300,6 +300,53 @@ test('getParentCwd returns a string on Linux and does not throw', () => {
   assert.ok(cwd === null || (typeof cwd === 'string' && cwd.length > 0));
 });
 
+test('resolveCredentials prefers auth-init vault over env STS temporary credentials', () => {
+  withTempHome(() => {
+    clearRuntimeCredentials();
+    writeGlobalCredentials({ ak: 'VAULT_AK', sk: 'VAULT_SK', region: 'cn-north-4' });
+
+    process.env.HW_ACCESS_KEY = 'STS_AK';
+    process.env.HW_SECRET_KEY = 'STS_SK';
+    process.env.HW_SECURITY_TOKEN = 'STS_TOKEN';
+    process.env.HW_REGION = 'cn-south-1';
+
+    const creds = resolveCredentials();
+    assert.equal(creds.ak, 'VAULT_AK');
+    assert.equal(creds.sk, 'VAULT_SK');
+    assert.equal(creds.securityToken, '');
+    assert.equal(creds.region, 'cn-north-4');
+  });
+});
+
+test('resolveCredentials keeps env STS when no auth-init vault exists', () => {
+  withTempHome(() => {
+    clearRuntimeCredentials();
+    process.env.HW_ACCESS_KEY = 'STS_AK';
+    process.env.HW_SECRET_KEY = 'STS_SK';
+    process.env.HW_SECURITY_TOKEN = 'STS_TOKEN';
+    process.env.HW_REGION = 'cn-south-1';
+
+    const creds = resolveCredentials();
+    assert.equal(creds.ak, 'STS_AK');
+    assert.equal(creds.sk, 'STS_SK');
+    assert.equal(creds.securityToken, 'STS_TOKEN');
+    assert.equal(creds.region, 'cn-south-1');
+  });
+});
+
+test('resolveCredentials keeps permanent env over vault (no security token)', () => {
+  withTempHome(() => {
+    clearRuntimeCredentials();
+    writeGlobalCredentials({ ak: 'VAULT_AK', sk: 'VAULT_SK', region: 'cn-north-4' });
+    process.env.HW_ACCESS_KEY = 'ENV_PERM_AK';
+    process.env.HW_SECRET_KEY = 'ENV_PERM_SK';
+
+    const creds = resolveCredentials();
+    assert.equal(creds.ak, 'ENV_PERM_AK');
+    assert.equal(creds.sk, 'ENV_PERM_SK');
+  });
+});
+
 test('resolveCredentials reads CodeArts credentials from CODEARTS_PROJECT_DIR', () => {
   withTempHome((_home) => {
     clearRuntimeCredentials();


### PR DESCRIPTION
## Problem

在码道（CodeArts）沙箱里，运行时会向进程注入临时 STS 凭据（`HW_ACCESS_KEY`/`HW_SECRET_KEY`/`HW_SECURITY_TOKEN`）。而 `resolveCredentials()` 里环境变量优先级最高，导致用户通过 `auth init` 配置的永久凭据被压过，代金券/IAM 等查询实际用的是沙箱临时账号而非用户自己的账号。参见 #479。

## Fix（方案 2，窄化）

仅在「env 凭证携带 `HW_SECURITY_TOKEN`（= 临时 STS）**且** 存在 `auth init` 永久凭证文件」时，让永久文件优先：

- env 带 token + 有永久文件 → 用永久文件
- env 带 token、无永久文件 → 仍用 env STS（沙箱自身账号）
- env 不带 token（用户显式永久 env）→ 仍覆盖文件（保留文档化覆盖行为）
- runtime 凭据（`huaweicloud_auth_init`）→ 仍最高

只处理 env 注入通道；CodeArts `mcp_settings.json` 通道（`readCodeArtsCredentials`）本次不动（它另有 securityToken 未透传的既有问题，建议单独跟踪）。

## Tests

`test/auth-credentials.test.mjs` 新增 3 条：STS+文件→文件；STS+无文件→STS；永久 env→覆盖文件。

## Verification

- `npm test`：200 全绿
- `npm run validate`、`lint:js`、`format:check` 通过
