### PR TITLE
feat(mcp): add remote (Streamable HTTP) transport mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,30 @@ No installation required — `npx` handles everything.
 
 > Set `HW_ACCESS_KEY`/`HW_SECRET_KEY` in the MCP config `env` field for project-level credentials.
 
+#### Connecting over Remote (HTTP)
+
+If your agent supports `type: "remote"` (Streamable HTTP) instead of stdio, start the devkit remote MCP server locally first:
+
+```bash
+npx --yes huaweicloud-devkit-mcp --transport remote
+```
+
+It listens on `127.0.0.1:9528` by default (no conflict with the IACMCPServer port 9527). Then connect with a remote config (opencode example):
+
+```jsonc
+{
+  "mcp": {
+    "huaweicloud-devkit": {
+      "type": "remote",
+      "url": "http://localhost:9528",
+      "enabled": true
+    }
+  }
+}
+```
+
+> Use `--port <port>` if 9528 is taken and update `url` accordingly; add `--host 0.0.0.0` for LAN access. The remote server has no built-in auth — do not expose it anonymously to the public internet.
+
 ### Install KooCLI
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -242,9 +242,9 @@ It listens on `127.0.0.1:9528` by default (no conflict with the IACMCPServer por
     "huaweicloud-devkit": {
       "type": "remote",
       "url": "http://localhost:9528",
-      "enabled": true
-    }
-  }
+      "enabled": true,
+    },
+  },
 }
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -226,6 +226,30 @@ npx --yes huaweicloud-devkit uninstall --target atomcode
 
 > 项目级 AK/SK 可通过 MCP 配置的 `env` 字段设置 `HW_ACCESS_KEY`/`HW_SECRET_KEY`。
 
+#### 通过 Remote（HTTP）连接
+
+若 Agent 支持 `type: "remote"`（Streamable HTTP）而非 stdio，可在本地先启动 devkit 的远程 MCP 服务器：
+
+```bash
+npx --yes huaweicloud-devkit-mcp --transport remote
+```
+
+默认监听 `127.0.0.1:9528`（与预置的 IACMCPServer 端口 9527 不冲突）。随后以远程方式连接（以 opencode 为例）：
+
+```jsonc
+{
+  "mcp": {
+    "huaweicloud-devkit": {
+      "type": "remote",
+      "url": "http://localhost:9528",
+      "enabled": true
+    }
+  }
+}
+```
+
+> 端口被占用时用 `--port <端口>` 换端口，`url` 同步修改；需要局域网访问时加 `--host 0.0.0.0`。remote 服务器不内置鉴权，请勿匿名暴露到公网。
+
 ### 安装 KooCLI
 
 ```bash

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -242,9 +242,9 @@ npx --yes huaweicloud-devkit-mcp --transport remote
     "huaweicloud-devkit": {
       "type": "remote",
       "url": "http://localhost:9528",
-      "enabled": true
-    }
-  }
+      "enabled": true,
+    },
+  },
 }
 ```
 

--- a/plugins/huaweicloud-core/src/mcp-protocol.mjs
+++ b/plugins/huaweicloud-core/src/mcp-protocol.mjs
@@ -1,0 +1,88 @@
+import { readFileSync } from 'node:fs';
+import { resolve, dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { TOOL_DEFINITIONS, callTool } from './tools.mjs';
+import { peekCachedUpdateInfo, applyUpdateHint } from './update-check.mjs';
+import { initTelemetry } from './telemetry/telemetry.mjs';
+import { detectAgent } from './telemetry/agent-detect.mjs';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const pluginRoot = resolve(__dirname, '..');
+const packageRoot = resolve(pluginRoot, '..', '..');
+let pkgVersion = '0.0.0';
+for (const base of [pluginRoot, packageRoot]) {
+  try {
+    const version = JSON.parse(readFileSync(join(base, 'package.json'), 'utf8')).version;
+    if (version) {
+      pkgVersion = version;
+      break;
+    }
+  } catch {}
+}
+
+// 会话内首个非 check/upgrade 工具调用附加 _updateInfo，只消费一次。
+let hintConsumed = false;
+function decorateResult(name, result) {
+  if (hintConsumed) return result;
+  try {
+    const hint = peekCachedUpdateInfo();
+    if (!hint) return result;
+    const decorated = applyUpdateHint(result, name, hint);
+    if (decorated !== result) hintConsumed = true;
+    return decorated;
+  } catch {
+    return result; // 兜底装饰失败绝不影响工具调用
+  }
+}
+
+export async function dispatch(method, params) {
+  if (method === 'initialize') {
+    const ci = params.clientInfo || {};
+
+    try {
+      const { hdkitGenerateUserHash } = await import('./sandbox/hdkitservice-api.mjs');
+      await Promise.race([
+        hdkitGenerateUserHash(),
+        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 3000)),
+      ]);
+    } catch {}
+
+    const agent = detectAgent(ci);
+    initTelemetry({ harness: agent.harness, version: agent.version });
+    return {
+      protocolVersion: params.protocolVersion || '2024-11-05',
+      capabilities: {
+        tools: {},
+      },
+      serverInfo: {
+        name: 'huaweicloud-devkit',
+        version: pkgVersion,
+      },
+    };
+  }
+
+  if (method === 'tools/list') {
+    return { tools: TOOL_DEFINITIONS };
+  }
+
+  if (method === 'tools/call') {
+    const result = await callTool(params.name, params.arguments || {});
+    const decorated = decorateResult(params.name, result);
+    return {
+      content: [
+        {
+          type: 'text',
+          text: JSON.stringify(decorated, null, 2),
+        },
+      ],
+      isError: false,
+    };
+  }
+
+  if (method === 'resources/list') {
+    return { resources: [] };
+  }
+
+  throw new Error(`Unsupported method: ${method}`);
+}

--- a/plugins/huaweicloud-core/src/mcp-server-remote.mjs
+++ b/plugins/huaweicloud-core/src/mcp-server-remote.mjs
@@ -1,0 +1,107 @@
+import { createServer } from 'node:http';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { format } from 'node:util';
+
+import { dispatch } from './mcp-protocol.mjs';
+
+export const DEFAULT_PORT = 9528;
+export const DEFAULT_HOST = '127.0.0.1';
+
+export async function startRemoteServer({ port = DEFAULT_PORT, host = DEFAULT_HOST } = {}) {
+  const server = createServer(async (req, res) => {
+    res.setHeader('Access-Control-Allow-Origin', '*');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS');
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, MCP-Protocol-Version, Mcp-Session-Id, Accept, Authorization',
+    );
+    res.setHeader('Access-Control-Expose-Headers', 'MCP-Protocol-Version, Mcp-Session-Id');
+
+    if (req.method === 'OPTIONS') {
+      res.writeHead(204);
+      res.end();
+      return;
+    }
+
+    if (req.method !== 'POST') {
+      res.writeHead(405, { Allow: 'POST, OPTIONS' });
+      res.end();
+      return;
+    }
+
+    let message;
+    try {
+      const chunks = [];
+      for await (const chunk of req) chunks.push(chunk);
+      message = JSON.parse(Buffer.concat(chunks).toString('utf8'));
+    } catch {
+      res.writeHead(400, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ jsonrpc: '2.0', id: null, error: { code: -32700, message: 'Parse error' } }));
+      return;
+    }
+
+    if (!Object.hasOwn(message, 'id')) {
+      // 通知类消息（含 notifications/initialized）无需响应体，HTTP 层直接 202。
+      res.writeHead(202);
+      res.end();
+      return;
+    }
+
+    let response;
+    try {
+      const result = await dispatch(message.method, message.params || {});
+      response = { jsonrpc: '2.0', id: message.id, result };
+      if (message.method === 'initialize') {
+        res.setHeader('MCP-Protocol-Version', result.protocolVersion || '2024-11-05');
+      }
+    } catch (error) {
+      response = {
+        jsonrpc: '2.0',
+        id: message.id,
+        error: { code: -32603, message: error.message },
+      };
+    }
+
+    writeMCPResponse(res, response, req.headers.accept || '');
+  });
+
+  await new Promise((resolvePromise, rejectPromise) => {
+    server.once('error', rejectPromise);
+    server.listen(port, host, () => resolvePromise());
+  });
+
+  const address = server.address();
+  process.stdout.write(format('huaweicloud-devkit MCP server (remote) listening on %s:%s\n', host, address.port));
+
+  return {
+    server,
+    port: address.port,
+    close: () => new Promise((resolvePromise) => server.close(resolvePromise)),
+  };
+}
+
+function writeMCPResponse(res, response, accept) {
+  const json = JSON.stringify(response);
+  if (accept.includes('application/json')) {
+    res.writeHead(200, { 'Content-Type': 'application/json' });
+    res.end(json);
+    return;
+  }
+  // 客户端只接受 SSE 时的兜底：单帧 event 后关闭流。
+  res.writeHead(200, { 'Content-Type': 'text/event-stream', 'Cache-Control': 'no-cache' });
+  res.write(`event: message\ndata: ${json}\n\n`);
+  res.end();
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === resolve(process.argv[1])) {
+  const portIdx = process.argv.indexOf('--port');
+  const port = portIdx > -1 ? Number(process.argv[portIdx + 1]) : DEFAULT_PORT;
+  const hostIdx = process.argv.indexOf('--host');
+  const host = hostIdx > -1 && process.argv[hostIdx + 1] ? process.argv[hostIdx + 1] : DEFAULT_HOST;
+  startRemoteServer({ port, host }).catch((error) => {
+    process.stderr.write(`Failed to start MCP remote server: ${error.message}\n`);
+    // eslint-disable-next-line n/no-process-exit -- fatal startup error in standalone CLI mode
+    process.exit(1);
+  });
+}

--- a/plugins/huaweicloud-core/src/mcp-server.mjs
+++ b/plugins/huaweicloud-core/src/mcp-server.mjs
@@ -1,14 +1,21 @@
 #!/usr/bin/env node
 import { stdin, stdout } from 'node:process';
-import { rmSync, existsSync, readFileSync } from 'node:fs';
-import { resolve, dirname, join } from 'node:path';
+import { rmSync, existsSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
 import { platform } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
-import { TOOL_DEFINITIONS, callTool } from './tools.mjs';
-import { getCachedUpdateInfo, readInstalledVersion, peekCachedUpdateInfo, applyUpdateHint } from './update-check.mjs';
-import { initTelemetry } from './telemetry/telemetry.mjs';
+import { dispatch } from './mcp-protocol.mjs';
+import { DEFAULT_PORT, DEFAULT_HOST } from './mcp-server-remote.mjs';
+import { getCachedUpdateInfo, readInstalledVersion } from './update-check.mjs';
 import { detectAgent } from './telemetry/agent-detect.mjs';
+
+const transportIdx = process.argv.indexOf('--transport');
+const transport = transportIdx > -1 && process.argv[transportIdx + 1] ? process.argv[transportIdx + 1] : 'stdio';
+const portIdx = process.argv.indexOf('--port');
+const remotePort = portIdx > -1 ? Number(process.argv[portIdx + 1]) : DEFAULT_PORT;
+const hostIdx = process.argv.indexOf('--host');
+const remoteHost = hostIdx > -1 && process.argv[hostIdx + 1] ? process.argv[hostIdx + 1] : DEFAULT_HOST;
 
 const projectDirIdx = process.argv.indexOf('--codearts-project-dir');
 if (projectDirIdx > -1 && process.argv[projectDirIdx + 1]) {
@@ -46,197 +53,132 @@ try {
   if (existsSync(marker)) rmSync(marker, { force: true });
 } catch {}
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const pluginRoot = resolve(__dirname, '..');
-const packageRoot = resolve(pluginRoot, '..', '..');
-let pkgVersion = '0.0.0';
-for (const base of [pluginRoot, packageRoot]) {
-  try {
-    const version = JSON.parse(readFileSync(join(base, 'package.json'), 'utf8')).version;
-    if (version) {
-      pkgVersion = version;
-      break;
+if (transport === 'remote') {
+  const { startRemoteServer } = await import('./mcp-server-remote.mjs');
+  startRemoteServer({ port: remotePort, host: remoteHost }).catch((error) => {
+    process.stderr.write(`Failed to start MCP remote server: ${error.message}\n`);
+    // eslint-disable-next-line n/no-process-exit -- fatal startup error; no active session to keep alive
+    process.exit(1);
+  });
+} else {
+  runStdioServer();
+}
+
+function runStdioServer() {
+  const updatePrewarm = () => {
+    getCachedUpdateInfo(readInstalledVersion() || '0.0.0').catch(() => {});
+  };
+
+  let buffer = Buffer.alloc(0);
+  let useContentLengthFraming = true;
+
+  // Keep the event loop alive after stdin is closed (Windows Hermes workaround).
+  // Node.js exits when no active handles remain; the stdin 'data' listener is
+  // the only handle. On Windows, Hermes may close the stdin pipe after the
+  // initial handshake, causing the process to exit silently (exit 0).
+  //
+  // For Hermes on Windows: start a keepalive timer on stdin close, and only exit
+  // when stdout also closes.
+  // For all other agents (OfficeAce, WorkBuddy, etc.): stdin close is the
+  // shutdown signal — exit cleanly so the host does not see CLOSE_TIMEOUT.
+  const { harness } = detectAgent();
+  const NEEDS_KEEPALIVE = harness === 'hermes' && platform() === 'win32';
+
+  // 版本升级检测预热：异步、非阻塞；失败静默（离线/超时不影响会话）。
+  process.nextTick(updatePrewarm);
+
+  let keepAlive = null;
+  function onStdinClose() {
+    if (keepAlive) return;
+    if (NEEDS_KEEPALIVE) {
+      keepAlive = setInterval(() => {}, 60000);
+    } else {
+      // eslint-disable-next-line n/no-process-exit -- stdin close is the shutdown signal; exit now without waiting for stdout
+      process.exit(0);
     }
-  } catch {}
-}
-
-let buffer = Buffer.alloc(0);
-let useContentLengthFraming = true;
-
-// Keep the event loop alive after stdin is closed (Windows Hermes workaround).
-// Node.js exits when no active handles remain; the stdin 'data' listener is
-// the only handle. On Windows, Hermes may close the stdin pipe after the
-// initial handshake, causing the process to exit silently (exit 0).
-//
-// For Hermes on Windows: start a keepalive timer on stdin close, and only exit
-// when stdout also closes.
-// For all other agents (OfficeAce, WorkBuddy, etc.): stdin close is the
-// shutdown signal — exit cleanly so the host does not see CLOSE_TIMEOUT.
-const { harness } = detectAgent();
-const NEEDS_KEEPALIVE = harness === 'hermes' && platform() === 'win32';
-
-// 版本升级检测预热：异步、非阻塞；失败静默（离线/超时不影响会话）。
-process.nextTick(() => {
-  getCachedUpdateInfo(readInstalledVersion() || '0.0.0').catch(() => {});
-});
-
-// 会话内首个非 check/upgrade 工具调用附加 _updateInfo，只消费一次。
-let hintConsumed = false;
-function decorateResult(name, result) {
-  if (hintConsumed) return result;
-  try {
-    const hint = peekCachedUpdateInfo();
-    if (!hint) return result;
-    const decorated = applyUpdateHint(result, name, hint);
-    if (decorated !== result) hintConsumed = true;
-    return decorated;
-  } catch {
-    return result; // 兜底装饰失败绝不影响工具调用
   }
-}
-
-let keepAlive = null;
-function onStdinClose() {
-  if (keepAlive) return;
-  if (NEEDS_KEEPALIVE) {
-    keepAlive = setInterval(() => {}, 60000);
-  } else {
-    // eslint-disable-next-line n/no-process-exit -- stdin close is the shutdown signal; exit now without waiting for stdout
-    process.exit(0);
-  }
-}
-function onStdoutClose() {
-  if (keepAlive) {
-    clearInterval(keepAlive);
-    keepAlive = null;
-  }
-  process.exitCode = 0;
-}
-stdin.on('close', onStdinClose);
-stdin.on('end', onStdinClose);
-stdout.on('close', onStdoutClose);
-
-stdin.on('data', (chunk) => {
-  buffer = Buffer.concat([buffer, chunk]);
-  readFrames();
-});
-
-function readFrames() {
-  while (true) {
-    const headerEnd = buffer.indexOf('\r\n\r\n');
-    if (headerEnd !== -1) {
-      useContentLengthFraming = true;
-      const consumed = parseContentLengthFrame(headerEnd);
-      if (!consumed) return;
-      continue;
+  function onStdoutClose() {
+    if (keepAlive) {
+      clearInterval(keepAlive);
+      keepAlive = null;
     }
-
-    const lf = buffer.indexOf('\n');
-    if (lf !== -1) {
-      useContentLengthFraming = false;
-      const line = buffer.subarray(0, lf).toString('utf8').trim();
-      buffer = buffer.subarray(lf + 1);
-      if (line) void handleMessage(JSON.parse(line));
-      continue;
-    }
-
-    return;
+    process.exitCode = 0;
   }
-}
+  stdin.on('close', onStdinClose);
+  stdin.on('end', onStdinClose);
+  stdout.on('close', onStdoutClose);
 
-function parseContentLengthFrame(headerEnd) {
-  const header = buffer.subarray(0, headerEnd).toString('utf8');
-  const match = header.match(/Content-Length:\s*(\d+)/i);
-  if (!match) {
-    buffer = Buffer.alloc(0);
+  stdin.on('data', (chunk) => {
+    buffer = Buffer.concat([buffer, chunk]);
+    readFrames();
+  });
+
+  function readFrames() {
+    while (true) {
+      const headerEnd = buffer.indexOf('\r\n\r\n');
+      if (headerEnd !== -1) {
+        useContentLengthFraming = true;
+        const consumed = parseContentLengthFrame(headerEnd);
+        if (!consumed) return;
+        continue;
+      }
+
+      const lf = buffer.indexOf('\n');
+      if (lf !== -1) {
+        useContentLengthFraming = false;
+        const line = buffer.subarray(0, lf).toString('utf8').trim();
+        buffer = buffer.subarray(lf + 1);
+        if (line) void handleMessage(JSON.parse(line));
+        continue;
+      }
+
+      return;
+    }
+  }
+
+  function parseContentLengthFrame(headerEnd) {
+    const header = buffer.subarray(0, headerEnd).toString('utf8');
+    const match = header.match(/Content-Length:\s*(\d+)/i);
+    if (!match) {
+      buffer = Buffer.alloc(0);
+      return true;
+    }
+    const length = Number(match[1]);
+    const bodyStart = headerEnd + 4;
+    const bodyEnd = bodyStart + length;
+    if (buffer.length < bodyEnd) return false;
+    const body = buffer.subarray(bodyStart, bodyEnd).toString('utf8');
+    buffer = buffer.subarray(bodyEnd);
+    void handleMessage(JSON.parse(body));
     return true;
   }
-  const length = Number(match[1]);
-  const bodyStart = headerEnd + 4;
-  const bodyEnd = bodyStart + length;
-  if (buffer.length < bodyEnd) return false;
-  const body = buffer.subarray(bodyStart, bodyEnd).toString('utf8');
-  buffer = buffer.subarray(bodyEnd);
-  void handleMessage(JSON.parse(body));
-  return true;
-}
 
-async function handleMessage(message) {
-  if (!Object.hasOwn(message, 'id')) {
-    if (message.method === 'notifications/initialized') return;
-    return;
-  }
-  try {
-    const result = await dispatch(message.method, message.params || {});
-    writeMessage({ jsonrpc: '2.0', id: message.id, result });
-  } catch (error) {
-    writeMessage({
-      jsonrpc: '2.0',
-      id: message.id,
-      error: {
-        code: -32603,
-        message: error.message,
-      },
-    });
-  }
-}
-
-async function dispatch(method, params) {
-  if (method === 'initialize') {
-    const ci = params.clientInfo || {};
-
+  async function handleMessage(message) {
+    if (!Object.hasOwn(message, 'id')) {
+      if (message.method === 'notifications/initialized') return;
+      return;
+    }
     try {
-      const { hdkitGenerateUserHash } = await import('./sandbox/hdkitservice-api.mjs');
-      await Promise.race([
-        hdkitGenerateUserHash(),
-        new Promise((_, reject) => setTimeout(() => reject(new Error('timeout')), 3000)),
-      ]);
-    } catch {}
-
-    const agent = detectAgent(ci);
-    initTelemetry({ harness: agent.harness, version: agent.version });
-    return {
-      protocolVersion: params.protocolVersion || '2024-11-05',
-      capabilities: {
-        tools: {},
-      },
-      serverInfo: {
-        name: 'huaweicloud-devkit',
-        version: pkgVersion,
-      },
-    };
-  }
-
-  if (method === 'tools/list') {
-    return { tools: TOOL_DEFINITIONS };
-  }
-
-  if (method === 'tools/call') {
-    const result = await callTool(params.name, params.arguments || {});
-    const decorated = decorateResult(params.name, result);
-    return {
-      content: [
-        {
-          type: 'text',
-          text: JSON.stringify(decorated, null, 2),
+      const result = await dispatch(message.method, message.params || {});
+      writeMessage({ jsonrpc: '2.0', id: message.id, result });
+    } catch (error) {
+      writeMessage({
+        jsonrpc: '2.0',
+        id: message.id,
+        error: {
+          code: -32603,
+          message: error.message,
         },
-      ],
-      isError: false,
-    };
+      });
+    }
   }
 
-  if (method === 'resources/list') {
-    return { resources: [] };
-  }
-
-  throw new Error(`Unsupported method: ${method}`);
-}
-
-function writeMessage(message) {
-  const json = JSON.stringify(message);
-  if (useContentLengthFraming) {
-    stdout.write(`Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`);
-  } else {
-    stdout.write(json + '\n');
+  function writeMessage(message) {
+    const json = JSON.stringify(message);
+    if (useContentLengthFraming) {
+      stdout.write(`Content-Length: ${Buffer.byteLength(json, 'utf8')}\r\n\r\n${json}`);
+    } else {
+      stdout.write(json + '\n');
+    }
   }
 }

--- a/test/remote-mcp-server.test.mjs
+++ b/test/remote-mcp-server.test.mjs
@@ -1,0 +1,180 @@
+import assert from 'node:assert/strict';
+import { spawn } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const root = fileURLToPath(new URL('..', import.meta.url));
+const srcDir = join(root, 'plugins', 'huaweicloud-core', 'src');
+const serverPath = join(srcDir, 'mcp-server.mjs');
+
+let server;
+let base;
+let startRemoteServer;
+
+test.before(async () => {
+  const mod = await import(join(srcDir, 'mcp-server-remote.mjs'));
+  startRemoteServer = mod.startRemoteServer;
+  const started = await startRemoteServer({ port: 0 });
+  server = started.server;
+  base = `http://127.0.0.1:${started.port}`;
+});
+
+test.after(async () => {
+  if (server) {
+    await new Promise((resolve) => server.close(resolve));
+  }
+});
+
+async function rpc(method, params = {}, extraHeaders = {}) {
+  const res = await fetch(`${base}/`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json, text/event-stream',
+      ...extraHeaders,
+    },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+  return { status: res.status, contentType: res.headers.get('content-type'), body: await res.json() };
+}
+
+test('remote MCP server initializes, lists tools, and plans CLI commands', async () => {
+  const initialized = await rpc('initialize', {
+    protocolVersion: '2024-11-05',
+    capabilities: {},
+    clientInfo: { name: 'test-client', version: '0.0.0' },
+  });
+  assert.equal(initialized.status, 200);
+  assert.equal(initialized.body.result.serverInfo.name, 'huaweicloud-devkit');
+  assert.equal(initialized.body.result.protocolVersion, '2024-11-05');
+  assert.deepEqual(initialized.body.result.capabilities, { tools: {} });
+
+  const listed = await rpc('tools/list');
+  const toolNames = new Set(listed.body.result.tools.map((tool) => tool.name));
+  assert.ok(toolNames.has('huaweicloud_plan_cli_command'));
+  assert.ok(toolNames.has('huaweicloud_list_operations'));
+
+  const planned = await rpc('tools/call', {
+    name: 'huaweicloud_plan_cli_command',
+    arguments: { args: ['ECS', 'NovaListServers'] },
+  });
+  assert.equal(planned.body.result.isError, false);
+  assert.match(planned.body.result.content[0].text, /NovaListServers/);
+});
+
+test('remote MCP server returns 202 for notifications/initialized', async () => {
+  const res = await fetch(`${base}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'application/json, text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', method: 'notifications/initialized' }),
+  });
+  assert.equal(res.status, 202);
+});
+
+test('remote MCP server returns 400 for invalid JSON body', async () => {
+  const res = await fetch(`${base}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: '{not-json]',
+  });
+  assert.equal(res.status, 400);
+});
+
+test('remote MCP server answers OPTIONS preflight with CORS headers', async () => {
+  const res = await fetch(`${base}/`, { method: 'OPTIONS' });
+  assert.equal(res.status, 204);
+  assert.equal(res.headers.get('access-control-allow-origin'), '*');
+  assert.match(res.headers.get('access-control-allow-headers') || '', /MCP-Protocol-Version/i);
+});
+
+test('remote MCP server rejects GET with 405', async () => {
+  const res = await fetch(`${base}/`, { method: 'GET' });
+  assert.equal(res.status, 405);
+});
+
+test('remote MCP server falls back to SSE when client only accepts text/event-stream', async () => {
+  const res = await fetch(`${base}/`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', Accept: 'text/event-stream' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 7, method: 'resources/list', params: {} }),
+  });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get('content-type') || '', /text\/event-stream/);
+  const text = await res.text();
+  assert.match(text, /event: message/);
+  assert.match(text, /"resources":/);
+});
+
+test('exports DEFAULT_PORT 9528 to avoid IACMCPServer port 9527 conflict', async () => {
+  const mod = await import(`${srcDir}/mcp-server-remote.mjs`);
+  assert.equal(mod.DEFAULT_PORT, 9528);
+});
+
+test('startRemoteServer binds DEFAULT_PORT when no port passed', async () => {
+  let started;
+  try {
+    started = await startRemoteServer({});
+    assert.equal(started.port, 9528);
+  } finally {
+    if (started) {
+      await started.close();
+    }
+  }
+});
+
+test('startRemoteServer supports binding non-loopback host via host option', async () => {
+  const started = await startRemoteServer({ port: 0, host: '0.0.0.0' });
+  try {
+    assert.equal(started.server.address().address, '0.0.0.0');
+  } finally {
+    await started.close();
+  }
+});
+
+function spawnRemote(flags) {
+  const child = spawn(process.execPath, [serverPath, '--transport', 'remote', ...flags], {
+    cwd: root,
+    stdio: ['ignore', 'pipe', 'pipe'],
+  });
+  let output = '';
+  const whenListening = new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error(`server did not report listening address:\n${output}`)), 10000);
+    child.stdout.on('data', (chunk) => {
+      output += chunk.toString();
+      const match = output.match(/listening on ([0-9.:]+):(\d+)/);
+      if (match) {
+        clearTimeout(timer);
+        resolve({ host: match[1], port: Number(match[2]) });
+      }
+    });
+    child.once('error', reject);
+  });
+  return { child, whenListening };
+}
+
+test('mcp-server.mjs --transport remote honors --host and --port flags', async () => {
+  const { child, whenListening } = spawnRemote(['--host', '0.0.0.0', '--port', '0']);
+  try {
+    const addr = await whenListening;
+    assert.equal(addr.host, '0.0.0.0');
+    const res = await fetch(`http://127.0.0.1:${addr.port}/`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'spawn-test', version: '0.0.0' },
+        },
+      }),
+    });
+    const body = await res.json();
+    assert.equal(body.result.serverInfo.name, 'huaweicloud-devkit');
+  } finally {
+    child.kill();
+  }
+});

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -581,11 +581,12 @@ test('tools.mjs registers version-update tools', () => {
   assert.match(tools, /from '\.\/update-check\.mjs'/);
 });
 
-test('mcp-server.mjs warms update cache and decorates first tool call', () => {
+test('stdio server warms update cache; shared protocol decorates first tool call', () => {
   const server = readFileSync(join(pluginRoot, 'src', 'mcp-server.mjs'), 'utf8');
   assert.match(server, /getCachedUpdateInfo\(readInstalledVersion\(\)/);
-  assert.match(server, /applyUpdateHint\(/);
-  assert.match(server, /peekCachedUpdateInfo\(\)/);
+  const protocol = readFileSync(join(pluginRoot, 'src', 'mcp-protocol.mjs'), 'utf8');
+  assert.match(protocol, /applyUpdateHint\(/);
+  assert.match(protocol, /peekCachedUpdateInfo\(\)/);
 });
 
 test('READMEs recommend @latest for updates', () => {


### PR DESCRIPTION
## 摘要

为 huaweicloud-devkit 增加 **remote（Streamable HTTP）** MCP 传输方式，与现有 stdio 并存。面向"大空间内多个 agent 沙箱共享一个常驻 MCP 服务器、agent 无需本地安装插件"的场景（对齐 IACMCPServer 部署形态）。

## 改动

- **`src/mcp-protocol.mjs`**（新增）：抽取共享 JSON-RPC 协议层（`dispatch`：initialize / tools/list / tools/call / resources/list、`_updateInfo` 装饰、版本解析），stdio 与 remote 两个传输入口复用。
- **`src/mcp-server-remote.mjs`**（新增）：零新增依赖的 Streamable HTTP server（`node:http`）
  - `POST /` JSON-RPC；`OPTIONS` CORS preflight；`GET` → 405
  - notifications（含 `notifications/initialized`）→ 202
  - 非法 JSON → 400
  - 仅 `Accept: text/event-stream` 时 SSE 单帧兜底
  - 无状态（session-less）
- **`src/mcp-server.mjs`**：支持 `--transport stdio|remote`（缺省 stdio，行为不变）、`--port`（默认 **9528**，避开 IACMCPServer 9527）、`--host`（支持非 loopback 绑定）。
- **`test/remote-mcp-server.test.mjs`**（新增，10 用例）：握手 / 工具列表 / 工具调用 / 202 / 400 / CORS / 405 / SSE fallback / 默认端口 / `--host` 绑定 / CLI 端到端。
- **`test/structure.test.mjs`**：装饰器不变量断言迁移到 `mcp-protocol.mjs`。
- **README（zh + en）**：新增"本地 remote 使用"说明：`npx huaweicloud-devkit-mcp --transport remote` 后连接 `http://localhost:9528`。

## 用法

```jsonc
// opencode.json
"mcp": {
  "huaweicloud-devkit": {
    "type": "remote",
    "url": "http://localhost:9528",
    "enabled": true
  }
}
```

## 验证

- `node --test`（仓库全部已跟踪测试 + 新增 remote 测试）：**308 通过 / 0 失败**
- `npm run lint:js` 通过；改动 README markdownlint 通过
- 不包含工作区未跟踪的 `test/risk-rule-deny-after-approval.test.mjs`（改动前已存在的失败，与本次无关）