### PR TITLE
fix: use agent-neutral wording for KooCLI config-write failure hint

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -4097,7 +4097,7 @@ async function cmdInstallHcloud() {
         if (r.status === 0) {
           console.log('  \x1b[32mPrivacy agreement accepted. KooCLI ready.\x1b[0m');
         } else {
-          console.log('  \x1b[33m无法写入配置目录。请在码道外终端运行: echo "y" | hcloud version\x1b[0m');
+          console.log('  \x1b[33m无法写入配置目录。请在普通终端运行: echo "y" | hcloud version\x1b[0m');
         }
       } else {
         console.log('  \x1b[33m请手动接受隐私协议：在终端运行 hcloud version 并按提示操作\x1b[0m');


### PR DESCRIPTION
## Problem

The Windows KooCLI install flow emits a hint that says to run in a "码道 (CodeArts)" terminal:

```js
console.log('  \x1b[33m无法写入配置目录。请在码道外终端运行: echo "y" | hcloud version\x1b[0m');
```

This branch is reached whenever `hcloud version` fails to write its config directory after the privacy agreement — but it is **not** gated by CodeArts sandbox detection (`detectCodeartsSandbox()`). So non-CodeArts users (opencode, Codex, Claude Code, etc.) see a misleading "码道" reference.

## Fix

Use neutral wording:

```js
console.log('  \x1b[33m无法写入配置目录。请在普通终端运行: echo "y" | hcloud version\x1b[0m');
```

The proper CodeArts-specific guidance (`printSandboxWarning`) remains unchanged and is still correctly gated on `detectCodeartsSandbox() === 'sandbox'`.
