### PR TITLE
docs: remove Cursor section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,12 +201,6 @@ npx --yes huaweicloud-devkit update --target atomcode
 npx --yes huaweicloud-devkit uninstall --target atomcode
 ```
 
-### Cursor
-
-Cursor is not an installer target. Connect it with the standard MCP config (see [Other Agents](#other-agents)).
-
-The repository is packaged to the [Open Plugins](https://open-plugins.com) standard for the [Cursor Directory](https://cursor.directory) marketplace and can be listed there by submitting this repository URL. The root-level `plugin.json`, `mcp.json`, `skills/`, and `rules/` files serve Cursor Directory discovery only and are **not** shipped in the npm tarball.
-
 ### Other Agents
 
 Any agent that supports MCP can use the standard config:

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -201,12 +201,6 @@ npx --yes huaweicloud-devkit update --target atomcode
 npx --yes huaweicloud-devkit uninstall --target atomcode
 ```
 
-### Cursor
-
-Cursor 不是安装器 target，使用标准 MCP 配置接入（见「其他 Agent」一节）。
-
-本仓库已按 [Open Plugins](https://open-plugins.com) 标准打包，可提交仓库 URL 上架到 [Cursor Directory](https://cursor.directory) 市场。根目录的 `plugin.json`、`mcp.json`、`skills/`、`rules/` 仅用于 Cursor Directory 发现，**不会**打入 npm 包。
-
 ### 其他 Agent
 
 任何支持 MCP 协议的 Agent，直接使用标准 MCP 配置：


### PR DESCRIPTION
Remove the `### Cursor` section from `README.md` and `README.zh-CN.md`.

Cursor is not an adapted install target yet (no `--target cursor`), so it should not appear in the README alongside the other agents.