### PR TITLE
feat(uninstall): optional KooCLI/OBS cleanup on global uninstall

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), Off
 
 ```bash
 npx --yes huaweicloud-devkit version  # print the installed plugin version per agent
+npx --yes huaweicloud-devkit uninstall --target all --clean-global  # also remove KooCLI + OBS config
 ```
 
 ### OpenCode

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -29,6 +29,7 @@
 
 ```bash
 npx --yes huaweicloud-devkit version  # 查看各 agent 已安装的插件版本
+npx --yes huaweicloud-devkit uninstall --target all --clean-global  # 一并删除 KooCLI 与 OBS 配置
 ```
 
 ### OpenCode

--- a/plugins/huaweicloud-core/src/sandbox/uninstall-cleanup.mjs
+++ b/plugins/huaweicloud-core/src/sandbox/uninstall-cleanup.mjs
@@ -1,0 +1,50 @@
+import { existsSync, readdirSync, rmSync } from 'node:fs';
+import { join } from 'node:path';
+import { homedir } from 'node:os';
+
+import { obsConfigPath } from '../auth/credentials.mjs';
+
+// Remove the KooCLI (hcloud) binary and its config directory. Only touches the
+// default install locations; a user-managed binary behind HCLOUD_BIN or a
+// Windows PATH entry is left alone. Returns the list of removed paths.
+export function removeKooCli(home = homedir()) {
+  const removed = [];
+
+  for (const bin of [
+    join(home, '.local', 'bin', 'hcloud'),
+    join(home, 'hcloud', 'hcloud'),
+    join(home, 'hcloud', 'hcloud.exe'),
+  ]) {
+    if (existsSync(bin)) {
+      rmSync(bin, { force: true });
+      removed.push(bin);
+    }
+  }
+
+  const configDir = join(home, '.hcloud');
+  if (existsSync(configDir)) {
+    rmSync(configDir, { recursive: true, force: true });
+    removed.push(configDir);
+  }
+
+  const installDir = join(home, 'hcloud');
+  try {
+    if (existsSync(installDir) && readdirSync(installDir).length === 0) {
+      rmSync(installDir, { recursive: true, force: true });
+      removed.push(installDir);
+    }
+  } catch {
+    // Non-fatal: an empty-dir cleanup is best-effort.
+  }
+
+  return removed;
+}
+
+// Remove the OBS credential config (~/.obsutilconfig). Returns the removed
+// path, or an empty array when the file did not exist.
+export function removeObsConfig() {
+  const p = obsConfigPath();
+  if (!existsSync(p)) return [];
+  rmSync(p, { force: true });
+  return [p];
+}

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -31,6 +31,7 @@ import {
   clearProxyConfig,
   getProxySettings,
 } from './proxy/proxy-config.mjs';
+import { removeKooCli, removeObsConfig } from './sandbox/uninstall-cleanup.mjs';
 
 const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite');
 
@@ -2967,8 +2968,63 @@ async function cmdUninstall() {
         console.log(`  Removed empty directory: ${vaultDir}`);
       }
     } catch {}
+    await promptGlobalCleanup();
   }
+
   console.log(`\n\x1b[32mUninstall complete.\x1b[0m`);
+
+  if (target !== 'all') {
+    console.log(
+      `\n\x1b[33m💡 本次仅卸载了 ${target} 的插件。如需清理全局配置（凭据库/OBS/KooCLI），请运行 \`npx huaweicloud-devkit uninstall --target all\`。\x1b[0m`,
+    );
+  }
+}
+
+function removeKooCliWithMessage() {
+  const removed = removeKooCli();
+  if (removed.length) {
+    console.log(`  KooCLI removed: ${removed.join(', ')}`);
+  } else {
+    console.log('  KooCLI not found (nothing to remove).');
+  }
+}
+
+function removeObsConfigWithMessage() {
+  const removed = removeObsConfig();
+  if (removed.length) {
+    console.log(`  OBS config removed: ${removed.join(', ')}`);
+  } else {
+    console.log('  OBS config not found (nothing to remove).');
+  }
+}
+
+async function promptGlobalCleanup() {
+  const hasFlag = (name) => process.argv.includes(name);
+  const cleanKocli = hasFlag('--clean-kocli') || hasFlag('--clean-global');
+  const cleanObs = hasFlag('--clean-obs') || hasFlag('--clean-global');
+
+  // Interactive terminal: ask the user for each account-level tool.
+  if (!cleanKocli && !cleanObs && process.stdin.isTTY && process.stdout.isTTY) {
+    console.log('\n  —— 全局凭据库已清除，是否一并删除账号级工具？——');
+    const kocliAnswer = await readLineQuestion('  是否一并删除 KooCLI (hcloud)？(y/N) ');
+    const obsAnswer = await readLineQuestion('  是否一并删除 OBS 配置 (~/.obsutilconfig)？(y/N) ');
+    if (/^\s*y\s*$/i.test(kocliAnswer)) removeKooCliWithMessage();
+    else console.log('  KooCLI kept.');
+    if (/^\s*y\s*$/i.test(obsAnswer)) removeObsConfigWithMessage();
+    else console.log('  OBS config kept.');
+    return;
+  }
+
+  // Explicit flags: delete deterministically, without prompting.
+  if (cleanKocli) removeKooCliWithMessage();
+  if (cleanObs) removeObsConfigWithMessage();
+
+  // No flag and non-interactive: keep them and surface the option.
+  if (!cleanKocli && !cleanObs) {
+    console.log(
+      `\n\x1b[33m已保留 KooCLI 与 OBS 配置（全局凭据库已删除）。如需一并清理，请使用 --clean-kocli / --clean-obs / --clean-global flag，或在交互终端重新执行全局卸载。\x1b[0m`,
+    );
+  }
 }
 
 async function cmdStatus() {
@@ -4108,6 +4164,9 @@ async function main() {
         '  --target     Target agent: opencode (default), codex, codearts, codearts-work, workbuddy, dsh, officeace, hermes, openclaw, atomcode, all',
       );
       console.log('  --version    Print installed plugin version per agent');
+      console.log('  --clean-kocli   (with: uninstall --target all) also remove KooCLI');
+      console.log('  --clean-obs     (with: uninstall --target all) also remove OBS config');
+      console.log('  --clean-global  (with: uninstall --target all) also remove KooCLI + OBS config');
       console.log('\nExamples:');
       console.log('  npx huaweicloud-devkit install');
       console.log('  npx huaweicloud-devkit install --target codex');

--- a/test/cross-platform-install.test.mjs
+++ b/test/cross-platform-install.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -147,6 +147,79 @@ test('version reports installed plugin version per agent', () => {
     assert.equal(res.status, 0, res.stderr);
     assert.match(res.stdout, /OpenCode: \d+\.\d+\.\d+/);
     assert.doesNotMatch(res.stdout, /not installed/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('single-agent uninstall hints about global cleanup', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cp-uninst-hint-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'cp-proj-'));
+  try {
+    assert.equal(runCli(home, cwd, ['install', '--target', 'opencode']).status, 0);
+    const res = runCli(home, cwd, ['uninstall', '--target', 'opencode']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /如需清理全局配置/);
+    assert.match(res.stdout, /uninstall --target all/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('uninstall --target all (non-TTY) keeps KooCLI/OBS but removes the vault', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cp-uninst-all-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'cp-proj-'));
+  try {
+    assert.equal(runCli(home, cwd, ['install', '--target', 'opencode']).status, 0);
+
+    // Simulate account-level artifacts that `auth init` would have written.
+    const vault = join(home, '.config', 'huaweicloud', 'credentials.json');
+    mkdirSync(join(home, '.config', 'huaweicloud'), { recursive: true });
+    writeFileSync(vault, '{}');
+    const obsFile = join(home, '.obsutilconfig');
+    writeFileSync(obsFile, 'ak=x\nsk=y\n');
+    const kocliBin = join(home, '.local', 'bin', 'hcloud');
+    mkdirSync(join(home, '.local', 'bin'), { recursive: true });
+    writeFileSync(kocliBin, '#!/bin/sh\n');
+
+    const res = runCli(home, cwd, ['uninstall', '--target', 'all']);
+    assert.equal(res.status, 0, res.stderr);
+
+    assert.ok(!existsSync(vault), 'vault should be removed on --target all');
+    assert.ok(existsSync(obsFile), 'OBS config must be kept without a flag in non-TTY');
+    assert.ok(existsSync(kocliBin), 'KooCLI must be kept without a flag in non-TTY');
+    assert.match(res.stdout, /已保留 KooCLI 与 OBS 配置/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('uninstall --target all --clean-global removes KooCLI and OBS config', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cp-uninst-clean-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'cp-proj-'));
+  try {
+    assert.equal(runCli(home, cwd, ['install', '--target', 'opencode']).status, 0);
+
+    const vault = join(home, '.config', 'huaweicloud', 'credentials.json');
+    mkdirSync(join(home, '.config', 'huaweicloud'), { recursive: true });
+    writeFileSync(vault, '{}');
+    const obsFile = join(home, '.obsutilconfig');
+    writeFileSync(obsFile, 'ak=x\nsk=y\n');
+    const kocliBin = join(home, '.local', 'bin', 'hcloud');
+    mkdirSync(join(home, '.local', 'bin'), { recursive: true });
+    writeFileSync(kocliBin, '#!/bin/sh\n');
+
+    const res = runCli(home, cwd, ['uninstall', '--target', 'all', '--clean-global']);
+    assert.equal(res.status, 0, res.stderr);
+
+    assert.ok(!existsSync(vault), 'vault should be removed on --target all');
+    assert.ok(!existsSync(obsFile), 'OBS config should be removed with --clean-global');
+    assert.ok(!existsSync(kocliBin), 'KooCLI should be removed with --clean-global');
+    assert.match(res.stdout, /KooCLI removed/);
+    assert.match(res.stdout, /OBS config removed/);
   } finally {
     rmSync(home, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });

--- a/test/uninstall-cleanup.test.mjs
+++ b/test/uninstall-cleanup.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict';
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import test from 'node:test';
+
+import { removeKooCli, removeObsConfig } from '../plugins/huaweicloud-core/src/sandbox/uninstall-cleanup.mjs';
+
+test('removeKooCli removes default hcloud binary and config dir', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cleanup-kocli-'));
+  try {
+    const bin = join(home, '.local', 'bin', 'hcloud');
+    mkdirSync(join(home, '.local', 'bin'), { recursive: true });
+    writeFileSync(bin, '#!/bin/sh\n');
+    const configDir = join(home, '.hcloud');
+    mkdirSync(configDir, { recursive: true });
+    writeFileSync(join(configDir, 'config.json'), '{}');
+    const installDir = join(home, 'hcloud');
+    mkdirSync(installDir, { recursive: true });
+    writeFileSync(join(installDir, 'hcloud.exe'), 'x');
+
+    const removed = removeKooCli(home);
+
+    assert.ok(!existsSync(bin), 'hcloud binary should be removed');
+    assert.ok(!existsSync(configDir), '.hcloud config dir should be removed');
+    assert.ok(!existsSync(join(installDir, 'hcloud.exe')), 'hcloud.exe should be removed');
+    assert.ok(removed.length >= 3, `expected at least 3 removed paths, got ${removed.length}`);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('removeKooCli does not touch an empty non-hcloud install dir', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cleanup-kocli2-'));
+  try {
+    const removed = removeKooCli(home);
+    assert.deepEqual(removed, []);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('removeObsConfig removes the OBS config file', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cleanup-obs-'));
+  const prev = process.env.HUAWEICLOUD_HOME;
+  try {
+    process.env.HUAWEICLOUD_HOME = home;
+    const obsFile = join(home, '.obsutilconfig');
+    writeFileSync(obsFile, 'ak=x\nsk=y\n');
+
+    const removed = removeObsConfig();
+
+    assert.deepEqual(removed, [obsFile]);
+    assert.ok(!existsSync(obsFile));
+  } finally {
+    if (prev === undefined) delete process.env.HUAWEICLOUD_HOME;
+    else process.env.HUAWEICLOUD_HOME = prev;
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('removeObsConfig returns empty when no OBS config exists', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cleanup-obs2-'));
+  const prev = process.env.HUAWEICLOUD_HOME;
+  try {
+    process.env.HUAWEICLOUD_HOME = home;
+    assert.deepEqual(removeObsConfig(), []);
+  } finally {
+    if (prev === undefined) delete process.env.HUAWEICLOUD_HOME;
+    else process.env.HUAWEICLOUD_HOME = prev;
+    rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## Motivation

卸载插件只清理「插件本体 + skill + 各 agent 的 MCP 配置」，从不清理账号级的 **KooCLI (hcloud)** 和 **OBS 配置 (~/.obsutilconfig)**，导致残留。且 agent 场景（非交互）下无法让用户选择是否一并清理。

## Change

### 全局删除 `uninstall --target all`
在三处均删除（含凭据库）后，可选择一并清理账号级工具：

- **交互终端（TTY）**：依次询问「是否删除 KooCLI / OBS 配置」两个独立问题。
- **显式 flag**（agent/脚本友好）：`--clean-kocli` / `--clean-obs` / `--clean-global`（合并别名）。
- **非交互且无 flag**：默认跳过并打印「已保留…」提示。

`removeKooCli` 删除默认路径 hcloud 二进制（`~/.local/bin/hcloud`、`~/hcloud/hcloud`、`~/hcloud/hcloud.exe`）与 `~/.hcloud/` 配置目录；**不碰** `HCLOUD_BIN` 自定义路径、**不碰** Windows 用户 PATH。`removeObsConfig` 删除 `~/.obsutilconfig`。

### 单 agent 删除 `uninstall --target <agent>`
行为不变，结束时提示「如需全局清理请用 `uninstall --target all`」。

## Files

- 新增 `plugins/huaweicloud-core/src/sandbox/uninstall-cleanup.mjs`
- `plugins/huaweicloud-core/src/setup-cli.mjs`（flag 解析 + 交互 + 提示 + help 文案）
- `README.md` / `README.zh-CN.md`
- 新增 `test/uninstall-cleanup.test.mjs` + `test/cross-platform-install.test.mjs` 用例

## Verification

- `npm test`：211 全绿
- `npm run validate` / `lint:js` / `format:check` 通过
