### PR TITLE
docs: remove Cursor Directory section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,6 @@ Help AI coding agents use Huawei Cloud safely and accurately — a single integr
 
 Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes, OpenClaw, and AtomCode.
 
-## Cursor Directory Plugin
-
-This repository also acts as an [Open Plugins](https://open-plugins.com) package for the [Cursor Directory](https://cursor.directory) marketplace. The root-level `plugin.json`, `mcp.json`, `skills/`, and `rules/` files are used **only** for Cursor Directory repository-scan discovery and are **not** shipped in the npm tarball (the `package.json` `files` whitelist excludes them). The npm package's manifests live under `plugins/huaweicloud-core/`.
-
-The `mcp.json` MCP server launches via `npx -y -p huaweicloud-devkit huaweicloud-devkit-mcp`, which tracks the npm `latest` tag. During pre-release this may differ from the manifest `version`; it can be pinned after a stable release.
-
 ## Prerequisites
 
 - Node.js >= 22
@@ -277,6 +271,12 @@ ECS, OBS, VPC, IAM, RDS, GaussDB, FunctionGraph, APIG, CCE, SMN/DMS, ModelArts, 
 - [DeepSeek Harness Integration](docs/dsh-integration.md)
 - [Changelog](docs/CHANGELOG.md)
 - [KooCLI official docs](https://support.huaweicloud.com/qs-hcli/hcli_02_003.html)
+
+## Cursor Directory Plugin
+
+This repository also acts as an [Open Plugins](https://open-plugins.com) package for the [Cursor Directory](https://cursor.directory) marketplace. The root-level `plugin.json`, `mcp.json`, `skills/`, and `rules/` files are used **only** for Cursor Directory repository-scan discovery and are **not** shipped in the npm tarball (the `package.json` `files` whitelist excludes them). The npm package's manifests live under `plugins/huaweicloud-core/`.
+
+The `mcp.json` MCP server launches via `npx -y -p huaweicloud-devkit huaweicloud-devkit-mcp`, which tracks the npm `latest` tag. During pre-release this may differ from the manifest `version`; it can be pinned after a stable release.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Help AI coding agents use Huawei Cloud safely and accurately — a single integration that gives agents cloud knowledge, CLI tooling, and safety guardrails.
 
-Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes, OpenClaw, and AtomCode.
+Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes, OpenClaw, AtomCode, and Cursor (via the [Cursor Directory](https://cursor.directory) marketplace).
 
 ## Prerequisites
 
@@ -201,6 +201,12 @@ npx --yes huaweicloud-devkit update --target atomcode
 npx --yes huaweicloud-devkit uninstall --target atomcode
 ```
 
+### Cursor
+
+Cursor is installed through the [Cursor Directory](https://cursor.directory) marketplace rather than an installer target. Submit this repository URL at [cursor.directory/plugins/new](https://cursor.directory/plugins/new) to auto-install the bundled skill, MCP server, and rules, or add the MCP server manually as described in [Other Agents](#other-agents).
+
+> Note: there is no `npx huaweicloud-devkit install --target cursor`. The root-level `plugin.json`, `mcp.json`, `skills/`, and `rules/` files are used **only** for Cursor Directory repository-scan discovery and are **not** shipped in the npm tarball.
+
 ### Other Agents
 
 Any agent that supports MCP can use the standard config:
@@ -271,12 +277,6 @@ ECS, OBS, VPC, IAM, RDS, GaussDB, FunctionGraph, APIG, CCE, SMN/DMS, ModelArts, 
 - [DeepSeek Harness Integration](docs/dsh-integration.md)
 - [Changelog](docs/CHANGELOG.md)
 - [KooCLI official docs](https://support.huaweicloud.com/qs-hcli/hcli_02_003.html)
-
-## Cursor Directory Plugin
-
-This repository also acts as an [Open Plugins](https://open-plugins.com) package for the [Cursor Directory](https://cursor.directory) marketplace. The root-level `plugin.json`, `mcp.json`, `skills/`, and `rules/` files are used **only** for Cursor Directory repository-scan discovery and are **not** shipped in the npm tarball (the `package.json` `files` whitelist excludes them). The npm package's manifests live under `plugins/huaweicloud-core/`.
-
-The `mcp.json` MCP server launches via `npx -y -p huaweicloud-devkit huaweicloud-devkit-mcp`, which tracks the npm `latest` tag. During pre-release this may differ from the manifest `version`; it can be pinned after a stable release.
 
 ## Contributors
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 
 Help AI coding agents use Huawei Cloud safely and accurately — a single integration that gives agents cloud knowledge, CLI tooling, and safety guardrails.
 
-Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes, OpenClaw, AtomCode, and Cursor (via the [Cursor Directory](https://cursor.directory) marketplace).
+Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), OfficeAce, Hermes, OpenClaw, and AtomCode.
 
 ## Prerequisites
 
@@ -203,9 +203,9 @@ npx --yes huaweicloud-devkit uninstall --target atomcode
 
 ### Cursor
 
-Cursor is installed through the [Cursor Directory](https://cursor.directory) marketplace rather than an installer target. Submit this repository URL at [cursor.directory/plugins/new](https://cursor.directory/plugins/new) to auto-install the bundled skill, MCP server, and rules, or add the MCP server manually as described in [Other Agents](#other-agents).
+Cursor is not an installer target. Connect it with the standard MCP config (see [Other Agents](#other-agents)).
 
-> Note: there is no `npx huaweicloud-devkit install --target cursor`. The root-level `plugin.json`, `mcp.json`, `skills/`, and `rules/` files are used **only** for Cursor Directory repository-scan discovery and are **not** shipped in the npm tarball.
+The repository is packaged to the [Open Plugins](https://open-plugins.com) standard for the [Cursor Directory](https://cursor.directory) marketplace and can be listed there by submitting this repository URL. The root-level `plugin.json`, `mcp.json`, `skills/`, and `rules/` files serve Cursor Directory discovery only and are **not** shipped in the npm tarball.
 
 ### Other Agents
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 
 帮助 AI 编码助手安全、准确地使用华为云——一站式集成云知识、CLI 工具和安全护栏。
 
-支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes、OpenClaw、AtomCode。
+支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes、OpenClaw、AtomCode，以及 Cursor（通过 [Cursor Directory](https://cursor.directory) 市场）。
 
 ## 前置条件
 
@@ -201,6 +201,12 @@ npx --yes huaweicloud-devkit update --target atomcode
 npx --yes huaweicloud-devkit uninstall --target atomcode
 ```
 
+### Cursor
+
+Cursor 通过 [Cursor Directory](https://cursor.directory) 市场分发，而非安装器 target。在 [cursor.directory/plugins/new](https://cursor.directory/plugins/new) 提交本仓库 URL 即可自动安装内置的 Skill、MCP 服务和规则；也可以手动添加 MCP 服务（见「其他 Agent」一节）。
+
+> 注意：不存在 `npx huaweicloud-devkit install --target cursor`。根目录的 `plugin.json`、`mcp.json`、`skills/`、`rules/` 仅用于 Cursor Directory 的仓库扫描发现，**不会**打入 npm 包。
+
 ### 其他 Agent
 
 任何支持 MCP 协议的 Agent，直接使用标准 MCP 配置：
@@ -269,12 +275,6 @@ ECS、OBS、VPC、IAM、RDS、GaussDB、FunctionGraph、APIG、CCE、SMN/DMS、M
 - [DeepSeek Harness 集成](docs/dsh-integration.md)
 - [变更记录](docs/CHANGELOG.md)
 - [KooCLI 官方文档](https://support.huaweicloud.com/qs-hcli/hcli_02_003.html)
-
-## Cursor Directory 插件
-
-本仓库同时作为 [Open Plugins](https://open-plugins.com) 包挂载到 [Cursor Directory](https://cursor.directory) 市场。根目录的 `plugin.json`、`mcp.json`、`skills/`、`rules/` 仅用于 Cursor Directory 的仓库扫描发现，**不会**打入 npm 包（`package.json` 的 `files` 白名单未包含它们）。npm 包的 manifests 位于 `plugins/huaweicloud-core/`。
-
-`mcp.json` 中的 MCP 服务通过 `npx -y -p huaweicloud-devkit huaweicloud-devkit-mcp` 启动，跟踪的是 npm 的 `latest` tag。预发布阶段可能与 manifest 中的 `version` 不一致，稳定发版后可以固定版本。
 
 ## 贡献者
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -9,7 +9,7 @@
 
 帮助 AI 编码助手安全、准确地使用华为云——一站式集成云知识、CLI 工具和安全护栏。
 
-支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes、OpenClaw、AtomCode，以及 Cursor（通过 [Cursor Directory](https://cursor.directory) 市场）。
+支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes、OpenClaw、AtomCode。
 
 ## 前置条件
 
@@ -203,9 +203,9 @@ npx --yes huaweicloud-devkit uninstall --target atomcode
 
 ### Cursor
 
-Cursor 通过 [Cursor Directory](https://cursor.directory) 市场分发，而非安装器 target。在 [cursor.directory/plugins/new](https://cursor.directory/plugins/new) 提交本仓库 URL 即可自动安装内置的 Skill、MCP 服务和规则；也可以手动添加 MCP 服务（见「其他 Agent」一节）。
+Cursor 不是安装器 target，使用标准 MCP 配置接入（见「其他 Agent」一节）。
 
-> 注意：不存在 `npx huaweicloud-devkit install --target cursor`。根目录的 `plugin.json`、`mcp.json`、`skills/`、`rules/` 仅用于 Cursor Directory 的仓库扫描发现，**不会**打入 npm 包。
+本仓库已按 [Open Plugins](https://open-plugins.com) 标准打包，可提交仓库 URL 上架到 [Cursor Directory](https://cursor.directory) 市场。根目录的 `plugin.json`、`mcp.json`、`skills/`、`rules/` 仅用于 Cursor Directory 发现，**不会**打入 npm 包。
 
 ### 其他 Agent
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -11,12 +11,6 @@
 
 支持 OpenCode、Codex、码道（CodeArts Agent）、WorkBuddy、DeepSeek Harness（DSH）、OfficeAce、Hermes、OpenClaw、AtomCode。
 
-## Cursor Directory 插件
-
-本仓库同时作为 [Open Plugins](https://open-plugins.com) 包挂载到 [Cursor Directory](https://cursor.directory) 市场。根目录的 `plugin.json`、`mcp.json`、`skills/`、`rules/` 仅用于 Cursor Directory 的仓库扫描发现，**不会**打入 npm 包（`package.json` 的 `files` 白名单未包含它们）。npm 包的 manifests 位于 `plugins/huaweicloud-core/`。
-
-`mcp.json` 中的 MCP 服务通过 `npx -y -p huaweicloud-devkit huaweicloud-devkit-mcp` 启动，跟踪的是 npm 的 `latest` tag。预发布阶段可能与 manifest 中的 `version` 不一致，稳定发版后可以固定版本。
-
 ## 前置条件
 
 - Node.js >= 22
@@ -275,6 +269,12 @@ ECS、OBS、VPC、IAM、RDS、GaussDB、FunctionGraph、APIG、CCE、SMN/DMS、M
 - [DeepSeek Harness 集成](docs/dsh-integration.md)
 - [变更记录](docs/CHANGELOG.md)
 - [KooCLI 官方文档](https://support.huaweicloud.com/qs-hcli/hcli_02_003.html)
+
+## Cursor Directory 插件
+
+本仓库同时作为 [Open Plugins](https://open-plugins.com) 包挂载到 [Cursor Directory](https://cursor.directory) 市场。根目录的 `plugin.json`、`mcp.json`、`skills/`、`rules/` 仅用于 Cursor Directory 的仓库扫描发现，**不会**打入 npm 包（`package.json` 的 `files` 白名单未包含它们）。npm 包的 manifests 位于 `plugins/huaweicloud-core/`。
+
+`mcp.json` 中的 MCP 服务通过 `npx -y -p huaweicloud-devkit huaweicloud-devkit-mcp` 启动，跟踪的是 npm 的 `latest` tag。预发布阶段可能与 manifest 中的 `version` 不一致，稳定发版后可以固定版本。
 
 ## 贡献者
 


### PR DESCRIPTION
Remove the "Cursor Directory Plugin" section from `README.md` and `README.zh-CN.md`.

Cursor is not an adapted target yet (no `--target cursor`, and the plugin is not listed on the cursor.directory marketplace), so it should not appear in the README alongside the other agents.