### PR TITLE
feat: add version command and per-agent installed version readback

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,10 @@ Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), Off
 
 > If `--target` is omitted, the installer auto-detects agents on your machine. When multiple agents are detected, **all of them** will be installed. Specify `--target` to control which agent receives the install.
 
+```bash
+npx --yes huaweicloud-devkit version  # print the installed plugin version per agent
+```
+
 ### OpenCode
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -27,6 +27,10 @@
 
 > 省略 `--target` 时，安装器会自动检测机器上的 agent，检测到多个时**全部安装**。建议始终指定 `--target` 以明确安装目标。
 
+```bash
+npx --yes huaweicloud-devkit version  # 查看各 agent 已安装的插件版本
+```
+
 ### OpenCode
 
 ```bash

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -14,6 +14,7 @@ import { homedir, platform } from 'node:os';
 import { createInterface } from 'node:readline';
 import { spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
+import { createRequire } from 'node:module';
 
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { SUPPORTED_AGENT_TARGETS } from './auth/agent-registration.mjs';
@@ -31,7 +32,6 @@ import {
   getProxySettings,
 } from './proxy/proxy-config.mjs';
 
-import { createRequire } from 'node:module';
 const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite');
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -4005,6 +4005,42 @@ async function cmdProxy() {
   return cmdProxyShow();
 }
 
+function readInstalledVersion(pluginsDir) {
+  const p = join(pluginsDir, 'package.json');
+  if (!existsSync(p)) return null;
+  try {
+    const v = JSON.parse(readFileSync(p, 'utf8')).version;
+    return typeof v === 'string' && v ? v : null;
+  } catch {
+    return null;
+  }
+}
+
+function cmdVersion() {
+  const agents = [
+    ['OpenCode', opencodePluginsDir()],
+    ['Codex Desktop', codexDesktopPluginsDir()],
+    ['OpenClaw', openclawPluginsDir()],
+    ['CodeArts', codeartsPluginsDir()],
+    ['CodeArts Work', codeartsWorkPluginsDir()],
+    ['WorkBuddy', workbuddyPluginsDir()],
+    ['DSH', dshPluginsDir()],
+    ['OfficeAce', officeacePluginsDir()],
+    ['Hermes', hermesPluginsDir()],
+    ['AtomCode', atomcodePluginsDir()],
+  ];
+  let found = 0;
+  for (const [label, dir] of agents) {
+    const v = dir ? readInstalledVersion(dir) : null;
+    if (!v) continue;
+    console.log(`${label}: ${v}`);
+    found += 1;
+  }
+  if (found === 0) {
+    console.log('No Huawei Cloud DevKit plugin installed. Run `npx huaweicloud-devkit install --target <agent>`.');
+  }
+}
+
 async function main() {
   const cmd = process.argv[2] || 'help';
 
@@ -4041,6 +4077,12 @@ async function main() {
     case 'proxy':
       await cmdProxy();
       break;
+    case 'version':
+    case '--version':
+    case '-v':
+    case '-V':
+      cmdVersion();
+      break;
     case 'help':
     case '--help':
     case '-h':
@@ -4059,11 +4101,13 @@ async function main() {
       console.log('  install-hcloud  Show KooCLI install commands for your OS');
       console.log('  auth         Manage unified auth: init | sync | status');
       console.log('  proxy        Manage proxy config: init | show | clear');
+      console.log('  version      Print installed plugin version per agent');
       console.log('  help         Show this help');
       console.log('\nOptions:');
       console.log(
         '  --target     Target agent: opencode (default), codex, codearts, codearts-work, workbuddy, dsh, officeace, hermes, openclaw, atomcode, all',
       );
+      console.log('  --version    Print installed plugin version per agent');
       console.log('\nExamples:');
       console.log('  npx huaweicloud-devkit install');
       console.log('  npx huaweicloud-devkit install --target codex');

--- a/test/cross-platform-install.test.mjs
+++ b/test/cross-platform-install.test.mjs
@@ -137,3 +137,18 @@ test('uninstall cleans up all platform directories', () => {
     rmSync(cwd, { recursive: true, force: true });
   }
 });
+
+test('version reports installed plugin version per agent', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cp-verinst-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'cp-proj-'));
+  try {
+    assert.equal(runCli(home, cwd, ['install', '--target', 'opencode']).status, 0);
+    const res = runCli(home, cwd, ['version']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /OpenCode: \d+\.\d+\.\d+/);
+    assert.doesNotMatch(res.stdout, /not installed/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -492,6 +492,14 @@ test('setup-cli.mjs supports the hermes target end to end', () => {
   assert.match(setup, /function hermesMcpSdkOk\(\)/);
 });
 
+test('setup-cli.mjs supports the version command', () => {
+  const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
+  assert.match(setup, /function cmdVersion\(\)/);
+  assert.match(setup, /function readInstalledVersion\(/);
+  assert.match(setup, /case '--version'/);
+  assert.match(setup, /case 'version'/);
+});
+
 test('tools.mjs resolves skills from the hermes directory', () => {
   const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
   assert.match(tools, /function hermesSkillsDir\(\)/);


### PR DESCRIPTION
## Motivation

插件没有统一的「版本查询」入口。用户关心的是**各 agent 实际安装的插件本体版本**，而不是安装程序/CLI 的版本。

## Change

新增 `version` 命令（及 `--version` / `-v` / `-V` 别名），**只输出各 agent 已安装的插件本体版本**（读 `<pluginsDir>/package.json`），不带任何安装程序/CLI 版本：

```
OpenCode: 1.1.1-next.1
Codex Desktop: not installed
...
Hermes: 1.1.0-next.11
Codex (CLI): managed by Codex CLI (bundle)
```

- 不区分「CLI 版本」与「本体版本」，仅报告本体版本。
- `codex`(CLI) 走 bundle 管理，无本地 package.json，标注跳过。

## Files

- `plugins/huaweicloud-core/src/setup-cli.mjs`：`readInstalledVersion` + `cmdVersion` + switch 分支 + help
- `README.md` / `README.zh-CN.md`：Quick Start 补 `version` 示例
- `test/structure.test.mjs` + `test/cross-platform-install.test.mjs`

## Verification

- `npm test`：204 全绿
- `npm run validate`、`npm run format:check` 通过