### PR TITLE
fix: speed up npm test (scope discovery + skip npm audit)

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     }
   },
   "scripts": {
-    "test": "node --test",
+    "test": "node --test \"test/*.test.mjs\"",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "lint:md": "markdownlint-cli2 \"**/*.md\" \"#node_modules\" \"#.git\" \"#test/**\" \"#docs/**\"",

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -474,7 +474,7 @@ function installRuntimeDeps(pluginsDir) {
     stdio: 'pipe',
     timeout: 120000,
   };
-  let r = spawnSync('npm', ['install', '--omit=dev'], spawnOpts);
+  let r = spawnSync('npm', ['install', '--omit=dev', '--no-audit', '--no-fund'], spawnOpts);
   const isRetryable = (res) => {
     if (res.status === 0) return false;
     const stderr = (res.stderr || '').toString();
@@ -483,12 +483,12 @@ function installRuntimeDeps(pluginsDir) {
   if (r.status !== 0 && isRetryable(r)) {
     console.log(`  \x1b[33m[WARN]\x1b[0m npm install hit file-lock error, retrying in 2s...`);
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 2000);
-    r = spawnSync('npm', ['install', '--omit=dev'], spawnOpts);
+    r = spawnSync('npm', ['install', '--omit=dev', '--no-audit', '--no-fund'], spawnOpts);
   }
   if (r.status !== 0 && !isRetryable(r)) {
     console.log(`  \x1b[33m[RETRY]\x1b[0m npm install failed (exit ${r.status}), retrying in 3s...`);
     Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 3000);
-    r = spawnSync('npm', ['install', '--omit=dev'], spawnOpts);
+    r = spawnSync('npm', ['install', '--omit=dev', '--no-audit', '--no-fund'], spawnOpts);
   }
   const undiciDir = join(pluginsDir, 'node_modules', 'undici');
   if (r.status === 0 && existsSync(undiciDir)) {


### PR DESCRIPTION
﻿## Problem

`npm test` hung for minutes and appeared to stall. Two root causes:

1. `node --test` (Node 22+) auto-discovers every `.js/.mjs` under any `test/` directory, so it also executed the stray nightly-harness driver `test/huaweicloud-agent-toolkit-test/scripts/invoke-mcp.mjs` (a 240s-bound MCP driver, not a test).
2. `installRuntimeDeps()` in `plugins/huaweicloud-core/src/setup-cli.mjs` runs `npm install --omit=dev` to fetch `undici`. npm's default security audit POST hangs/times out on restricted networks, blocking every install (with a 120s timeout plus retries).

## Changes

- `package.json`: scope tests to real files: `node --test "test/*.test.mjs"`.
- `setup-cli.mjs`: add `--no-audit --no-fund` to the three `npm install` calls in `installRuntimeDeps`.

## Verification

- `npm test` completes in ~20-30s (previously hung >2 min).
- `node bin/setup.cjs install --target opencode` completes in <2s (previously >90s).
