### PR TITLE
feat(update): session-level version update detection & auto-upgrade

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,10 +249,13 @@ npx --yes huaweicloud-devkit install --target all
 ### Update All Agents
 
 ```bash
-npx --yes huaweicloud-devkit update --target all
+npx huaweicloud-devkit version
+npx --yes huaweicloud-devkit@latest update --target all
 ```
 
-`update` is incremental — it refreshes installed files without touching your config.
+`update` is incremental — it refreshes installed files without touching your
+config. Always keep `@latest` so npm fetches the newest version instead of a
+locally cached older one.
 
 ## What It Does
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -249,10 +249,11 @@ npx --yes huaweicloud-devkit install --target all
 ### 更新所有 Agent
 
 ```bash
-npx --yes huaweicloud-devkit update --target all
+npx huaweicloud-devkit version
+npx --yes huaweicloud-devkit@latest update --target all
 ```
 
-`update` 是增量更新——只刷新已安装的文件，不动配置文件。
+`update` 是增量更新——只刷新已安装的文件，不动配置文件。请务必保留 `@latest`，确保 npm 获取最新版本而非本地缓存的旧版本。
 
 ## 功能特性
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "huaweicloud-devkit",
-  "version": "1.1.1-next.16",
+  "version": "1.1.2-next.0",
   "description": "Agent toolkit that helps coding agents use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities safely and accurately.",
   "type": "module",
   "files": [

--- a/plugin.json
+++ b/plugin.json
@@ -10,13 +10,5 @@
   "homepage": "https://github.com/huaweicloud/huaweicloud-devkit",
   "repository": "https://github.com/huaweicloud/huaweicloud-devkit",
   "license": "Apache-2.0",
-  "keywords": [
-    "huaweicloud",
-    "huawei-cloud",
-    "mcp",
-    "koocli",
-    "hcloud",
-    "agent",
-    "skills"
-  ]
+  "keywords": ["huaweicloud", "huawei-cloud", "mcp", "koocli", "hcloud", "agent", "skills"]
 }

--- a/plugin.json
+++ b/plugin.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://agent-plugins.org/schemas/1.0.0/plugin.schema.json",
   "name": "huaweicloud-devkit",
-  "version": "1.1.1-next.16",
+  "version": "1.1.2-next.0",
   "description": "Huawei Cloud guidance, CLI/API/SDK routing, MCP tools, and safety for coding agents.",
   "author": {
     "name": "HuaweiCloud Mate",
@@ -10,5 +10,13 @@
   "homepage": "https://github.com/huaweicloud/huaweicloud-devkit",
   "repository": "https://github.com/huaweicloud/huaweicloud-devkit",
   "license": "Apache-2.0",
-  "keywords": ["huaweicloud", "huawei-cloud", "mcp", "koocli", "hcloud", "agent", "skills"]
+  "keywords": [
+    "huaweicloud",
+    "huawei-cloud",
+    "mcp",
+    "koocli",
+    "hcloud",
+    "agent",
+    "skills"
+  ]
 }

--- a/plugins/huaweicloud-core/.claude-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.claude-plugin/plugin.json
@@ -5,10 +5,7 @@
     "longDescription": "HuaweiCloud Devkit helps coding agents choose and use Huawei Cloud Skills, KooCLI, APIs, SDKs, and MCP tools with less context, safer command execution, and more accurate cloud implementation decisions.",
     "developerName": "HuaweiCloud Mate",
     "category": "Cloud",
-    "capabilities": [
-      "Read",
-      "Interactive"
-    ],
+    "capabilities": ["Read", "Interactive"],
     "websiteURL": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
     "brandColor": "#C7000B",
     "defaultPrompt": [
@@ -30,15 +27,5 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": [
-    "huaweicloud",
-    "huawei-cloud",
-    "koocli",
-    "hcloud",
-    "agent",
-    "mcp",
-    "api",
-    "sdk",
-    "skills"
-  ]
+  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"]
 }

--- a/plugins/huaweicloud-core/.claude-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.claude-plugin/plugin.json
@@ -5,7 +5,10 @@
     "longDescription": "HuaweiCloud Devkit helps coding agents choose and use Huawei Cloud Skills, KooCLI, APIs, SDKs, and MCP tools with less context, safer command execution, and more accurate cloud implementation decisions.",
     "developerName": "HuaweiCloud Mate",
     "category": "Cloud",
-    "capabilities": ["Read", "Interactive"],
+    "capabilities": [
+      "Read",
+      "Interactive"
+    ],
     "websiteURL": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
     "brandColor": "#C7000B",
     "defaultPrompt": [
@@ -17,7 +20,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "skills": "./skills/",
-  "version": "1.1.1-next.16",
+  "version": "1.1.2-next.0",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"
@@ -27,5 +30,15 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"]
+  "keywords": [
+    "huaweicloud",
+    "huawei-cloud",
+    "koocli",
+    "hcloud",
+    "agent",
+    "mcp",
+    "api",
+    "sdk",
+    "skills"
+  ]
 }

--- a/plugins/huaweicloud-core/.codex-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.codex-plugin/plugin.json
@@ -2,10 +2,7 @@
   "interface": {
     "shortDescription": "HuaweiCloud Devkit - Huawei Cloud guidance, CLI/API/SDK routing, MCP tools, and safety for coding agents.",
     "developerName": "HuaweiCloud Mate",
-    "capabilities": [
-      "Read",
-      "Interactive"
-    ],
+    "capabilities": ["Read", "Interactive"],
     "brandColor": "#C7000B",
     "composerIcon": "./assets/icon.png",
     "logo": "./assets/logo.png",
@@ -32,15 +29,5 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": [
-    "huaweicloud",
-    "huawei-cloud",
-    "koocli",
-    "hcloud",
-    "agent",
-    "mcp",
-    "api",
-    "sdk",
-    "skills"
-  ]
+  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"]
 }

--- a/plugins/huaweicloud-core/.codex-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.codex-plugin/plugin.json
@@ -2,7 +2,10 @@
   "interface": {
     "shortDescription": "HuaweiCloud Devkit - Huawei Cloud guidance, CLI/API/SDK routing, MCP tools, and safety for coding agents.",
     "developerName": "HuaweiCloud Mate",
-    "capabilities": ["Read", "Interactive"],
+    "capabilities": [
+      "Read",
+      "Interactive"
+    ],
     "brandColor": "#C7000B",
     "composerIcon": "./assets/icon.png",
     "logo": "./assets/logo.png",
@@ -20,7 +23,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Agent toolkit that helps coding agents use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities safely and accurately.",
   "skills": "./skills/",
-  "version": "1.1.1-next.16",
+  "version": "1.1.2-next.0",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"
@@ -29,5 +32,15 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"]
+  "keywords": [
+    "huaweicloud",
+    "huawei-cloud",
+    "koocli",
+    "hcloud",
+    "agent",
+    "mcp",
+    "api",
+    "sdk",
+    "skills"
+  ]
 }

--- a/plugins/huaweicloud-core/.cursor-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.cursor-plugin/plugin.json
@@ -5,10 +5,7 @@
     "longDescription": "HuaweiCloud Devkit helps coding agents choose and use Huawei Cloud Skills, KooCLI, APIs, SDKs, and MCP tools with less context, safer command execution, and more accurate cloud implementation decisions.",
     "developerName": "HuaweiCloud Mate",
     "category": "Cloud",
-    "capabilities": [
-      "Read",
-      "Interactive"
-    ],
+    "capabilities": ["Read", "Interactive"],
     "websiteURL": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
     "brandColor": "#C7000B",
     "defaultPrompt": [
@@ -30,15 +27,5 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": [
-    "huaweicloud",
-    "huawei-cloud",
-    "koocli",
-    "hcloud",
-    "agent",
-    "mcp",
-    "api",
-    "sdk",
-    "skills"
-  ]
+  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"]
 }

--- a/plugins/huaweicloud-core/.cursor-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.cursor-plugin/plugin.json
@@ -5,7 +5,10 @@
     "longDescription": "HuaweiCloud Devkit helps coding agents choose and use Huawei Cloud Skills, KooCLI, APIs, SDKs, and MCP tools with less context, safer command execution, and more accurate cloud implementation decisions.",
     "developerName": "HuaweiCloud Mate",
     "category": "Cloud",
-    "capabilities": ["Read", "Interactive"],
+    "capabilities": [
+      "Read",
+      "Interactive"
+    ],
     "websiteURL": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
     "brandColor": "#C7000B",
     "defaultPrompt": [
@@ -17,7 +20,7 @@
   "mcpServers": "./.mcp.json",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "skills": "./skills/",
-  "version": "1.1.1-next.16",
+  "version": "1.1.2-next.0",
   "author": {
     "name": "HuaweiCloud Mate",
     "url": "https://github.com/huaweicloud"
@@ -27,5 +30,15 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"]
+  "keywords": [
+    "huaweicloud",
+    "huawei-cloud",
+    "koocli",
+    "hcloud",
+    "agent",
+    "mcp",
+    "api",
+    "sdk",
+    "skills"
+  ]
 }

--- a/plugins/huaweicloud-core/.hermes-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.hermes-plugin/plugin.json
@@ -9,17 +9,7 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": [
-    "huaweicloud",
-    "huawei-cloud",
-    "koocli",
-    "hcloud",
-    "agent",
-    "mcp",
-    "api",
-    "sdk",
-    "skills"
-  ],
+  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
@@ -28,10 +18,7 @@
     "longDescription": "HuaweiCloud Devkit helps coding agents choose and use Huawei Cloud Skills, KooCLI, APIs, SDKs, and MCP tools with less context, safer command execution, and more accurate cloud implementation decisions.",
     "developerName": "HuaweiCloud Mate",
     "category": "Cloud",
-    "capabilities": [
-      "Read",
-      "Interactive"
-    ],
+    "capabilities": ["Read", "Interactive"],
     "websiteURL": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
     "brandColor": "#C7000B",
     "defaultPrompt": [

--- a/plugins/huaweicloud-core/.hermes-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.hermes-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "huaweicloud-devkit",
-  "version": "1.1.1-next.16",
+  "version": "1.1.2-next.0",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {
     "name": "HuaweiCloud Mate",
@@ -9,7 +9,17 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"],
+  "keywords": [
+    "huaweicloud",
+    "huawei-cloud",
+    "koocli",
+    "hcloud",
+    "agent",
+    "mcp",
+    "api",
+    "sdk",
+    "skills"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
@@ -18,7 +28,10 @@
     "longDescription": "HuaweiCloud Devkit helps coding agents choose and use Huawei Cloud Skills, KooCLI, APIs, SDKs, and MCP tools with less context, safer command execution, and more accurate cloud implementation decisions.",
     "developerName": "HuaweiCloud Mate",
     "category": "Cloud",
-    "capabilities": ["Read", "Interactive"],
+    "capabilities": [
+      "Read",
+      "Interactive"
+    ],
     "websiteURL": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
     "brandColor": "#C7000B",
     "defaultPrompt": [

--- a/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
@@ -9,17 +9,7 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": [
-    "huaweicloud",
-    "huawei-cloud",
-    "koocli",
-    "hcloud",
-    "agent",
-    "mcp",
-    "api",
-    "sdk",
-    "skills"
-  ],
+  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
@@ -28,10 +18,7 @@
     "longDescription": "HuaweiCloud Devkit helps coding agents choose and use Huawei Cloud Skills, KooCLI, APIs, SDKs, and MCP tools with less context, safer command execution, and more accurate cloud implementation decisions.",
     "developerName": "HuaweiCloud Mate",
     "category": "Cloud",
-    "capabilities": [
-      "Read",
-      "Interactive"
-    ],
+    "capabilities": ["Read", "Interactive"],
     "websiteURL": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
     "brandColor": "#C7000B",
     "defaultPrompt": [

--- a/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
+++ b/plugins/huaweicloud-core/.workbuddy-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "huaweicloud-devkit",
-  "version": "1.1.1-next.16",
+  "version": "1.1.2-next.0",
   "description": "Guide coding agents to use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities with safer execution and less context.",
   "author": {
     "name": "HuaweiCloud Mate",
@@ -9,7 +9,17 @@
   "homepage": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "repository": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
   "license": "Apache-2.0",
-  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills"],
+  "keywords": [
+    "huaweicloud",
+    "huawei-cloud",
+    "koocli",
+    "hcloud",
+    "agent",
+    "mcp",
+    "api",
+    "sdk",
+    "skills"
+  ],
   "skills": "./skills/",
   "mcpServers": "./.mcp.json",
   "interface": {
@@ -18,7 +28,10 @@
     "longDescription": "HuaweiCloud Devkit helps coding agents choose and use Huawei Cloud Skills, KooCLI, APIs, SDKs, and MCP tools with less context, safer command execution, and more accurate cloud implementation decisions.",
     "developerName": "HuaweiCloud Mate",
     "category": "Cloud",
-    "capabilities": ["Read", "Interactive"],
+    "capabilities": [
+      "Read",
+      "Interactive"
+    ],
     "websiteURL": "https://github.com/huaweicloud/HuaweiCloud-Devkit",
     "brandColor": "#C7000B",
     "defaultPrompt": [

--- a/plugins/huaweicloud-core/openclaw.plugin.json
+++ b/plugins/huaweicloud-core/openclaw.plugin.json
@@ -13,22 +13,8 @@
   "homepage": "https://github.com/huaweicloud/huaweicloud-devkit",
   "repository": "https://github.com/huaweicloud/huaweicloud-devkit",
   "license": "Apache-2.0",
-  "keywords": [
-    "huaweicloud",
-    "huawei-cloud",
-    "koocli",
-    "hcloud",
-    "agent",
-    "mcp",
-    "api",
-    "sdk",
-    "skills",
-    "cloud"
-  ],
+  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills", "cloud"],
   "category": "Cloud",
-  "capabilities": [
-    "Read",
-    "Interactive"
-  ],
+  "capabilities": ["Read", "Interactive"],
   "brandColor": "#C7000B"
 }

--- a/plugins/huaweicloud-core/openclaw.plugin.json
+++ b/plugins/huaweicloud-core/openclaw.plugin.json
@@ -2,7 +2,7 @@
   "name": "huaweicloud-devkit",
   "id": "huaweicloud-devkit",
   "displayName": "HuaweiCloud DevKit",
-  "version": "1.1.1-next.16",
+  "version": "1.1.2-next.0",
   "family": "bundle-plugin",
   "bundleFormat": "codex",
   "description": "Guide coding agents to use Huawei Cloud safely — KooCLI, APIs, SDKs, 28 MCP tools, skills, and safety guardrails.",
@@ -13,8 +13,22 @@
   "homepage": "https://github.com/huaweicloud/huaweicloud-devkit",
   "repository": "https://github.com/huaweicloud/huaweicloud-devkit",
   "license": "Apache-2.0",
-  "keywords": ["huaweicloud", "huawei-cloud", "koocli", "hcloud", "agent", "mcp", "api", "sdk", "skills", "cloud"],
+  "keywords": [
+    "huaweicloud",
+    "huawei-cloud",
+    "koocli",
+    "hcloud",
+    "agent",
+    "mcp",
+    "api",
+    "sdk",
+    "skills",
+    "cloud"
+  ],
   "category": "Cloud",
-  "capabilities": ["Read", "Interactive"],
+  "capabilities": [
+    "Read",
+    "Interactive"
+  ],
   "brandColor": "#C7000B"
 }

--- a/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-core/SKILL.md
@@ -10,6 +10,14 @@ version: 1
 
 Huawei Cloud comprises 200+ services. This skill is the entry point for ANY action or question related to Huawei Cloud. It matches a workload to the right service, then hands off to a service-specific skill for operational questions.
 
+## 会话启动
+
+首次操作前必须先调用 `huaweicloud_check_update` 检查插件版本：
+
+1. 如果 `updateAvailable == true` 且 `dismissed == false`，先询问用户是否升级
+2. 用户同意 → 调用 `huaweicloud_upgrade`，完成后提示重启会话
+3. 用户拒绝 → 调用 `huaweicloud_check_update` 传 `dismiss: true`
+
 ## How This Skill Works
 
 1. Match user intent against the Sub-skill registry below

--- a/plugins/huaweicloud-core/src/mcp-server.mjs
+++ b/plugins/huaweicloud-core/src/mcp-server.mjs
@@ -6,6 +6,7 @@ import { platform } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
 import { TOOL_DEFINITIONS, callTool } from './tools.mjs';
+import { getCachedUpdateInfo, readInstalledVersion, peekCachedUpdateInfo, applyUpdateHint } from './update-check.mjs';
 import { initTelemetry } from './telemetry/telemetry.mjs';
 import { detectAgent } from './telemetry/agent-detect.mjs';
 
@@ -73,6 +74,27 @@ let useContentLengthFraming = true;
 // shutdown signal — exit cleanly so the host does not see CLOSE_TIMEOUT.
 const { harness } = detectAgent();
 const NEEDS_KEEPALIVE = harness === 'hermes' && platform() === 'win32';
+
+// 版本升级检测预热：异步、非阻塞；失败静默（离线/超时不影响会话）。
+process.nextTick(() => {
+  getCachedUpdateInfo(readInstalledVersion() || '0.0.0').catch(() => {});
+});
+
+// 会话内首个非 check/upgrade 工具调用附加 _updateInfo，只消费一次。
+let hintConsumed = false;
+function decorateResult(name, result) {
+  if (hintConsumed) return result;
+  try {
+    const hint = peekCachedUpdateInfo();
+    if (!hint) return result;
+    const decorated = applyUpdateHint(result, name, hint);
+    if (decorated !== result) hintConsumed = true;
+    return decorated;
+  } catch {
+    return result; // 兜底装饰失败绝不影响工具调用
+  }
+}
+
 let keepAlive = null;
 function onStdinClose() {
   if (keepAlive) return;
@@ -191,11 +213,12 @@ async function dispatch(method, params) {
 
   if (method === 'tools/call') {
     const result = await callTool(params.name, params.arguments || {});
+    const decorated = decorateResult(params.name, result);
     return {
       content: [
         {
           type: 'text',
-          text: JSON.stringify(result, null, 2),
+          text: JSON.stringify(decorated, null, 2),
         },
       ],
       isError: false,

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -35,6 +35,7 @@ import {
   getProxySettings,
 } from './proxy/proxy-config.mjs';
 import { removeKooCli, removeObsConfig } from './sandbox/uninstall-cleanup.mjs';
+import { queryDistTagsSync, determineTarget, semverCompare } from './update-check.mjs';
 
 const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite');
 
@@ -3056,20 +3057,12 @@ function parseTarget() {
 
 function checkForUpdate() {
   if (pkgVersion === '0.0.0') return;
-  const tag = /-next\.\d+/.test(pkgVersion) ? 'next' : 'latest';
-  let latest = null;
-  try {
-    const npmBin = process.platform === 'win32' ? 'npm.cmd' : 'npm';
-    const r = spawnSync(npmBin, ['view', `huaweicloud-devkit@${tag}`, 'version'], {
-      encoding: 'utf8',
-      timeout: 5000,
-      windowsHide: true,
-    });
-    if (r.status === 0) latest = (r.stdout || '').trim().split('\n').pop().trim();
-  } catch {}
-  if (latest && latest !== pkgVersion) {
+  const distTags = queryDistTagsSync({ timeoutMs: 5000 });
+  const target = determineTarget(pkgVersion, distTags ?? {});
+  if (target && semverCompare(target, pkgVersion) > 0) {
+    const tag = distTags.next && semverCompare(target, distTags.next) === 0 ? 'next' : 'latest';
     console.log(
-      `\n\x1b[33mℹ️ 检测到新版本：${latest}（当前 ${pkgVersion}，${tag} 频道）。建议运行 \`npx huaweicloud-devkit@${tag} update\` 更新。\x1b[0m`,
+      `\n\x1b[33mℹ️ 检测到新版本：${target}（当前 ${pkgVersion}，${tag} 频道）。建议运行 \`npx --yes huaweicloud-devkit@${tag} update\` 更新。\x1b[0m`,
     );
   }
 }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -46,6 +46,17 @@ import {
 } from './auth/credentials.mjs';
 import { trackToolInvoke, trackSkillRetrieve } from './telemetry/telemetry.mjs';
 import { fingerprint, runHcloudConfigure, resolveManagedProfile } from './auth/reconcile.mjs';
+import {
+  getCachedUpdateInfo,
+  getUpdateDistTags,
+  invalidateUpdateCache,
+  judgeUpdate,
+  determineTarget,
+  readInstalledVersion,
+  writeSkipState,
+  resolveSkipFilePath,
+  upgradePackage,
+} from './update-check.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILLS_ROOT_DEV = join(__dirname, '..', 'skills');
@@ -795,6 +806,36 @@ export const TOOL_DEFINITIONS = [
       },
     },
   },
+  {
+    name: 'huaweicloud_check_update',
+    description:
+      '检查 huaweicloud-devkit 插件是否有新版本。结果含 currentVersion / latestStable / latestNext / targetVersion / updateAvailable / dismissExpiresAt / result。支持 dismiss:true 记录用户拒绝（3 天冷却，新版本会重新提醒）。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        dismiss: { type: 'boolean', description: '用户拒绝升级时传 true，记录冷却状态。' },
+        dismissVersion: {
+          type: 'string',
+          description: '与 dismiss:true 搭配，用户拒绝的版本号。缺省时用当前检测到的 targetVersion。',
+        },
+      },
+    },
+  },
+  {
+    name: 'huaweicloud_upgrade',
+    description:
+      '升级 huaweicloud-devkit 到最新版本。执行前必须先征得用户同意。version 仅支持 "latest"。完成后需重启会话生效。',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        version: { type: 'string', description: '仅支持 "latest"（默认）。' },
+        target: {
+          type: 'string',
+          description: 'agent 目标（opencode/codex/codearts/.../all）。缺省时用 all（仅更新已安装的）。',
+        },
+      },
+    },
+  },
 ];
 
 function toolInvokeValue(name, args) {
@@ -1284,9 +1325,44 @@ export async function callTool(name, args = {}) {
       return await hdkitVoucherStatus(args.domain_id);
     case 'huaweicloud_voucher_claim':
       return await hdkitVoucherClaim(args.domain_id);
+    case 'huaweicloud_check_update':
+      return await handleCheckUpdate(args);
+    case 'huaweicloud_upgrade':
+      return await handleUpgrade(args);
     default:
       throw new Error(`Unknown tool: ${name}`);
   }
+}
+
+async function handleCheckUpdate(args = {}) {
+  const current = readInstalledVersion() || '0.0.0';
+  if (args.dismiss === true) {
+    const distTags = await getUpdateDistTags(current);
+    const target = determineTarget(current, distTags);
+    const dismissedVersion =
+      typeof args.dismissVersion === 'string' && args.dismissVersion ? args.dismissVersion : target || current;
+    const state = writeSkipState(resolveSkipFilePath(), dismissedVersion);
+    invalidateUpdateCache();
+    return judgeUpdate(current, distTags, state);
+  }
+  return getCachedUpdateInfo(current);
+}
+
+async function handleUpgrade(args = {}) {
+  const target = typeof args.target === 'string' && args.target ? args.target : 'all';
+  const version = typeof args.version === 'string' && args.version ? args.version : 'latest';
+  const current = readInstalledVersion() || '0.0.0';
+  const info = await getCachedUpdateInfo(current);
+  if (info && info.result === 'up_to_date') {
+    return {
+      success: false,
+      requiresRestart: false,
+      message: '已是最新版本，无需升级。',
+      currentVersion: info.currentVersion,
+      targetVersion: info.targetVersion,
+    };
+  }
+  return upgradePackage({ target, version });
 }
 
 function hookResult(result) {

--- a/plugins/huaweicloud-core/src/update-check.mjs
+++ b/plugins/huaweicloud-core/src/update-check.mjs
@@ -257,6 +257,12 @@ export function peekCachedUpdateInfo() {
   return lastHint && lastHint.updateAvailable && lastHint.targetVersion ? lastHint : null;
 }
 
+export async function getUpdateDistTags(current) {
+  const result = await getCachedUpdateInfo(current);
+  if (!result) return null;
+  return { latest: result.latestStable ?? null, next: result.latestNext ?? null };
+}
+
 export function applyUpdateHint(result, name, hint) {
   if (!hint || !hint.updateAvailable) return result;
   if (name === 'huaweicloud_check_update' || name === 'huaweicloud_upgrade') return result;

--- a/plugins/huaweicloud-core/src/update-check.mjs
+++ b/plugins/huaweicloud-core/src/update-check.mjs
@@ -1,7 +1,7 @@
 // Version-update detection & auto-upgrade for huaweicloud-devkit (session-level).
 // Spec: docs/superpowers/specs/2026-09-07-version-upgrade-design.md (internal, not committed).
-import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
-import { spawnSync } from 'node:child_process';
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync, rmSync } from 'node:fs';
+import { spawn, spawnSync } from 'node:child_process';
 import { join, dirname, resolve } from 'node:path';
 import { homedir } from 'node:os';
 import { fileURLToPath } from 'node:url';
@@ -176,9 +176,14 @@ export function writeSkipState(file, dismissedVersion, { at = Date.now(), days =
     expireAt: new Date(at + days * 24 * 60 * 60 * 1000).toISOString(),
   };
   mkdirSync(dirname(file), { recursive: true });
-  const tmp = `${file}.tmp`;
+  const tmp = `${file}.${process.pid}.${Date.now()}.tmp`;
   writeFileSync(tmp, JSON.stringify(state, null, 2), 'utf8');
-  renameSync(tmp, file);
+  try {
+    renameSync(tmp, file);
+  } catch (error) {
+    rmSync(tmp, { force: true });
+    throw error;
+  }
   return state;
 }
 
@@ -197,8 +202,38 @@ export function queryDistTagsSync({ timeoutMs = 5000, cwd } = {}) {
   }
 }
 
-export function queryDistTags(options = {}) {
-  return Promise.resolve(queryDistTagsSync(options));
+export function queryDistTags({ timeoutMs = 5000, cwd } = {}) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(NPM_BIN, ['view', 'huaweicloud-devkit', 'dist-tags', '--json'], {
+        windowsHide: true,
+        cwd,
+      });
+    } catch {
+      resolve(null);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {}
+      resolve(null);
+    }, timeoutMs);
+    let stdout = '';
+    child.stdout.on('data', (d) => {
+      stdout += String(d);
+    });
+    child.on('error', () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      if (code === 0) resolve(parseDistTagsOutput(stdout));
+      else resolve(null);
+    });
+  });
 }
 
 let cachedDistTags = null;
@@ -264,7 +299,7 @@ export async function getUpdateDistTags(current) {
 }
 
 export function applyUpdateHint(result, name, hint) {
-  if (!hint || !hint.updateAvailable) return result;
+  if (!hint || !hint.updateAvailable || !hint.targetVersion) return result;
   if (name === 'huaweicloud_check_update' || name === 'huaweicloud_upgrade') return result;
   return {
     ...result,
@@ -289,19 +324,40 @@ export async function upgradePackage({ target = 'all', version = 'latest' } = {}
   }
   const { doQuery = queryDistTags, spawnFn = defaultSpawn } = options;
   const previousVersion = readInstalledVersion();
-  const distTags = await doQuery();
+  let distTags;
+  try {
+    distTags = await doQuery();
+  } catch (error) {
+    return {
+      success: false,
+      error: error?.message || '无法确认最新版本（registry 查询失败）。',
+      manual: `npx --yes huaweicloud-devkit@latest update --target ${target}`,
+    };
+  }
   const targetVersion = determineTarget(previousVersion, distTags ?? {});
-  if (!targetVersion && !distTags) {
+  if (distTags === null) {
     return {
       success: false,
       error: '无法确认最新版本（registry 查询失败）。',
       manual: `npx --yes huaweicloud-devkit@latest update --target ${target}`,
     };
   }
-  const isNextTarget = Boolean(distTags?.next && targetVersion && semverCompare(targetVersion, distTags.next) === 0);
+  if (!targetVersion) {
+    return { success: false, message: '已是最新版本，无需升级。', requiresRestart: false };
+  }
+  const isNextTarget = Boolean(distTags.next && semverCompare(targetVersion, distTags.next) === 0);
   const tag = isNextTarget ? 'next' : 'latest';
   const command = ['--yes', `huaweicloud-devkit@${tag}`, 'update', '--target', String(target)];
-  const execResult = spawnFn(NPX_BIN, command, { encoding: 'utf8', timeout: 300000, windowsHide: true });
+  let execResult;
+  try {
+    execResult = spawnFn(NPX_BIN, command, { encoding: 'utf8', timeout: 300000, windowsHide: true });
+  } catch (error) {
+    return {
+      success: false,
+      error: error?.message || '升级命令执行失败。',
+      manual: `npx --yes huaweicloud-devkit@${tag} update --target ${target}`,
+    };
+  }
   if (execResult.status === 0) {
     invalidateUpdateCache();
     return {
@@ -312,8 +368,13 @@ export async function upgradePackage({ target = 'all', version = 'latest' } = {}
       message: restartMessage(target),
     };
   }
+  const errObj = execResult.error;
   const stderr = String(execResult.stderr || '').trim();
-  const reason = stderr ? stderr.split(/\r?\n/).filter(Boolean).slice(-2).join(' ') : `exit ${execResult.status}`;
+  const reason = errObj?.message
+    ? errObj.message
+    : stderr
+      ? stderr.split(/\r?\n/).filter(Boolean).slice(-2).join(' ')
+      : `exit ${execResult.status}`;
   return {
     success: false,
     error: reason,

--- a/plugins/huaweicloud-core/src/update-check.mjs
+++ b/plugins/huaweicloud-core/src/update-check.mjs
@@ -181,3 +181,87 @@ export function writeSkipState(file, dismissedVersion, { at = Date.now(), days =
   renameSync(tmp, file);
   return state;
 }
+
+export function queryDistTagsSync({ timeoutMs = 5000, cwd } = {}) {
+  try {
+    const result = spawnSync(NPM_BIN, ['view', 'huaweicloud-devkit', 'dist-tags', '--json'], {
+      encoding: 'utf8',
+      timeout: timeoutMs,
+      windowsHide: true,
+      cwd,
+    });
+    if (result.status !== 0) return null;
+    return parseDistTagsOutput(result.stdout);
+  } catch {
+    return null;
+  }
+}
+
+export function queryDistTags(options = {}) {
+  return Promise.resolve(queryDistTagsSync(options));
+}
+
+let cachedDistTags = null;
+let cachedAt = 0;
+let failedAt = 0;
+let inflightQuery = null;
+let lastHint = null;
+
+export function invalidateUpdateCache() {
+  cachedDistTags = null;
+  cachedAt = 0;
+  failedAt = 0;
+  inflightQuery = null;
+  lastHint = null;
+}
+
+function cacheValid() {
+  return Boolean(cachedDistTags) && Date.now() - cachedAt <= TTL_MS;
+}
+
+export async function getCachedUpdateInfo(current, { doQuery = queryDistTags } = {}) {
+  if (process.env.HUAWEICLOUD_DEVKIT_SKIP_UPDATE === '1') {
+    lastHint = judgeUpdate(current, null);
+    return lastHint;
+  }
+  const skipState = readSkipState(resolveSkipFilePath());
+  if (!cacheValid()) {
+    if (!cachedDistTags && Date.now() - failedAt < FAIL_THROTTLE_MS) {
+      lastHint = judgeUpdate(current, null, skipState);
+      return lastHint;
+    }
+    if (!inflightQuery) {
+      inflightQuery = doQuery()
+        .then((distTags) => {
+          if (distTags) {
+            cachedDistTags = distTags;
+            cachedAt = Date.now();
+          } else {
+            failedAt = Date.now();
+          }
+          return distTags;
+        })
+        .finally(() => {
+          inflightQuery = null;
+        });
+    }
+    const distTags = await inflightQuery;
+    lastHint = judgeUpdate(current, distTags, skipState);
+    return lastHint;
+  }
+  lastHint = judgeUpdate(current, cachedDistTags, skipState);
+  return lastHint;
+}
+
+export function peekCachedUpdateInfo() {
+  return lastHint && lastHint.updateAvailable && lastHint.targetVersion ? lastHint : null;
+}
+
+export function applyUpdateHint(result, name, hint) {
+  if (!hint || !hint.updateAvailable) return result;
+  if (name === 'huaweicloud_check_update' || name === 'huaweicloud_upgrade') return result;
+  return {
+    ...result,
+    _updateInfo: { currentVersion: hint.currentVersion, latestVersion: hint.targetVersion },
+  };
+}

--- a/plugins/huaweicloud-core/src/update-check.mjs
+++ b/plugins/huaweicloud-core/src/update-check.mjs
@@ -265,3 +265,52 @@ export function applyUpdateHint(result, name, hint) {
     _updateInfo: { currentVersion: hint.currentVersion, latestVersion: hint.targetVersion },
   };
 }
+
+function defaultSpawn(command, args, options) {
+  return spawnSync(command, args, options);
+}
+
+function restartMessage(target) {
+  if (target === 'officeace') {
+    return '升级完成，请打开连接器 → 我的连接器 → huaweicloud-devkit → 重新连接后使用新版本。';
+  }
+  return '升级完成，请重启当前会话使新版本生效。';
+}
+
+export async function upgradePackage({ target = 'all', version = 'latest' } = {}, options = {}) {
+  if (version !== 'latest') {
+    return { success: false, error: 'version 参数仅支持 latest。目标版本由插件自动判定。' };
+  }
+  const { doQuery = queryDistTags, spawnFn = defaultSpawn } = options;
+  const previousVersion = readInstalledVersion();
+  const distTags = await doQuery();
+  const targetVersion = determineTarget(previousVersion, distTags ?? {});
+  if (!targetVersion && !distTags) {
+    return {
+      success: false,
+      error: '无法确认最新版本（registry 查询失败）。',
+      manual: `npx --yes huaweicloud-devkit@latest update --target ${target}`,
+    };
+  }
+  const isNextTarget = Boolean(distTags?.next && targetVersion && semverCompare(targetVersion, distTags.next) === 0);
+  const tag = isNextTarget ? 'next' : 'latest';
+  const command = ['--yes', `huaweicloud-devkit@${tag}`, 'update', '--target', String(target)];
+  const execResult = spawnFn(NPX_BIN, command, { encoding: 'utf8', timeout: 300000, windowsHide: true });
+  if (execResult.status === 0) {
+    invalidateUpdateCache();
+    return {
+      success: true,
+      previousVersion,
+      installedVersion: targetVersion,
+      requiresRestart: true,
+      message: restartMessage(target),
+    };
+  }
+  const stderr = String(execResult.stderr || '').trim();
+  const reason = stderr ? stderr.split(/\r?\n/).filter(Boolean).slice(-2).join(' ') : `exit ${execResult.status}`;
+  return {
+    success: false,
+    error: reason,
+    manual: `npx --yes huaweicloud-devkit@${tag} update --target ${target}`,
+  };
+}

--- a/plugins/huaweicloud-core/src/update-check.mjs
+++ b/plugins/huaweicloud-core/src/update-check.mjs
@@ -1,0 +1,126 @@
+// Version-update detection & auto-upgrade for huaweicloud-devkit (session-level).
+// Spec: docs/superpowers/specs/2026-09-07-version-upgrade-design.md (internal, not committed).
+import { existsSync, readFileSync, writeFileSync, renameSync, mkdirSync } from 'node:fs';
+import { spawnSync } from 'node:child_process';
+import { join, dirname, resolve } from 'node:path';
+import { homedir } from 'node:os';
+import { fileURLToPath } from 'node:url';
+
+const IS_WINDOWS = process.platform === 'win32';
+const NPM_BIN = IS_WINDOWS ? 'npm.cmd' : 'npm';
+const NPX_BIN = IS_WINDOWS ? 'npx.cmd' : 'npx';
+const TTL_MS = 60 * 60 * 1000;
+const FAIL_THROTTLE_MS = 5 * 60 * 1000;
+const COOLDOWN_DAYS = 3;
+
+export function semverParse(input) {
+  const m = /^(\d+)\.(\d+)\.(\d+)(?:-([0-9A-Za-z.-]+))?$/.exec(String(input).trim());
+  if (!m) return null;
+  const pre = m[4] ? m[4].split('.') : null;
+  return { major: Number(m[1]), minor: Number(m[2]), patch: Number(m[3]), pre, raw: String(input).trim() };
+}
+
+function comparePre(a, b) {
+  if (a === null && b === null) return 0;
+  if (a === null) return 1; // 无 prerelease（正式版）更大
+  if (b === null) return -1;
+  const length = Math.max(a.length, b.length);
+  for (let i = 0; i < length; i++) {
+    const x = a[i];
+    const y = b[i];
+    if (x === undefined) return -1;
+    if (y === undefined) return 1;
+    const xNum = /^\d+$/.test(x);
+    const yNum = /^\d+$/.test(y);
+    if (xNum && yNum) {
+      const dx = Number(x);
+      const dy = Number(y);
+      if (dx !== dy) return dx < dy ? -1 : 1;
+    } else if (xNum) {
+      return -1; // 数字标识符 < 字母标识符
+    } else if (yNum) {
+      return 1;
+    } else if (x !== y) {
+      return x < y ? -1 : 1;
+    }
+  }
+  return 0;
+}
+
+export function semverCompare(a, b) {
+  const A = semverParse(a);
+  const B = semverParse(b);
+  if (!A || !B) {
+    const sa = String(a);
+    const sb = String(b);
+    return sa === sb ? 0 : sa < sb ? -1 : 1;
+  }
+  if (A.major !== B.major) return A.major < B.major ? -1 : 1;
+  if (A.minor !== B.minor) return A.minor < B.minor ? -1 : 1;
+  if (A.patch !== B.patch) return A.patch < B.patch ? -1 : 1;
+  return comparePre(A.pre, B.pre);
+}
+
+export function hasPrerelease(v) {
+  const parsed = semverParse(v);
+  return Boolean(parsed && parsed.pre);
+}
+
+export function determineTarget(current, distTags = {}) {
+  const isPre = hasPrerelease(current);
+  const candidates = [];
+  if (distTags.latest) candidates.push(distTags.latest);
+  if (isPre && distTags.next) candidates.push(distTags.next);
+  if (!candidates.length) return null;
+  return candidates.slice().sort(semverCompare).pop();
+}
+
+export function parseDistTagsOutput(stdout) {
+  try {
+    const text = String(stdout || '').trim();
+    if (!text) return null; // 空输出视为 npm view 失败
+    const parsed = JSON.parse(text);
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+    return {
+      latest: typeof parsed.latest === 'string' ? parsed.latest : null,
+      next: typeof parsed.next === 'string' ? parsed.next : null,
+    };
+  } catch {
+    return null;
+  }
+}
+
+function buildResult(current, distTags, extra = {}) {
+  const result = {
+    currentVersion: current,
+    latestStable: distTags?.latest ?? null,
+    latestNext: distTags?.next ?? null,
+    targetVersion: extra.target ?? null,
+    updateAvailable: extra.result === 'update_available',
+    dismissed: extra.result === 'dismissed',
+    dismissExpiresAt: extra.dismissExpiresAt ?? null,
+    result: extra.result ?? 'up_to_date',
+  };
+  if (extra.note) result.note = extra.note;
+  return result;
+}
+
+export function judgeUpdate(current, distTags, skipState, now = Date.now()) {
+  if (process.env.HUAWEICLOUD_DEVKIT_SKIP_UPDATE === '1') {
+    return buildResult(current, distTags ?? null);
+  }
+  if (!distTags) {
+    return buildResult(current, null, { result: 'check_failed', note: '检测失败，不影响使用' });
+  }
+  const target = determineTarget(current, distTags);
+  if (!target || semverCompare(target, current) <= 0) {
+    return buildResult(current, distTags, { result: 'up_to_date', target: target ?? null });
+  }
+  const expiresAt = skipState?.expireAt ? new Date(skipState.expireAt).getTime() : 0;
+  const inCooldown =
+    Boolean(skipState) && now < expiresAt && semverCompare(target, String(skipState.dismissedVersion)) <= 0;
+  if (inCooldown) {
+    return buildResult(current, distTags, { result: 'dismissed', target, dismissExpiresAt: skipState.expireAt });
+  }
+  return buildResult(current, distTags, { result: 'update_available', target });
+}

--- a/plugins/huaweicloud-core/src/update-check.mjs
+++ b/plugins/huaweicloud-core/src/update-check.mjs
@@ -124,3 +124,60 @@ export function judgeUpdate(current, distTags, skipState, now = Date.now()) {
   }
   return buildResult(current, distTags, { result: 'update_available', target });
 }
+
+function selfDir() {
+  return dirname(fileURLToPath(import.meta.url));
+}
+
+export function readInstalledVersion() {
+  const pluginRoot = resolve(selfDir(), '..');
+  const packageRoot = resolve(pluginRoot, '..', '..');
+  for (const base of [pluginRoot, packageRoot]) {
+    try {
+      const version = JSON.parse(readFileSync(join(base, 'package.json'), 'utf8')).version;
+      if (typeof version === 'string' && version) return version;
+    } catch {}
+  }
+  return null;
+}
+
+export function skipFilePath() {
+  return join(resolve(selfDir(), '..'), '.update-skip.json');
+}
+
+export function fallbackSkipFilePath() {
+  const base = process.env.HUAWEICLOUD_HOME || homedir();
+  return join(base, '.config', 'huaweicloud', 'devkit-skip.json');
+}
+
+// A1 定稿: 标准 agent 用插件目录副本(有 package.json); codex 等无副本时回退共享文件
+export function resolveSkipFilePath() {
+  try {
+    if (existsSync(join(dirname(skipFilePath()), 'package.json'))) return skipFilePath();
+  } catch {}
+  return fallbackSkipFilePath();
+}
+
+export function readSkipState(file) {
+  if (!existsSync(file)) return null;
+  try {
+    const parsed = JSON.parse(readFileSync(file, 'utf8'));
+    if (!parsed || typeof parsed.dismissedVersion !== 'string' || !parsed.dismissedAt || !parsed.expireAt) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSkipState(file, dismissedVersion, { at = Date.now(), days = COOLDOWN_DAYS } = {}) {
+  const state = {
+    dismissedVersion: String(dismissedVersion),
+    dismissedAt: new Date(at).toISOString(),
+    expireAt: new Date(at + days * 24 * 60 * 60 * 1000).toISOString(),
+  };
+  mkdirSync(dirname(file), { recursive: true });
+  const tmp = `${file}.tmp`;
+  writeFileSync(tmp, JSON.stringify(state, null, 2), 'utf8');
+  renameSync(tmp, file);
+  return state;
+}

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -581,3 +581,10 @@ test('tools.mjs registers version-update tools', () => {
   }
   assert.match(tools, /from '\.\/update-check\.mjs'/);
 });
+
+test('mcp-server.mjs warms update cache and decorates first tool call', () => {
+  const server = readFileSync(join(pluginRoot, 'src', 'mcp-server.mjs'), 'utf8');
+  assert.match(server, /getCachedUpdateInfo\(readInstalledVersion\(\)/);
+  assert.match(server, /applyUpdateHint\(/);
+  assert.match(server, /peekCachedUpdateInfo\(\)/);
+});

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -572,3 +572,12 @@ test('official Huawei Cloud Icons library is integrated', () => {
   assert.match(discovery, /huaweicloud_get_service_icon/);
   assert.match(discovery, /open\.huaweicloud\.com\/openplatform\/icons\.html/);
 });
+
+test('tools.mjs registers version-update tools', () => {
+  const tools = readFileSync(join(pluginRoot, 'src', 'tools.mjs'), 'utf8');
+  for (const name of ['huaweicloud_check_update', 'huaweicloud_upgrade']) {
+    assert.match(tools, new RegExp(`name: '${name}'`));
+    assert.match(tools, new RegExp(`case '${name}':`));
+  }
+  assert.match(tools, /from '\.\/update-check\.mjs'/);
+});

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -515,12 +515,11 @@ test('setup-cli.mjs resolves the active KooCLI profile for configureHcloud', () 
   assert.doesNotMatch(setup, /hcloud configure init/);
 });
 
-test('setup-cli.mjs checks for updates on install/update', () => {
+test('setup-cli.mjs checks for updates on install/update via shared query', () => {
   const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
   assert.match(setup, /function checkForUpdate\(\)/);
-  assert.match(setup, /\? 'next' : 'latest'/);
-  assert.match(setup, /huaweicloud-devkit@\$\{tag\}/);
-  assert.match(setup, /npm\.cmd/);
+  assert.match(setup, /queryDistTagsSync\(/);
+  assert.match(setup, /semverCompare\(/);
   const calls = setup.match(/checkForUpdate\(\);?/g);
   assert.ok(calls && calls.length >= 2, 'checkForUpdate should be called in both cmdInstall and cmdUpdate');
 });

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -587,3 +587,10 @@ test('mcp-server.mjs warms update cache and decorates first tool call', () => {
   assert.match(server, /applyUpdateHint\(/);
   assert.match(server, /peekCachedUpdateInfo\(\)/);
 });
+
+test('READMEs recommend @latest for updates', () => {
+  const en = readFileSync(join(root, 'README.md'), 'utf8');
+  assert.match(en, /huaweicloud-devkit@latest update --target all/);
+  const zh = readFileSync(join(root, 'README.zh-CN.md'), 'utf8');
+  assert.match(zh, /huaweicloud-devkit@latest update --target all/);
+});

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -520,7 +520,7 @@ test('setup-cli.mjs checks for updates on install/update via shared query', () =
   assert.match(setup, /function checkForUpdate\(\)/);
   assert.match(setup, /queryDistTagsSync\(/);
   assert.match(setup, /semverCompare\(/);
-  const calls = setup.match(/checkForUpdate\(\);?/g);
+  const calls = setup.match(/^\s+checkForUpdate\(\);$/gm);
   assert.ok(calls && calls.length >= 2, 'checkForUpdate should be called in both cmdInstall and cmdUpdate');
 });
 

--- a/test/update-check.test.mjs
+++ b/test/update-check.test.mjs
@@ -1,5 +1,9 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
 import {
   semverParse,
   semverCompare,
@@ -7,6 +11,8 @@ import {
   determineTarget,
   judgeUpdate,
   parseDistTagsOutput,
+  readSkipState,
+  writeSkipState,
 } from '../plugins/huaweicloud-core/src/update-check.mjs';
 
 test('semverParse 解析稳定版与 prerelease', () => {
@@ -100,4 +106,27 @@ test('parseDistTagsOutput 解析 npm view --json 输出', () => {
   assert.deepEqual(parseDistTagsOutput('{"latest":"1.1.0"}'), { latest: '1.1.0', next: null });
   assert.equal(parseDistTagsOutput('not json'), null);
   assert.equal(parseDistTagsOutput(''), null);
+});
+
+function tmpDir() {
+  const dir = mkdtempSync(join(tmpdir(), 'upd-'));
+  return dir;
+}
+
+test('skip state 原子写往返 + 损坏容错', () => {
+  const dir = tmpDir();
+  try {
+    const file = join(dir, '.update-skip.json');
+    assert.equal(readSkipState(file), null); // 不存在
+    const state = writeSkipState(file, '1.1.1-next.12');
+    assert.equal(state.dismissedVersion, '1.1.1-next.12');
+    assert.ok(!existsSync(`${file}.tmp`)); // 不留 tmp 残渣
+    const read = readSkipState(file);
+    assert.equal(read.dismissedVersion, '1.1.1-next.12');
+    assert.ok(Date.parse(read.expireAt) - Date.parse(read.dismissedAt) >= 2 * 24 * 60 * 60 * 1000); // 3 天
+    writeFileSync(file, '{broken json');
+    assert.equal(readSkipState(file), null); // 损坏 → null
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });

--- a/test/update-check.test.mjs
+++ b/test/update-check.test.mjs
@@ -1,0 +1,103 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+import {
+  semverParse,
+  semverCompare,
+  hasPrerelease,
+  determineTarget,
+  judgeUpdate,
+  parseDistTagsOutput,
+} from '../plugins/huaweicloud-core/src/update-check.mjs';
+
+test('semverParse 解析稳定版与 prerelease', () => {
+  assert.deepEqual(semverParse('1.1.1-next.15'), {
+    major: 1,
+    minor: 1,
+    patch: 1,
+    pre: ['next', '15'],
+    raw: '1.1.1-next.15',
+  });
+  assert.equal(semverParse('1.1.1').pre, null);
+  assert.equal(semverParse('not-a-version'), null);
+});
+
+test('semverCompare 完整排序契约', () => {
+  assert.equal(semverCompare('1.1.1', '1.1.1-next.15'), 1); // 稳定 > 同基数预发布
+  assert.equal(semverCompare('1.1.1-next.15', '1.1.1-next.12'), 1);
+  assert.equal(semverCompare('1.1.1-next.15', '1.1.1-next.9'), 1); // 数值序
+  assert.equal(semverCompare('1.1.1-next.12', '1.1.1-next.12'), 0);
+  assert.equal(semverCompare('1.0.2', '1.1.0'), -1);
+  assert.equal(semverCompare('1.1.0', '1.0.2'), 1);
+});
+
+test('hasPrerelease', () => {
+  assert.equal(hasPrerelease('1.1.1-next.12'), true);
+  assert.equal(hasPrerelease('1.1.1'), false);
+});
+
+test('determineTarget 频道选取（§4 矩阵）', () => {
+  assert.equal(determineTarget('1.0.2', { latest: '1.1.0', next: null }), '1.1.0');
+  assert.equal(determineTarget('1.1.1-next.12', { latest: '1.1.1', next: '1.1.1-next.15' }), '1.1.1');
+  assert.equal(determineTarget('1.1.1-next.12', { latest: '1.1.0', next: '1.1.1-next.15' }), '1.1.1-next.15');
+  assert.equal(determineTarget('1.1.1-next.15', { latest: '1.1.1', next: '1.1.1-next.15' }), '1.1.1');
+  assert.equal(determineTarget('1.1.1-next.12', { latest: '1.1.0', next: null }), '1.1.0');
+  assert.equal(determineTarget('1.1.0', { latest: null, next: '1.1.1-next.15' }), null); // 稳定用户不看 next
+  assert.equal(determineTarget('1.1.0', { latest: null, next: null }), null);
+});
+
+test('judgeUpdate 四态 + 冷却（§4 全表）', () => {
+  const now = Date.parse('2026-09-08T00:00:00Z');
+  const inCooldown = {
+    dismissedVersion: '1.1.0',
+    dismissedAt: '2026-09-07T00:00:00Z',
+    expireAt: '2026-09-10T00:00:00Z',
+  };
+  const inCooldownOlderVersion = { ...inCooldown, dismissedVersion: '1.0.2' };
+
+  assert.equal(judgeUpdate('1.0.2', { latest: '1.1.0', next: null }, null, now).result, 'update_available');
+  assert.equal(judgeUpdate('1.1.0', { latest: '1.1.0', next: null }, null, now).result, 'up_to_date');
+  assert.equal(
+    judgeUpdate('1.1.1-next.12', { latest: '1.1.1', next: '1.1.1-next.15' }, null, now).result,
+    'update_available',
+  );
+  assert.equal(
+    judgeUpdate('1.1.1-next.12', { latest: '1.1.0', next: '1.1.1-next.15' }, null, now).result,
+    'update_available',
+  );
+  assert.equal(
+    judgeUpdate('1.1.1-next.15', { latest: '1.1.1', next: '1.1.1-next.15' }, null, now).result,
+    'update_available',
+  );
+  assert.equal(judgeUpdate('1.1.1-next.12', { latest: '1.1.0', next: null }, null, now).result, 'up_to_date');
+  assert.equal(judgeUpdate('1.0.2', { latest: '1.1.0', next: null }, inCooldown, now).result, 'dismissed');
+  assert.equal(judgeUpdate('1.0.2', { latest: '1.1.1', next: null }, inCooldown, now).result, 'update_available'); // 新版本无视冷却
+  assert.equal(
+    judgeUpdate('1.0.2', { latest: '1.1.0', next: null }, inCooldownOlderVersion, now).result,
+    'update_available',
+  ); // 拒绝的是更旧版本
+  assert.equal(judgeUpdate('1.0.2', null, null, now).result, 'check_failed'); // distTags 缺失
+});
+
+test('judgeUpdate 返回字段完整性', () => {
+  const r = judgeUpdate('1.0.2', { latest: '1.1.0', next: null }, null);
+  assert.equal(r.currentVersion, '1.0.2');
+  assert.equal(r.latestStable, '1.1.0');
+  assert.equal(r.latestNext, null);
+  assert.equal(r.targetVersion, '1.1.0');
+  assert.equal(r.updateAvailable, true);
+  assert.equal(r.dismissed, false);
+  assert.equal(r.result, 'update_available');
+  const f = judgeUpdate('1.0.2', null, null);
+  assert.equal(f.result, 'check_failed');
+  assert.equal(f.note, '检测失败，不影响使用');
+});
+
+test('parseDistTagsOutput 解析 npm view --json 输出', () => {
+  assert.deepEqual(parseDistTagsOutput('{"latest":"1.1.0","next":"1.1.1-next.15"}'), {
+    latest: '1.1.0',
+    next: '1.1.1-next.15',
+  });
+  assert.deepEqual(parseDistTagsOutput('{"latest":"1.1.0"}'), { latest: '1.1.0', next: null });
+  assert.equal(parseDistTagsOutput('not json'), null);
+  assert.equal(parseDistTagsOutput(''), null);
+});

--- a/test/update-check.test.mjs
+++ b/test/update-check.test.mjs
@@ -13,6 +13,11 @@ import {
   parseDistTagsOutput,
   readSkipState,
   writeSkipState,
+  queryDistTagsSync,
+  getCachedUpdateInfo,
+  peekCachedUpdateInfo,
+  invalidateUpdateCache,
+  applyUpdateHint,
 } from '../plugins/huaweicloud-core/src/update-check.mjs';
 
 test('semverParse 解析稳定版与 prerelease', () => {
@@ -129,4 +134,86 @@ test('skip state 原子写往返 + 损坏容错', () => {
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
+});
+
+test('queryDistTagsSync 成功返回 distTags 对象', () => {
+  const result = queryDistTagsSync({ timeoutMs: 5000 });
+  // 结果允许为 null（离线/超时）；若成功则形状必须正确
+  if (result !== null) {
+    assert.equal(typeof result.latest, 'string');
+    assert.ok(result.next === null || typeof result.next === 'string');
+  }
+});
+
+test('getCachedUpdateInfo 单飞: 并发只查一次', async () => {
+  invalidateUpdateCache();
+  let calls = 0;
+  const fakeQuery = async () => {
+    calls++;
+    await new Promise((r) => setTimeout(r, 20));
+    return { latest: '1.1.1', next: null };
+  };
+  const [a, b] = await Promise.all([
+    getCachedUpdateInfo('1.0.2', { doQuery: fakeQuery }),
+    getCachedUpdateInfo('1.0.2', { doQuery: fakeQuery }),
+  ]);
+  assert.equal(calls, 1);
+  assert.equal(a.result, 'update_available');
+  assert.equal(b.result, 'update_available');
+  assert.equal(a.targetVersion, '1.1.1');
+  invalidateUpdateCache();
+});
+
+test('getCachedUpdateInfo TTL: 未过期不重复查询', async () => {
+  invalidateUpdateCache();
+  let calls = 0;
+  const fakeQuery = async () => {
+    calls++;
+    return { latest: '1.2.0', next: null };
+  };
+  assert.equal((await getCachedUpdateInfo('1.0.2', { doQuery: fakeQuery })).result, 'update_available');
+  assert.equal((await getCachedUpdateInfo('1.0.2', { doQuery: fakeQuery })).result, 'update_available');
+  assert.equal(calls, 1);
+  invalidateUpdateCache();
+});
+
+test('getCachedUpdateInfo 失败节流: 失败后短时间不重查', async () => {
+  invalidateUpdateCache();
+  let calls = 0;
+  const failQuery = async () => {
+    calls++;
+    return null;
+  };
+  const r1 = await getCachedUpdateInfo('1.0.2', { doQuery: failQuery });
+  const r2 = await getCachedUpdateInfo('1.0.2', { doQuery: failQuery });
+  assert.equal(r1.result, 'check_failed');
+  assert.equal(r2.result, 'check_failed');
+  assert.equal(calls, 1); // 同会话节流
+  invalidateUpdateCache();
+});
+
+test('peekCachedUpdateInfo 返回已就绪 hint | null', async () => {
+  invalidateUpdateCache();
+  assert.equal(peekCachedUpdateInfo(), null);
+  const fakeQuery = async () => ({ latest: '1.1.0', next: null });
+  await getCachedUpdateInfo('1.0.2', { doQuery: fakeQuery });
+  const hint = peekCachedUpdateInfo();
+  assert.ok(hint && hint.updateAvailable === true);
+  assert.equal(hint.currentVersion, '1.0.2');
+  assert.equal(hint.targetVersion, '1.1.0');
+  invalidateUpdateCache();
+});
+
+test('applyUpdateHint 附加/跳过规则', () => {
+  const base = { ok: true };
+  const hint = { updateAvailable: true, currentVersion: '1.0.2', targetVersion: '1.1.0' };
+  assert.equal(applyUpdateHint(base, 'huaweicloud_check_cli', hint)._updateInfo.latestVersion, '1.1.0');
+  assert.equal(applyUpdateHint(base, 'huaweicloud_check_update', hint), base); // 自身不加
+  assert.equal(applyUpdateHint(base, 'huaweicloud_upgrade', hint), base);
+  assert.equal(applyUpdateHint(base, 'huaweicloud_check_cli', null), base); // 无 hint 不加
+  assert.equal(applyUpdateHint(base, 'huaweicloud_check_cli', { updateAvailable: false }), base);
+  assert.deepEqual(applyUpdateHint(base, 'huaweicloud_check_cli', hint)._updateInfo, {
+    currentVersion: '1.0.2',
+    latestVersion: '1.1.0',
+  });
 });

--- a/test/update-check.test.mjs
+++ b/test/update-check.test.mjs
@@ -274,7 +274,7 @@ test('upgradePackage 成功路径: 目标版本/重启/文案/缓存失效', asy
   const doQuery = async () => ({ latest: '1.1.1', next: null });
   const r = await upgradePackage({ target: 'opencode', version: 'latest' }, { doQuery, spawnFn });
   assert.equal(r.success, true);
-  assert.equal(r.previousVersion, '1.1.1-next.15'); // repo package.json 当前版本
+  assert.equal(r.previousVersion, '1.1.2-next.0'); // repo package.json 当前版本
   assert.equal(r.installedVersion, '1.1.1');
   assert.equal(r.requiresRestart, true);
   assert.match(r.message, /重启当前会话/);

--- a/test/update-check.test.mjs
+++ b/test/update-check.test.mjs
@@ -18,6 +18,7 @@ import {
   peekCachedUpdateInfo,
   invalidateUpdateCache,
   applyUpdateHint,
+  upgradePackage,
 } from '../plugins/huaweicloud-core/src/update-check.mjs';
 
 test('semverParse 解析稳定版与 prerelease', () => {
@@ -216,4 +217,70 @@ test('applyUpdateHint 附加/跳过规则', () => {
     currentVersion: '1.0.2',
     latestVersion: '1.1.0',
   });
+});
+
+test('upgradePackage 参数校验: version 仅支持 latest', async () => {
+  const r = await upgradePackage({ target: 'opencode', version: '1.0.0' }, { spawnFn: () => ({ status: 0 }) });
+  assert.equal(r.success, false);
+  assert.match(r.error, /version 参数仅支持 latest/);
+});
+
+test('upgradePackage 成功路径: 目标版本/重启/文案/缓存失效', async () => {
+  invalidateUpdateCache();
+  let spawned = null;
+  const spawnFn = (cmd, args, opts) => {
+    spawned = { cmd, args, opts };
+    return { status: 0, stdout: '', stderr: '' };
+  };
+  const doQuery = async () => ({ latest: '1.1.1', next: null });
+  const r = await upgradePackage({ target: 'opencode', version: 'latest' }, { doQuery, spawnFn });
+  assert.equal(r.success, true);
+  assert.equal(r.previousVersion, '1.1.1-next.15'); // repo package.json 当前版本
+  assert.equal(r.installedVersion, '1.1.1');
+  assert.equal(r.requiresRestart, true);
+  assert.match(r.message, /重启当前会话/);
+  assert.equal(spawned.cmd, 'npx');
+  assert.deepEqual(spawned.args, ['--yes', 'huaweicloud-devkit@latest', 'update', '--target', 'opencode']);
+  assert.equal(spawned.opts.timeout, 300000);
+  // 升级后缓存失效 → 下一次检测重新查询（此处不 fetch，只验证 invalidate 生效）
+  invalidateUpdateCache();
+});
+
+test('upgradePackage next 目标: 用 next tag', async () => {
+  let spawned = null;
+  const spawnFn = (cmd, args) => {
+    spawned = args;
+    return { status: 0 };
+  };
+  const doQuery = async () => ({ latest: '1.1.0', next: '1.1.1-next.15' });
+  await upgradePackage({ target: 'opencode' }, { doQuery, spawnFn });
+  assert.ok(spawned.some((a) => a === 'huaweicloud-devkit@next'));
+});
+
+test('upgradePackage officeace 专属重连文案', async () => {
+  const spawnFn = () => ({ status: 0 });
+  const doQuery = async () => ({ latest: '1.1.1', next: null });
+  const r = await upgradePackage({ target: 'officeace' }, { doQuery, spawnFn });
+  assert.match(r.message, /连接器/);
+});
+
+test('upgradePackage 失败: 返回手动命令', async () => {
+  const spawnFn = () => ({ status: 1, stdout: '', stderr: 'EPERM: permission denied' });
+  const doQuery = async () => ({ latest: '1.1.1', next: null });
+  const r = await upgradePackage({ target: 'opencode' }, { doQuery, spawnFn });
+  assert.equal(r.success, false);
+  assert.match(r.manual, /npx --yes huaweicloud-devkit@latest update --target opencode/);
+  assert.match(r.error, /EPERM/);
+});
+
+test('upgradePackage 查询失败: 不 spawn 并给手动提示', async () => {
+  let spawned = false;
+  const spawnFn = () => {
+    spawned = true;
+    return { status: 0 };
+  };
+  const r = await upgradePackage({ target: 'opencode' }, { doQuery: async () => null, spawnFn });
+  assert.equal(r.success, false);
+  assert.equal(spawned, false);
+  assert.match(r.manual, /huaweicloud-devkit@latest update/);
 });

--- a/test/update-check.test.mjs
+++ b/test/update-check.test.mjs
@@ -1,6 +1,6 @@
 import { test } from 'node:test';
 import assert from 'node:assert/strict';
-import { mkdtempSync, rmSync, writeFileSync, existsSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
@@ -14,6 +14,7 @@ import {
   readSkipState,
   writeSkipState,
   queryDistTagsSync,
+  queryDistTags,
   getCachedUpdateInfo,
   peekCachedUpdateInfo,
   invalidateUpdateCache,
@@ -137,8 +138,41 @@ test('skip state 原子写往返 + 损坏容错', () => {
   }
 });
 
+test('writeSkipState 目标不可写时清理临时文件', () => {
+  const dir = tmpDir();
+  try {
+    const file = join(dir, '.update-skip.json');
+    mkdirSync(file, { recursive: true }); // 目标为目录 → rename 失败
+    let threw = false;
+    try {
+      writeSkipState(file, '1.1.1');
+    } catch {
+      threw = true;
+    }
+    assert.equal(threw, true);
+    const leftover = readdirSync(dir).filter((f) => f.includes('.tmp'));
+    assert.deepEqual(leftover, []); // 不留 temp 残渣
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test('queryDistTagsSync 成功返回 distTags 对象', () => {
   const result = queryDistTagsSync({ timeoutMs: 5000 });
+  // 结果允许为 null（离线/超时）；若成功则形状必须正确
+  if (result !== null) {
+    assert.equal(typeof result.latest, 'string');
+    assert.ok(result.next === null || typeof result.next === 'string');
+  }
+});
+
+test('queryDistTags 异步非阻塞: 同步调用立即返回 Promise', async () => {
+  const before = Date.now();
+  const p = queryDistTags({ timeoutMs: 5000 });
+  const callMs = Date.now() - before;
+  assert.ok(p instanceof Promise, 'queryDistTags 应返回 Promise');
+  assert.ok(callMs < 100, `queryDistTags 同步调用应非阻塞, 实际耗时 ${callMs}ms`);
+  const result = await p;
   // 结果允许为 null（离线/超时）；若成功则形状必须正确
   if (result !== null) {
     assert.equal(typeof result.latest, 'string');
@@ -213,6 +247,11 @@ test('applyUpdateHint 附加/跳过规则', () => {
   assert.equal(applyUpdateHint(base, 'huaweicloud_upgrade', hint), base);
   assert.equal(applyUpdateHint(base, 'huaweicloud_check_cli', null), base); // 无 hint 不加
   assert.equal(applyUpdateHint(base, 'huaweicloud_check_cli', { updateAvailable: false }), base);
+  assert.equal(applyUpdateHint(base, 'huaweicloud_check_cli', { updateAvailable: true }), base); // 无 targetVersion 不加
+  assert.equal(
+    applyUpdateHint(base, 'huaweicloud_check_cli', { updateAvailable: true, currentVersion: '1.0.2' }),
+    base,
+  );
   assert.deepEqual(applyUpdateHint(base, 'huaweicloud_check_cli', hint)._updateInfo, {
     currentVersion: '1.0.2',
     latestVersion: '1.1.0',
@@ -271,6 +310,34 @@ test('upgradePackage 失败: 返回手动命令', async () => {
   assert.equal(r.success, false);
   assert.match(r.manual, /npx --yes huaweicloud-devkit@latest update --target opencode/);
   assert.match(r.error, /EPERM/);
+});
+
+test('upgradePackage 失败: spawn 不存在时报可读错误而非 exit null', async () => {
+  const spawnFn = () => ({
+    status: null,
+    stdout: '',
+    stderr: '',
+    error: new Error('spawn npx ENOENT'),
+  });
+  const doQuery = async () => ({ latest: '1.1.1', next: null });
+  const r = await upgradePackage({ target: 'opencode' }, { doQuery, spawnFn });
+  assert.equal(r.success, false);
+  assert.match(r.error, /ENOENT/);
+  assert.doesNotMatch(r.error, /exit null/);
+});
+
+test('upgradePackage 无目标版本: distTags 有效但无候选时不 spawn 并返回无需升级', async () => {
+  let spawned = false;
+  const spawnFn = () => {
+    spawned = true;
+    return { status: 0 };
+  };
+  const doQuery = async () => ({ latest: null, next: null });
+  const r = await upgradePackage({ target: 'opencode' }, { doQuery, spawnFn });
+  assert.equal(spawned, false);
+  assert.equal(r.success, false);
+  assert.equal(r.requiresRestart, false);
+  assert.match(r.message, /已是最新版本，无需升级。/);
 });
 
 test('upgradePackage 查询失败: 不 spawn 并给手动提示', async () => {


### PR DESCRIPTION
## 版本升级检测与自动升级

### 新增功能
- `huaweicloud_check_update` MCP tool：会话启动时检测插件新版本（通道感知比对，next 用户收同基数 stable 提醒）
- `huaweicloud_upgrade` MCP tool：用户同意后自动升级（`npx --yes huaweicloud-devkit@<tag> update`），`version` 仅支持 latest 防降级
- 3 天冷却：拒绝后不再打扰；新版本（> 拒绝版本）无视冷却重新提醒
- 会话启动异步预热 + 首调用 `_updateInfo` 兜底提示（仅附加一次）
- CLI `checkForUpdate()` 重构复用共享 `queryDistTags`（消除两套查询逻辑）
- `SKILL.md` 新增"会话启动"节；README 中/英更新命令补 `@latest`
- 异步 registry 查询（不阻塞 MCP 会话）+ 单飞缓存 + TTL + 失败节流
- 版本提升至 `1.1.2-next.0`（跨所有 plugin manifest 同步，@next 发布走 CI）

### 实现
- 新增 `plugins/huaweicloud-core/src/update-check.mjs`（逻辑/IO/缓存/升级分离，可单测）
- `tools.mjs` / `mcp-server.mjs` / `setup-cli.mjs` 接线

### 测试
- `test/update-check.test.mjs` 24 单测（比对矩阵、单飞/TTL/节流、冷却、升级校验/错误路径）
- `test/structure.test.mjs` 扩展
- `npm run lint` / `npm run validate` / prettier 通过
