### PR TITLE
chore(registry): add mcpName for MCP Registry ownership verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "huaweicloud-devkit",
+  "mcpName": "io.github.huaweicloud/huaweicloud-devkit",
   "version": "1.1.1",
   "description": "Agent toolkit that helps coding agents use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities safely and accurately.",
   "type": "module",


### PR DESCRIPTION
## Description

Add `mcpName` field to `package.json`, required by the official MCP Registry (https://registry.modelcontextprotocol.io/) for npm-package ownership verification. This is the prerequisite for publishing `huaweicloud-devkit` to the official MCP Registry, so that AI clients (Codex / Claude Code / Cursor, etc.) can discover and install it.

Only one field added, no logic changes:

```json
"mcpName": "io.github.huaweicloud/huaweicloud-devkit"
```

Docs: https://modelcontextprotocol.io/registry/quickstart

## Type of change

- [ ] feat
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] perf
- [ ] test
- [x] chore
- [ ] ci
- [ ] security

## Checklist

- [x] PR title follows `https://www.conventionalcommits.org/` (`<type>(<scope>): <subject>`)
- [ ] CI checks pass (PR Lint, CI, CodeQL)
- [x] `npm test` passes locally
- [x] `npm run validate` passes locally
- [x] `npm run lint` passes locally

### README & Documentation

> **Required for `feat`, `fix`, `refactor` PRs.** Check one:

- [ ] **Yes, README updated** — I added/changed documentation to reflect this PR
- [x] **No change needed** — this PR does not affect features, agents, or behavior visible to users
- [ ] **Docs-only** — this PR only contains documentation changes

## Notes

Follow-up steps after merge:

1. Publish a new npm version (e.g. `1.1.2`) — published versions are immutable, so a new release is required to carry this field.
2. A member of the **huaweicloud** org then runs:
   ```bash
   mcp-publisher login github
   mcp-publisher publish
   ```
3. A validated `server.json` draft (packages form, with `HW_ACCESS_KEY` / `HW_SECRET_KEY` env vars) has already passed `mcp-publisher validate`.

The `mcpName` value must exactly match the `name` in the registry server.json, which prevents third parties from impersonating this package on the registry.