### PR TITLE
feat: E2E test architecture + MCP tool invocation tests

### DIFF
--- a/docs/e2e-test-architecture.md
+++ b/docs/e2e-test-architecture.md
@@ -1,0 +1,136 @@
+# E2E 测试架构设计
+
+## 1. 设计目标
+
+验证华为云 DevKit 插件在真实 Code Agent 环境中的安装、加载、工具调用和卸载全流程，不依赖外部框架（无 pytest、无 DeepEval、无 YAML），基于现有 Node.js 体系构建。
+
+## 2. 架构分层
+
+```
+第三层：场景回归（人工/半自动）
+  ├── nightly 回归 Skill（买 ECS、部署 OBS 等复杂交互场景）
+  ├── 人工执行 + 记录缺口 + 迭代修复
+  └── 不追求全自动化（交互场景需多轮决策）
+
+第二层：E2E 插件验证（自动，CI 可跑）
+  ├── 安装插件 → 验证技能/配置/安全策略
+  ├── 启动 MCP 服务器 → 调用只读工具 → 验证返回结果
+  ├── 卸载插件 → 验证清理干净
+  └── node --test 驱动，CI 自动执行
+
+第一层：单元/集成测试（自动，CI 已跑）
+  ├── 18 个 .test.mjs 文件
+  ├── 覆盖：安装、卸载、配置、安全策略、工具定义、风险引擎等
+  └── npm test 自动执行
+```
+
+## 3. 与 Issue #230 提案的区别
+
+| 维度 | #230 提案 | 本架构 |
+|------|----------|--------|
+| 测试框架 | pytest（Python） | node --test（Node.js） |
+| 语义评测 | DeepEval（LLM 裁判） | 确定性断言（不需要 LLM） |
+| 测试用例格式 | YAML 配置 | .test.mjs 代码 |
+| Agent 适配层 | 统一 Adapter 接口 | 直接 spawn CLI |
+| 外部依赖 | Python + DeepEval + YAML | 无新增依赖 |
+| CI 集成 | GitHub Actions Matrix | 现有 ci.yml 加一行 |
+
+**核心原则**：不引入新依赖，用现有 Node.js 体系把 E2E 补全。
+
+## 4. E2E 测试生命周期
+
+```
+┌──────────────────────────┐
+│  1. 创建临时环境           │
+│  ├── 临时 HOME 目录       │
+│  └── 临时工作目录          │
+├──────────────────────────┤
+│  2. 安装插件               │
+│  ├── 运行 setup.cjs install│
+│  └── 验证退出码 = 0        │
+├──────────────────────────┤
+│  3. 验证安装结果           │
+│  ├── 技能数 >= 6          │
+│  ├── MCP 服务器文件存在    │
+│  ├── 安全策略文件存在      │
+│  └── MCP 配置已注册        │
+├──────────────────────────┤
+│  4. 启动 MCP 服务器        │
+│  ├── spawn node mcp-server│
+│  └── 发送 initialize 请求  │
+├──────────────────────────┤
+│  5. 调用只读 MCP 工具      │
+│  ├── tools/list           │
+│  ├── 验证工具数 > 0        │
+│  └── 验证工具名前缀正确     │
+├──────────────────────────┤
+│  6. 卸载插件               │
+│  ├── 运行 setup.cjs uninstall│
+│  └── 验证文件已清除        │
+├──────────────────────────┤
+│  7. 清理环境               │
+│  └── rm -rf 临时目录       │
+└──────────────────────────┘
+```
+
+## 5. MCP 工具调用方式
+
+不启动完整 Agent CLI，直接通过 stdio 与 MCP 服务器通信：
+
+```javascript
+// 启动 MCP 服务器子进程
+const child = spawn('node', [mcpServerPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+
+// 发送 JSON-RPC initialize
+child.stdin.write(JSON.stringify({
+  jsonrpc: '2.0', method: 'initialize',
+  params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'e2e-test', version: '1.0' } },
+  id: 1
+}) + '\n');
+
+// 发送 tools/list
+child.stdin.write(JSON.stringify({
+  jsonrpc: '2.0', method: 'tools/list', params: {}, id: 2
+}) + '\n');
+
+// 从 stdout 读取响应（按行解析 JSON）
+```
+
+## 6. 测试覆盖的 Agent
+
+| Agent | 安装测试 | MCP 工具调用 | 卸载测试 |
+|-------|---------|-------------|---------|
+| OpenCode | ✅ | ✅ | ✅ |
+| Codex Desktop | ✅ | ✅ | ✅ |
+| WorkBuddy | ✅ | ✅ | ✅ |
+
+## 7. CI 集成
+
+在现有 `ci.yml` 中增加 E2E 测试步骤：
+
+```yaml
+- name: Run E2E tests
+  run: node --test test/plugins-e2e.test.mjs
+```
+
+## 8. 各负责人优化方向
+
+| 测试文件 | 优化方向 |
+|---------|---------|
+| structure.test.mjs | 补充新增组件（claude-code 集成）的结构验证 |
+| agent-install.test.mjs | 增加 Claude Code target 的安装测试 |
+| tools.test.mjs | 验证工具标注（readOnlyHint / destructiveHint） |
+| safety-policy.test.mjs | 补充新安全规则的测试用例 |
+| mcp-server.test.mjs | 验证 MCP 服务器 initialize + tools/list 流程 |
+| auth-credentials.test.mjs | 补充 STS 临时凭证的测试 |
+| 其他适配测试 | 各 Agent 负责人补充对应适配测试 |
+
+## 9. 不做的事情
+
+| 不做 | 原因 |
+|------|------|
+| 引入 pytest/Python | 增加维护成本，与现有体系不一致 |
+| 引入 DeepEval | LLM 裁判非确定性，测试结果不可复现 |
+| YAML 测试用例 | 增加间接层，不如直接写 .test.mjs |
+| 真实云操作 E2E | 费用高、风险大、耗时长，留给 nightly 回归 |
+| 多轮交互自动化 | 交互场景需根据中间结果决策，无法用单次 prompt 覆盖 |

--- a/docs/e2e-test-architecture.md
+++ b/docs/e2e-test-architecture.md
@@ -1,131 +1,197 @@
 # E2E 测试架构设计
 
-## 1. 设计目标
+## 1. 背景
 
-验证华为云 DevKit 插件在真实 Code Agent 环境中的安装、加载、工具调用和卸载全流程，不依赖外部框架（无 pytest、无 DeepEval、无 YAML），基于现有 Node.js 体系构建。
+### 1.1 为什么需要 E2E 测试
 
-## 2. 架构分层
+当前 DevKit 插件已适配 9 个 Agent（OpenCode、Codex、CodeArts、WorkBuddy、DSH、OfficeAce、Hermes、OpenClaw、AtomCode），但测试覆盖存在缺口：
+
+| 测试层 | 现状 | 问题 |
+|--------|------|------|
+| 单元/集成测试 | 18 个 .test.mjs，CI 已跑 | 只测组件级，不测完整流程 |
+| E2E 插件验证 | plugins-e2e.test.mjs（骨架） | 只测安装/卸载，不测 MCP 工具是否真正可用 |
+| 场景回归 | nightly 回归 Skill（人工） | 依赖人工执行，无法在 CI 中自动跑 |
+
+**核心问题**：插件安装成功 ≠ MCP 工具能用。现有测试验证了"文件复制到位"，但没有验证"MCP 服务器能启动、工具能调用、结果能返回"。
+
+### 1.2 与 Issue #230 的关系
+
+Issue #230（ChenyYin 提案）提出了完整的 E2E 测试框架方案，包含 pytest、DeepEval、YAML、GitHub Actions Matrix 等。经团队评估（zrr 反馈）：
+
+- #230 作为**参考方案**，不直接照搬
+- 需要团队**自己设计架构**，适配实际情况
+- 各负责人**优化自己负责的测试用例**
+
+本设计基于 #230 的思路，简化为现有 Node.js 体系可实现方案。
+
+## 2. 设计目标
+
+验证 DevKit 插件在真实环境中的**安装 → MCP 工具调用 → 卸载**全流程，不引入新依赖。
+
+| 目标 | 说明 |
+|------|------|
+| 验证 MCP 工具可用 | 安装后启动 MCP 服务器，调用 tools/list，验证工具返回 |
+| CI 可自动执行 | 在现有 ci.yml 中加一行，无需新增 CI 作业 |
+| 无新依赖 | 不引入 Python、pytest、DeepEval、YAML |
+| 覆盖多 Agent | OpenCode、Codex Desktop、WorkBuddy 三个 target |
+| 环境隔离 | 每个测试用例使用独立临时目录，互不干扰 |
+
+## 3. 架构分层
 
 ```
-第三层：场景回归（人工/半自动）
-  ├── nightly 回归 Skill（买 ECS、部署 OBS 等复杂交互场景）
-  ├── 人工执行 + 记录缺口 + 迭代修复
-  └── 不追求全自动化（交互场景需多轮决策）
-
-第二层：E2E 插件验证（自动，CI 可跑）
-  ├── 安装插件 → 验证技能/配置/安全策略
-  ├── 启动 MCP 服务器 → 调用只读工具 → 验证返回结果
-  ├── 卸载插件 → 验证清理干净
-  └── node --test 驱动，CI 自动执行
-
-第一层：单元/集成测试（自动，CI 已跑）
-  ├── 18 个 .test.mjs 文件
-  ├── 覆盖：安装、卸载、配置、安全策略、工具定义、风险引擎等
-  └── npm test 自动执行
+┌─────────────────────────────────────────────────┐
+│  第三层：场景回归（人工/半自动）                    │
+│  ├── nightly 回归 Skill                          │
+│  │   ├── 买 ECS、部署 OBS 等复杂交互场景           │
+│  │   └── 人工执行 + 记录缺口 + 迭代修复            │
+│  └── 不追求全自动化（交互场景需多轮决策）            │
+├─────────────────────────────────────────────────┤
+│  第二层：E2E 插件验证（自动，CI 可跑）  ← 本次新增   │
+│  ├── 安装插件 → 验证技能/配置/安全策略              │
+│  ├── 启动 MCP 服务器 → 调用 tools/list → 验证返回  │
+│  ├── 卸载插件 → 验证清理干净                       │
+│  └── node --test 驱动，CI 自动执行                 │
+├─────────────────────────────────────────────────┤
+│  第一层：单元/集成测试（自动，CI 已跑）              │
+│  ├── 18 个 .test.mjs 文件                         │
+│  ├── 覆盖：安装、卸载、配置、安全策略、工具定义等    │
+│  └── npm test 自动执行                            │
+└─────────────────────────────────────────────────┘
 ```
 
-## 3. 与 Issue #230 提案的区别
+## 4. 与 Issue #230 提案的区别
 
-| 维度 | #230 提案 | 本架构 |
-|------|----------|--------|
-| 测试框架 | pytest（Python） | node --test（Node.js） |
-| 语义评测 | DeepEval（LLM 裁判） | 确定性断言（不需要 LLM） |
-| 测试用例格式 | YAML 配置 | .test.mjs 代码 |
-| Agent 适配层 | 统一 Adapter 接口 | 直接 spawn CLI |
-| 外部依赖 | Python + DeepEval + YAML | 无新增依赖 |
-| CI 集成 | GitHub Actions Matrix | 现有 ci.yml 加一行 |
+| 维度 | #230 提案 | 本架构 | 选择理由 |
+|------|----------|--------|---------|
+| 测试框架 | pytest（Python） | node --test（Node.js） | 与现有 18 个测试一致，无新依赖 |
+| 语义评测 | DeepEval（LLM 裁判） | 确定性断言 | LLM 裁判非确定性，结果不可复现 |
+| 测试用例格式 | YAML 配置 | .test.mjs 代码 | 不增加间接层，直接写代码更灵活 |
+| Agent 适配层 | 统一 Adapter 接口 | 直接 spawn CLI | 3 个 target 不需要抽象层 |
+| CI 集成 | GitHub Actions Matrix | 现有 ci.yml 加一行 | 复用现有 integration job |
+| 外部依赖 | Python + DeepEval + YAML | 无新增 | 降低维护成本 |
 
 **核心原则**：不引入新依赖，用现有 Node.js 体系把 E2E 补全。
 
-## 4. E2E 测试生命周期
+## 5. E2E 测试生命周期
 
 ```
-┌──────────────────────────┐
-│  1. 创建临时环境           │
-│  ├── 临时 HOME 目录       │
-│  └── 临时工作目录          │
-├──────────────────────────┤
-│  2. 安装插件               │
-│  ├── 运行 setup.cjs install│
-│  └── 验证退出码 = 0        │
-├──────────────────────────┤
-│  3. 验证安装结果           │
-│  ├── 技能数 >= 6          │
-│  ├── MCP 服务器文件存在    │
-│  ├── 安全策略文件存在      │
-│  └── MCP 配置已注册        │
-├──────────────────────────┤
-│  4. 启动 MCP 服务器        │
-│  ├── spawn node mcp-server│
-│  └── 发送 initialize 请求  │
-├──────────────────────────┤
-│  5. 调用只读 MCP 工具      │
-│  ├── tools/list           │
-│  ├── 验证工具数 > 0        │
-│  └── 验证工具名前缀正确     │
-├──────────────────────────┤
-│  6. 卸载插件               │
-│  ├── 运行 setup.cjs uninstall│
-│  └── 验证文件已清除        │
-├──────────────────────────┤
-│  7. 清理环境               │
-│  └── rm -rf 临时目录       │
-└──────────────────────────┘
+┌──────────────────────────────────┐
+│  1. 创建临时环境                   │
+│  ├── 临时 HOME 目录               │
+│  └── 临时工作目录                  │
+├──────────────────────────────────┤
+│  2. 安装插件                       │
+│  ├── 运行 setup.cjs install       │
+│  └── 验证退出码 = 0               │
+├──────────────────────────────────┤
+│  3. 验证安装结果                   │
+│  ├── 技能数 >= 6                  │
+│  ├── MCP 服务器文件存在            │
+│  ├── 安全策略文件存在              │
+│  └── MCP 配置已注册                │
+├──────────────────────────────────┤
+│  4. 启动 MCP 服务器                │
+│  ├── spawn node mcp-server.mjs    │
+│  └── 发送 initialize 请求          │
+│      → 验证 serverInfo.name 正确   │
+├──────────────────────────────────┤
+│  5. 调用 tools/list               │
+│  ├── 验证工具数 > 0                │
+│  └── 验证工具名以 huaweicloud_ 开头 │
+├──────────────────────────────────┤
+│  6. 卸载插件                       │
+│  ├── 运行 setup.cjs uninstall     │
+│  └── 验证文件已清除                │
+├──────────────────────────────────┤
+│  7. 清理环境                       │
+│  └── rm -rf 临时目录               │
+└──────────────────────────────────┘
 ```
 
-## 5. MCP 工具调用方式
+## 6. MCP 工具调用方式
 
 不启动完整 Agent CLI，直接通过 stdio 与 MCP 服务器通信：
 
 ```javascript
 // 启动 MCP 服务器子进程
-const child = spawn('node', [mcpServerPath], { stdio: ['pipe', 'pipe', 'pipe'] });
+const child = spawn('node', [mcpServerPath], {
+  stdio: ['pipe', 'pipe', 'pipe'],
+  env: makeEnv(home, cwd),
+});
 
 // 发送 JSON-RPC initialize
 child.stdin.write(JSON.stringify({
   jsonrpc: '2.0', method: 'initialize',
-  params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'e2e-test', version: '1.0' } },
+  params: {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'e2e-test', version: '1.0' }
+  },
   id: 1
 }) + '\n');
 
-// 发送 tools/list
+// 收到 initialize 响应后，发送 tools/list
 child.stdin.write(JSON.stringify({
   jsonrpc: '2.0', method: 'tools/list', params: {}, id: 2
 }) + '\n');
 
-// 从 stdout 读取响应（按行解析 JSON）
+// 从 stdout 按行读取 JSON-RPC 响应
+// 验证：serverInfo.name = "huaweicloud-devkit"
+// 验证：tools 数组非空，所有工具名以 huaweicloud_ 开头
 ```
 
-## 6. 测试覆盖的 Agent
+**为什么不调用具体工具（如 list_regions）**：具体工具需要华为云凭证和网络访问，在 CI 环境中不可用。tools/list 只需要 MCP 服务器启动，不需要外部依赖。
 
-| Agent | 安装测试 | MCP 工具调用 | 卸载测试 |
-|-------|---------|-------------|---------|
-| OpenCode | ✅ | ✅ | ✅ |
-| Codex Desktop | ✅ | ✅ | ✅ |
-| WorkBuddy | ✅ | ✅ | ✅ |
+## 7. 测试覆盖的 Agent
 
-## 7. CI 集成
+| Agent | 安装测试 | MCP 工具调用 | 卸载测试 | 合计测试数 |
+|-------|---------|-------------|---------|-----------|
+| OpenCode | ✅ | ✅ | ✅ | 3 |
+| Codex Desktop | ✅ | ✅ | ✅ | 3 |
+| WorkBuddy | ✅ | ✅ | ✅ | 3 |
+| **合计** | 3 | 3 | 3 | **9** |
 
-在现有 `ci.yml` 中增加 E2E 测试步骤：
+## 8. CI 集成
+
+在现有 `ci.yml` 的 `integration` job 中增加一行：
 
 ```yaml
-- name: Run E2E tests
-  run: node --test test/plugins-e2e.test.mjs
+  integration:
+    needs: [test]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: npm
+      - run: npm ci
+      # 现有
+      - run: node --test test/agent-install.test.mjs test/cross-platform-*.test.mjs
+      # 新增 ↓
+      - run: node --test test/plugins-e2e.test.mjs
 ```
 
-## 8. 各负责人优化方向
+**不需要新增 CI 作业**，复用现有 integration job。
 
-| 测试文件 | 优化方向 |
-|---------|---------|
-| structure.test.mjs | 补充新增组件（claude-code 集成）的结构验证 |
-| agent-install.test.mjs | 增加 Claude Code target 的安装测试 |
-| tools.test.mjs | 验证工具标注（readOnlyHint / destructiveHint） |
-| safety-policy.test.mjs | 补充新安全规则的测试用例 |
-| mcp-server.test.mjs | 验证 MCP 服务器 initialize + tools/list 流程 |
-| auth-credentials.test.mjs | 补充 STS 临时凭证的测试 |
-| 其他适配测试 | 各 Agent 负责人补充对应适配测试 |
+## 9. 各负责人优化方向
 
-## 9. 不做的事情
+现有 18 个测试文件，各负责人按模块优化：
+
+| 测试文件 | 大小 | 优化方向 |
+|---------|------|---------|
+| structure.test.mjs | 28KB | 补充 claude-code 集成的结构验证 |
+| agent-install.test.mjs | 17KB | 增加 Claude Code target 的安装测试 |
+| tools.test.mjs | 7.5KB | 验证工具标注（readOnlyHint / destructiveHint） |
+| safety-policy.test.mjs | 7.5KB | 补充新安全规则的测试用例 |
+| mcp-server.test.mjs | 6.0KB | 验证 MCP 服务器 initialize + tools/list 流程 |
+| auth-credentials.test.mjs | 12KB | 补充 STS 临时凭证的测试 |
+| codearts-adaptation.test.mjs | 13KB | CodeArts 负责人优化 |
+| dsh-adaptation.test.mjs | 9.7KB | DSH 负责人优化 |
+| officeace-adaptation.test.mjs | 3.2KB | OfficeAce 负责人优化 |
+| 其他 9 个文件 | 1.3-13KB | 各模块负责人优化 |
+
+## 10. 不做的事情
 
 | 不做 | 原因 |
 |------|------|
@@ -134,3 +200,33 @@ child.stdin.write(JSON.stringify({
 | YAML 测试用例 | 增加间接层，不如直接写 .test.mjs |
 | 真实云操作 E2E | 费用高、风险大、耗时长，留给 nightly 回归 |
 | 多轮交互自动化 | 交互场景需根据中间结果决策，无法用单次 prompt 覆盖 |
+| 调用具体 MCP 工具 | 需要凭证和网络，CI 环境不可用；tools/list 足够验证 MCP 服务器可用性 |
+
+## 11. 预期收益
+
+| 指标 | 现状 | 实施后 |
+|------|------|--------|
+| CI 中自动跑的 E2E 测试数 | 0 | 9（3 Agent × 3 场景） |
+| MCP 工具可用性验证 | 人工 | 自动（CI 每次 PR 自动跑） |
+| 测试文件总数 | 18 | 18（不新增文件，增强现有） |
+| 新增外部依赖 | - | 0 |
+| 安装→工具调用→卸载全流程 | 人工 | 自动 |
+
+## 12. 工作量估算
+
+| 任务 | 负责人 | 工作量 |
+|------|--------|--------|
+| 架构设计文档 | 已完成 | - |
+| 补全 plugins-e2e.test.mjs | 已完成 | - |
+| ci.yml 集成 | 维护者 | 5 分钟（加一行） |
+| 各负责人优化测试用例 | 各负责人 | 每人 2-4 小时 |
+| 评审会议 | 全体 | 30-60 分钟 |
+
+## 13. 风险与应对
+
+| 风险 | 概率 | 影响 | 应对 |
+|------|------|------|------|
+| MCP 服务器在 CI 环境启动失败 | 低 | E2E 测试报错 | CI 已有 Node.js 22+，MCP 服务器无外部依赖 |
+| 临时目录清理不干净 | 低 | 磁盘占用 | 使用 finally 块确保清理 |
+| 测试超时 | 低 | CI 卡住 | 设置 15 秒超时 + child.kill() |
+| 新增 Agent 需要补充测试 | 中 | 覆盖不全 | targets 数组加一项即可，代码结构可扩展 |

--- a/test/plugins-e2e.test.mjs
+++ b/test/plugins-e2e.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
@@ -31,6 +31,53 @@ function runCli(home, cwd, args) {
 function countSkills(dir) {
   if (!existsSync(dir)) return 0;
   return readdirSync(dir, { withFileTypes: true }).filter((d) => d.isDirectory() && d.name.startsWith('huawei')).length;
+}
+
+function invokeMcpTools(mcpServerPath, env, timeout = 15000) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(process.execPath, [mcpServerPath], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      env,
+      timeout,
+    });
+    let buffer = '';
+    const responses = [];
+    let seq = 0;
+
+    child.stdout.on('data', (chunk) => {
+      buffer += chunk.toString();
+      const lines = buffer.split('\n');
+      buffer = lines.pop();
+      for (const line of lines) {
+        if (line.trim()) {
+          try {
+            const msg = JSON.parse(line);
+            if (msg.id !== undefined && msg.id !== null) {
+              responses.push(msg);
+              if (responses.length === 1) {
+                child.stdin.write(JSON.stringify({
+                  jsonrpc: '2.0', method: 'tools/list', params: {}, id: ++seq,
+                }) + '\n');
+              } else if (responses.length === 2) {
+                child.kill();
+                resolve(responses);
+              }
+            }
+          } catch {}
+        }
+      }
+    });
+
+    child.stderr.on('data', () => {});
+    child.on('error', reject);
+    setTimeout(() => { child.kill(); reject(new Error('MCP timeout')); }, timeout);
+
+    child.stdin.write(JSON.stringify({
+      jsonrpc: '2.0', method: 'initialize',
+      params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'e2e-test', version: '1.0' } },
+      id: ++seq,
+    }) + '\n');
+  });
 }
 
 const targets = [
@@ -118,6 +165,31 @@ for (const target of targets) {
       assert.equal(countSkills(target.skillsDir(home)), 0, `${target.name}: skills removed`);
       assert.ok(!existsSync(target.pluginsDir(home)), `${target.name}: plugins dir removed`);
       assert.ok(!target.hasServer(target.configPath(home)), `${target.name}: MCP config cleaned`);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  test(`${target.name}: MCP server responds to initialize and tools/list`, async () => {
+    const home = mkdtempSync(join(tmpdir(), `${target.name}-mcp-`));
+    const cwd = mkdtempSync(join(tmpdir(), `${target.name}-mcp-proj-`));
+    try {
+      const install = runCli(home, cwd, ['install', '--target', target.name]);
+      assert.equal(install.status, 0, install.stderr);
+
+      const mcpServerPath = join(target.pluginsDir(home), 'src', 'mcp-server.mjs');
+      assert.ok(existsSync(mcpServerPath), `${target.name}: MCP server file exists`);
+
+      const responses = await invokeMcpTools(mcpServerPath, makeEnv(home, cwd));
+
+      assert.ok(responses[0].result, `${target.name}: initialize returned result`);
+      assert.equal(responses[0].result.serverInfo.name, 'huaweicloud-devkit', `${target.name}: server name correct`);
+
+      assert.ok(responses[1].result, `${target.name}: tools/list returned result`);
+      const tools = responses[1].result.tools;
+      assert.ok(tools.length > 0, `${target.name}: tools array not empty`);
+      assert.ok(tools.every((t) => t.name.startsWith('huaweicloud_')), `${target.name}: all tools have huaweicloud_ prefix`);
     } finally {
       rmSync(home, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## E2E 测试架构设计 + MCP 工具调用测试

### 变更文件（仅 2 个）

| 文件 | 变更 |
|------|------|
| docs/e2e-test-architecture.md | 新增（232 行）|
| test/plugins-e2e.test.mjs | 修改（+74 行）|

### 新增内容

#### 1. 测试架构设计文档

三层测试架构：
- 第一层：单元/集成测试（18 个 .test.mjs，已有，各负责人优化）
- 第二层：E2E 插件验证（安装→MCP工具调用→验证→卸载，本次新增）
- 第三层：场景回归（nightly 回归 Skill，人工/半自动，已有）

参考 Issue #230，不引入新依赖（无 pytest、无 DeepEval、无 YAML）。

#### 2. E2E 测试补全

在 plugins-e2e.test.mjs 新增 MCP 服务器生命周期测试：
- 安装插件 → 启动 MCP 服务器 → initialize → tools/list → 验证工具返回 → 清理
- 覆盖 3 个 Agent：OpenCode、Codex Desktop、WorkBuddy
- 自测通过：9/9 pass（ECS Linux，48 秒）

### CI 集成（需维护者操作）

ci.yml integration job 加一行：
```yaml
- run: node --test test/plugins-e2e.test.mjs
```

### 自测结果

9/9 pass，48 秒，ECS Linux 环境。