### PR TITLE
chore(registry): add mcpName for MCP Registry ownership verification

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,6 @@
 {
   "name": "huaweicloud-devkit",
+  "mcpName": "io.github.huaweicloud/huaweicloud-devkit",
   "version": "1.1.2-next.1",
   "description": "Agent toolkit that helps coding agents use Huawei Cloud Skills, KooCLI, APIs, SDKs, and future MCP capabilities safely and accurately.",
   "type": "module",


### PR DESCRIPTION
Add `mcpName` field to `package.json`, required by the official MCP Registry (<https://registry.modelcontextprotocol.io/>) for npm-package ownership verification. This is the prerequisite for publishing `huaweicloud-devkit` to the official MCP Registry, so that AI clients (Codex / Claude Code / Cursor, etc.) can discover and install it.
