### PR TITLE
fix(release): make create-release-pr path helpers idempotent (fix ENOENT)

### DIFF
--- a/scripts/create-release-pr.mjs
+++ b/scripts/create-release-pr.mjs
@@ -1,6 +1,6 @@
 import { execSync } from 'node:child_process';
 import { readFileSync, writeFileSync, mkdtempSync, rmSync } from 'node:fs';
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 import { tmpdir } from 'node:os';
 import { fileURLToPath } from 'node:url';
 
@@ -12,12 +12,14 @@ function run(cmd, opts) {
   return execSync(cmd, { cwd: root, stdio: 'inherit', ...opts });
 }
 
+// resolve() 对已是绝对路径的参数幂等（join() 会重复拼接），
+// 保证 readJson/writeJson 既支持相对路径也接受调用方拼好的绝对路径。
 function readJson(p) {
-  return JSON.parse(readFileSync(join(root, p), 'utf8'));
+  return JSON.parse(readFileSync(resolve(root, p), 'utf8'));
 }
 
 function writeJson(p, obj) {
-  writeFileSync(join(root, p), `${JSON.stringify(obj, null, 2)}\n`, 'utf8');
+  writeFileSync(resolve(root, p), `${JSON.stringify(obj, null, 2)}\n`, 'utf8');
 }
 
 const manifest = readJson('.release-please-manifest.json');


### PR DESCRIPTION
## 问题

手动触发 Release workflow（`release.yml`）在 dev 上失败：

```
Error: ENOENT: no such file or directory, open
  '/home/runner/work/huaweicloud-devkit/huaweicloud-devkit/home/runner/.../plugin.json'
    at readJson (scripts/create-release-pr.mjs:16)
```

路径中 `huaweicloud-devkit` 出现两次。

## 根因

`scripts/create-release-pr.mjs` 的 `readJson`/`writeJson` 内部使用 `path.join(root, p)` 拼接路径，假定入参是**相对路径**。但 #528 新增的 `plugin.json` 版本同步块传入的是已拼好的**绝对路径**（`join(root, 'plugin.json')`）。由于 `path.join()` 遇到绝对路径参数不会重置，导致 root 前缀被拼接两次 → 找不到文件。

该代码路径仅在**手动 `workflow_dispatch` 或 push main** 时执行（push dev 时 `bump` 步骤被跳过），#528 合并后从未走到，因此一直潜伏，直到这次手动触发暴露。

## 修复

`readJson`/`writeJson` 改用 `path.resolve(root, p)`：对绝对路径幂等（直接使用），对相对路径仍按 root 拼接，两种调用方式均正确，从根上消灭这类错误。

```diff
-import { join } from 'node:path';
+import { join, resolve } from 'node:path';
 function readJson(p) {
-  return JSON.parse(readFileSync(join(root, p), 'utf8'));
+  return JSON.parse(readFileSync(resolve(root, p), 'utf8'));
 }
 function writeJson(p, obj) {
-  writeFileSync(join(root, p), `${JSON.stringify(obj, null, 2)}\n`, 'utf8');
+  writeFileSync(resolve(root, p), `${JSON.stringify(obj, null, 2)}\n`, 'utf8');
 }
```

## 验证

- 本地模拟：`readJson('plugin.json')`（相对）与 `readJson(join(root,'plugin.json'))`（绝对，原失败场景）均能读到同一文件，结果一致
- `eslint` + `prettier --check` 通过