### PR TITLE
feat: detect new plugin versions on install/update

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -2743,11 +2743,32 @@ function parseTarget() {
   process.exit(1);
 }
 
+function checkForUpdate() {
+  if (pkgVersion === '0.0.0') return;
+  const tag = /-next\.\d+/.test(pkgVersion) ? 'next' : 'latest';
+  let latest = null;
+  try {
+    const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
+    const r = spawnSync(npmBin, ['view', `huaweicloud-devkit@${tag}`, 'version'], {
+      encoding: 'utf8',
+      timeout: 5000,
+      windowsHide: true,
+    });
+    if (r.status === 0) latest = (r.stdout || '').trim().split('\n').pop().trim();
+  } catch {}
+  if (latest && latest !== pkgVersion) {
+    console.log(
+      `\n\x1b[33mℹ️ 检测到新版本：${latest}（当前 ${pkgVersion}，${tag} 频道）。建议运行 \`npx huaweicloud-devkit@${tag} update\` 更新。\x1b[0m`,
+    );
+  }
+}
+
 async function cmdInstall() {
   const target = parseTarget();
   console.log(BANNER);
   console.log(`Installing HuaweiCloud DevKit${target !== 'opencode' ? ` for ${target}` : ''}...\n`);
   checkNode();
+  checkForUpdate();
 
   if (target === 'opencode' || target === 'all') {
     console.log('[OpenCode]');
@@ -3450,6 +3471,7 @@ async function cmdDoctor() {
 async function cmdUpdate() {
   console.log(BANNER);
   const target = parseTarget();
+  checkForUpdate();
 
   if (target === 'opencode') {
     if (!existsSync(join(opencodePluginsDir(), 'src', 'mcp-server.mjs'))) {

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -500,6 +500,16 @@ test('setup-cli.mjs supports the version command', () => {
   assert.match(setup, /case 'version'/);
 });
 
+test('setup-cli.mjs checks for updates on install/update', () => {
+  const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
+  assert.match(setup, /function checkForUpdate\(\)/);
+  assert.match(setup, /\? 'next' : 'latest'/);
+  assert.match(setup, /huaweicloud-devkit@\$\{tag\}/);
+  assert.match(setup, /npm\.cmd/);
+  const calls = setup.match(/checkForUpdate\(\);?/g);
+  assert.ok(calls && calls.length >= 2, 'checkForUpdate should be called in both cmdInstall and cmdUpdate');
+});
+
 test('tools.mjs resolves skills from the hermes directory', () => {
   const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
   assert.match(tools, /function hermesSkillsDir\(\)/);


### PR DESCRIPTION
## Motivation

`install`/`update` 没有任何「新版本可更新」的提示，且当 `npx huaweicloud-devkit@next` 命中了陈旧的全局/缓存副本时，用户无从察觉自己跑的是旧版。

## Change

新增 best-effort 的 `checkForUpdate()`，在 `install` 和 `update` 开头各调一次：

- 频道推断：当前版本带 `-next.N` → 对 `next` dist-tag；否则为正式版 → 对 `latest` dist-tag（**薯道隔离，不会给 stable 用户查 next，反之亦然**）。
- 查询 `npm view huaweicloud-devkit@<tag> version`（`timeout: 5000` + try/catch，离线/超时静默跳过，不阻断）。
- 版本不一致时打印：

  `ℹ️ 检测到新版本：<latest>（当前 <pkgVersion>，<tag> 频道）。建议运行 \`npx huaweicloud-devkit@<tag> update\` 更新。`

## Files

- `plugins/huaweicloud-core/src/setup-cli.mjs`
- `test/structure.test.mjs`

## Verification

- `npm test`：212 全绿
- `npm run validate` / `lint:js` / `format:check` 通过
