### PR TITLE
Fix Codex install, KooCLI auth diagnostics, and safety hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,13 +57,35 @@ npx --yes huaweicloud-devkit install --target codex
 **Restart the Codex session** after installation.
 
 ```bash
+codex plugin list  # verify huaweicloud-devkit@huaweicloud-devkit is installed and enabled
 npx --yes huaweicloud-devkit doctor --target codex
 npx --yes huaweicloud-devkit status --target codex
 npx --yes huaweicloud-devkit update --target codex
 npx --yes huaweicloud-devkit uninstall --target codex
 ```
 
+Then mention `@huaweicloud-devkit` in Codex or describe your Huawei Cloud task directly.
+
 > **Requires Codex CLI** — the `codex` command must be in PATH. If Codex is installed via WindowsApps (Microsoft Store), use `--target codex-desktop` instead. Run `codex --version` to verify CLI availability.
+
+### Codex Desktop
+
+Use this target when the Codex CLI is unavailable or when Codex is installed through WindowsApps on Windows.
+
+```bash
+npx --yes huaweicloud-devkit install --target codex-desktop
+```
+
+**Restart the Codex Desktop session** after installation.
+
+```bash
+npx --yes huaweicloud-devkit doctor --target codex-desktop
+npx --yes huaweicloud-devkit status --target codex-desktop
+npx --yes huaweicloud-devkit update --target codex-desktop
+npx --yes huaweicloud-devkit uninstall --target codex-desktop
+```
+
+Then mention `@huaweicloud-devkit` in a new Codex Desktop task or describe your Huawei Cloud task directly.
 
 ### CodeArts Agent
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -57,13 +57,35 @@ npx --yes huaweicloud-devkit install --target codex
 安装后**重启 Codex 会话**。
 
 ```bash
+codex plugin list  # 验证 huaweicloud-devkit@huaweicloud-devkit 已安装并启用
 npx --yes huaweicloud-devkit doctor --target codex
 npx --yes huaweicloud-devkit status --target codex
 npx --yes huaweicloud-devkit update --target codex
 npx --yes huaweicloud-devkit uninstall --target codex
 ```
 
+随后在 Codex 中提及 `@huaweicloud-devkit`，或直接描述华为云任务。
+
 > **需要 Codex CLI** — `codex` 命令必须在 PATH 中。若 Codex 通过 WindowsApps（Microsoft Store）安装，请使用 `--target codex-desktop` 替代。运行 `codex --version` 验证 CLI 可用性。
+
+### Codex Desktop
+
+当 Codex CLI 不可用，或 Windows 上通过 WindowsApps 安装 Codex 时，使用此目标。
+
+```bash
+npx --yes huaweicloud-devkit install --target codex-desktop
+```
+
+安装后**重启 Codex Desktop 会话**。
+
+```bash
+npx --yes huaweicloud-devkit doctor --target codex-desktop
+npx --yes huaweicloud-devkit status --target codex-desktop
+npx --yes huaweicloud-devkit update --target codex-desktop
+npx --yes huaweicloud-devkit uninstall --target codex-desktop
+```
+
+随后在新的 Codex Desktop 任务中提及 `@huaweicloud-devkit`，或直接描述华为云任务。
 
 ### CodeArts Agent（码道）
 

--- a/docs/hook-rule-model.md
+++ b/docs/hook-rule-model.md
@@ -7,7 +7,7 @@ Huawei Cloud DevKit 安全模型由三层组成：**技能教学 → Hook 拦截
 ```
 Agent 生成命令/产物/部署计划
         │
-        ├── PreToolUse Hook (Python)     ← 实时拦截 Bash/hcloud 命令
+        ├── PreToolUse Hook (Node/Codex, Python/Hermes) ← 实时拦截 Bash/hcloud 命令
         │
         ├── huaweicloud_hook_check_*  ← MCP 工具，主动检查
         │   ├── command   → 检查计划执行的命令
@@ -29,18 +29,18 @@ Hook 系统强制以下隐私边界，禁止以下数据进入 agent 上下文�
 | **AK/SK 输出**       | `hcloud configure show`、`hcloud configure get`        | `policy.json` → `blockedConfigureSubcommands` |
 | **未经审批的写操作** | `Create*`、`Delete*`、`Bind*` 等 hcloud 命令           | `policy.json` → `writeOperationPrefixes`      |
 
-> **原则**：凭证、Token、密钥等敏感数据**不允许**以任何形式进入 agent 上下文。Agent 只能通过红act 后的工具输出获取必要信息。
+> **原则**：凭证、Token、密钥等敏感数据**不允许**以任何形式进入 agent 上下文。Agent 只能通过脱敏后的工具输出获取必要信息。
 
 ## 三层 Hook 机制
 
 ### 第 1 层：PreToolUse 实时拦截
 
-`hooks/huaweicloud-safety.py` 在每次 `Bash` 工具调用前执行，使用正则匹配拦截：
+Codex 原生插件通过 `hooks/huaweicloud-safety.mjs` 执行 PreToolUse 拦截，避免 Windows/Codex 环境依赖 `python3`。`hooks/huaweicloud-safety.py` 保留给 Hermes/Python hook 场景和既有兼容路径。Hook 使用共享策略拦截：
 
 - **凭证文件**：匹配 `.hcloud`、`.huaweicloud`、`hcloud/config` 等路径模式
 - **环境变量**：匹配 `env | HUAWEICLOUD` 等组合
 - **Secret 读取**：匹配 `ShowSecretVersion`、`secret_string` 等
-- **风险规则**：加载 `safety/rules/cloud-risk-rules.json`，对命令文本进行规则匹配
+- **风险规则**：加载 `safety/rules/cloud-risk-rules.json`，对 `hcloud` 命令和通用 shell 命令文本进行规则匹配
 
 拦截时返回 `permissionDecision: "deny"`，并附带 `permissionDecisionReason`。
 
@@ -89,7 +89,8 @@ Agent 在**执行前**应主动调用以下 MCP 工具进行风险检查：
 `src/risk-rule-engine.mjs` 实现了规则匹配引擎，被多个组件复用：
 
 - **MCP 工具**：`huaweicloud_hook_check_*` 调用 `evaluateCommandRisk` / `evaluateArtifacts` / `evaluateDeployPlan`
-- **Python Hook**：`huaweicloud-safety.py` 独立加载 `cloud-risk-rules.json` 进行匹配
+- **Node Hook**：`huaweicloud-safety.mjs` 通过 `src/safety-policy.mjs` 复用 `src/risk-rule-engine.mjs`，供 Codex 原生插件使用
+- **Python Hook**：`huaweicloud-safety.py` 独立加载 `cloud-risk-rules.json`，供 Hermes/Python hook 场景使用
 - **安全策略检查**：`src/safety-policy.mjs` 读取 `policy.json` 进行凭证/写操作分类
 
 三者共享同一套规则定义，确保策略一致性。

--- a/docs/safety-model.md
+++ b/docs/safety-model.md
@@ -14,7 +14,8 @@ The toolkit assumes coding agents can accidentally expose secrets or perform exp
 
 - `plugins/huaweicloud-core/skills/huaweicloud-safety/SKILL.md` teaches agents when to classify risk.
 - `huaweicloud_hook_check_command`, `huaweicloud_hook_check_artifacts`, and `huaweicloud_hook_check_deploy_plan` let MCP-capable agents proactively inspect planned work.
-- `plugins/huaweicloud-core/hooks/huaweicloud-safety.py` blocks command-stage deny rules on hook-capable agents.
+- `plugins/huaweicloud-core/hooks/huaweicloud-safety.mjs` blocks command-stage deny rules for Codex native hooks without requiring Python.
+- `plugins/huaweicloud-core/hooks/huaweicloud-safety.py` remains available for Hermes/Python hook compatibility.
 - `plugins/huaweicloud-core/src/safety-policy.mjs` handles Codex/OpenCode MCP paths and merges existing command safety with public cloud risk rules.
 - `plugins/huaweicloud-core/safety/policy.json` stores hard safety vocabulary.
 - `plugins/huaweicloud-core/safety/rules/cloud-risk-rules.json` stores generalized cloud risk rules.

--- a/plugins/huaweicloud-core/hooks/hooks.json
+++ b/plugins/huaweicloud-core/hooks/hooks.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/huaweicloud-safety.py\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/huaweicloud-safety.mjs\"",
             "timeout": 5
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "python3 \"${CLAUDE_PLUGIN_ROOT}/hooks/huaweicloud-safety.py\"",
+            "command": "node \"${CLAUDE_PLUGIN_ROOT}/hooks/huaweicloud-safety.mjs\"",
             "timeout": 5
           }
         ]

--- a/plugins/huaweicloud-core/hooks/huaweicloud-safety.mjs
+++ b/plugins/huaweicloud-core/hooks/huaweicloud-safety.mjs
@@ -1,0 +1,56 @@
+import { readFileSync } from 'node:fs';
+
+import { classifyTextCommand } from '../src/safety-policy.mjs';
+
+const DENY_PREFIX = 'Huawei Cloud safety hook blocked this action: ';
+
+function commandText(toolInput) {
+  if (typeof toolInput === 'string') return toolInput;
+  if (toolInput && typeof toolInput === 'object') {
+    const values = [];
+    for (const key of ['command', 'cmd', 'script', 'args', 'arguments']) {
+      const value = toolInput[key];
+      if (Array.isArray(value)) values.push(value.map(String).join(' '));
+      else if (value !== undefined && value !== null) values.push(String(value));
+    }
+    if (values.length > 0) return values.join('\n');
+    return JSON.stringify(toolInput);
+  }
+  return JSON.stringify(toolInput);
+}
+
+function deny(reason) {
+  process.stdout.write(
+    JSON.stringify({
+      hookSpecificOutput: {
+        hookEventName: 'PreToolUse',
+        permissionDecision: 'deny',
+        permissionDecisionReason: DENY_PREFIX + reason,
+      },
+    }) + '\n',
+  );
+}
+
+function readStdin() {
+  try {
+    return readFileSync(0, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function main() {
+  const input = readStdin();
+  let data;
+  try {
+    data = JSON.parse(input);
+  } catch {
+    return;
+  }
+
+  const text = commandText(data.tool_input ?? {});
+  const result = classifyTextCommand(text);
+  if (result.decision === 'deny') deny(result.reason);
+}
+
+main();

--- a/plugins/huaweicloud-core/skills/huaweicloud-safety/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-safety/SKILL.md
@@ -27,7 +27,7 @@ Use this skill before any Huawei Cloud action that may expose secrets, change re
 
 ## Enforcement Layers
 
-- Hooks: `hooks/huaweicloud-safety.py` can block risky tool calls on platforms that support plugin hooks.
+- Hooks: `hooks/huaweicloud-safety.mjs` blocks risky Codex native hook calls without requiring Python; `hooks/huaweicloud-safety.py` remains for Hermes/Python hook compatibility.
 - MCP wrapper: the Node MCP server applies the same safety policy for Codex/OpenCode paths that do not enforce hooks.
 - Skills: this document teaches agents the rule before they act.
 

--- a/plugins/huaweicloud-core/src/auth/credentials.mjs
+++ b/plugins/huaweicloud-core/src/auth/credentials.mjs
@@ -272,10 +272,14 @@ export function readLastSync() {
   }
 }
 
-export function writeLastSync() {
+export function writeLastSync(metadata = {}) {
   const path = lastSyncPath();
   mkdirSync(dirname(path), { recursive: true });
-  const payload = { ts: Date.now() };
+  const payload = {
+    ts: Date.now(),
+    ...(metadata.kooCliProfile ? { kooCliProfile: String(metadata.kooCliProfile) } : {}),
+    ...(metadata.s1Fingerprint ? { s1Fingerprint: String(metadata.s1Fingerprint) } : {}),
+  };
   writeFileSync(path, JSON.stringify(payload), { encoding: 'utf8', mode: 0o600 });
   ensurePrivateMode(path);
 }

--- a/plugins/huaweicloud-core/src/auth/reconcile.mjs
+++ b/plugins/huaweicloud-core/src/auth/reconcile.mjs
@@ -11,6 +11,7 @@ import {
   readLastSync,
   resolveCredentialsWithRuntime,
 } from './credentials.mjs';
+import { resolveHcloudCommand } from '../hcloud-probe.mjs';
 import { redactSecrets } from '../safety-policy.mjs';
 
 export { hasRuntimeCredentials };
@@ -47,6 +48,7 @@ export function readKooCliProfiles() {
     return {
       current,
       mtimeMs,
+      configPath,
       profiles: profiles.map((p) => ({
         name: String(p.name || ''),
         fingerprint: fingerprint(p.accessKeyId, p.secretAccessKey),
@@ -70,15 +72,32 @@ export function currentFingerprintFromHcloud(res) {
   return cur ? cur.fingerprint : null;
 }
 
+function currentProfileFromHcloud(res) {
+  if (res.error) return null;
+  return res.profiles.find((p) => p.name === res.current) || null;
+}
+
+function s2CurrentMatchesLastDevkitSync(kooCli, s1, s1Fingerprint) {
+  const current = currentProfileFromHcloud(kooCli);
+  const lastSync = readLastSync();
+  if (!current || !lastSync?.ts || !lastSync.kooCliProfile || !lastSync.s1Fingerprint) return false;
+  if (!s1?.ak || current.accessKeyId !== s1.ak) return false;
+  if (lastSync.kooCliProfile !== kooCli.current) return false;
+  if (lastSync.s1Fingerprint !== s1Fingerprint) return false;
+  return Number(kooCli.mtimeMs || 0) <= Number(lastSync.ts) + 1000;
+}
+
 export function scanState() {
   const s1 = readGlobalCredentials() || {};
   const envAk = process.env.HW_ACCESS_KEY || '';
   const envSk = process.env.HW_SECRET_KEY || '';
   const kooCli = readKooCliProfiles();
-  const currentFp = currentFingerprintFromHcloud(kooCli);
   const inconsistencies = [];
 
   const s1Fingerprint = fingerprint(s1.ak, s1.sk);
+  const currentFp = currentFingerprintFromHcloud(kooCli);
+  const s2SyncedByDevkit = s1Fingerprint ? s2CurrentMatchesLastDevkitSync(kooCli, s1, s1Fingerprint) : false;
+  const effectiveCurrentFp = s2SyncedByDevkit ? s1Fingerprint : currentFp;
   const envFingerprint = fingerprint(envAk, envSk);
   const s3 = existsSync(obsConfigPath()) ? parseS3ObsConfig(obsConfigPath()) : null;
   const s3Fingerprint = s3 ? fingerprint(s3.ak, s3.sk) : null;
@@ -93,12 +112,12 @@ export function scanState() {
     // nothing resolvable → runtime store inactive
   }
 
-  if (s1Fingerprint && currentFp && s1Fingerprint !== currentFp) {
+  if (s1Fingerprint && currentFp && s1Fingerprint !== effectiveCurrentFp) {
     inconsistencies.push({
       store: 'S2-current',
       source: 'KooCLI current profile',
       fingerprint: currentFp,
-      manualModified: isManualModified(join(baseHome(), '.hcloud', 'config.json')),
+      manualModified: isManualModified(kooCli.configPath || join(baseHome(), '.hcloud', 'config.json')),
     });
   }
   if (s1Fingerprint && s3Fingerprint && s1Fingerprint !== s3Fingerprint) {
@@ -114,7 +133,7 @@ export function scanState() {
     stores: {
       s1Fingerprint,
       envFingerprint,
-      currentFingerprint: currentFp,
+      currentFingerprint: effectiveCurrentFp,
       s3Fingerprint,
       runtimeFingerprint,
     },
@@ -153,7 +172,7 @@ export function exportStateForStatus(_jailed) {
 }
 
 export function runHcloudConfigure(profile, ak, sk, region) {
-  const bin = process.env.HCLOUD_BIN || 'hcloud';
+  const { executable, argsPrefix } = resolveHcloudCommand();
   const args = [
     'configure',
     'set',
@@ -162,7 +181,12 @@ export function runHcloudConfigure(profile, ak, sk, region) {
     `--cli-secret-key=${sk}`,
     `--cli-region=${region || ''}`,
   ];
-  const r = spawnSync(bin, args, { shell: false, windowsHide: true, stdio: 'pipe', timeout: 30000 });
+  const r = spawnSync(executable, [...argsPrefix, ...args], {
+    shell: false,
+    windowsHide: true,
+    stdio: 'pipe',
+    timeout: 30000,
+  });
   return {
     ok: r.status === 0,
     error: redactSecrets(

--- a/plugins/huaweicloud-core/src/auth/service.mjs
+++ b/plugins/huaweicloud-core/src/auth/service.mjs
@@ -1,5 +1,4 @@
 import { existsSync } from 'node:fs';
-import { spawnSync } from 'node:child_process';
 
 import { getAgentRegistrationStatuses } from './agent-registration.mjs';
 import {
@@ -10,38 +9,27 @@ import {
   writeObsConfig,
 } from './credentials.mjs';
 import {
+  fingerprint,
   exportStateForStatus,
   hasRuntimeCredentials,
   resolveManagedProfile,
   runHcloudConfigure,
 } from './reconcile.mjs';
-
-function hcloudInstalled() {
-  const bin = process.env.HCLOUD_BIN || 'hcloud';
-  try {
-    const r = spawnSync(`"${bin}" version`, [], {
-      shell: true,
-      windowsHide: true,
-      stdio: 'pipe',
-      timeout: 5000,
-    });
-    const out = `${r.stdout || ''}${r.stderr || ''}`;
-    return r.status === 0 && /KooCLI|Current.*version|当前KooCLI/i.test(out);
-  } catch {
-    return false;
-  }
-}
+import { hcloudProbeNextStep, probeHcloud } from '../hcloud-probe.mjs';
 
 export function getAuthStatus(target = 'all') {
   const credentials = readGlobalCredentials();
   const reconciled = { ...exportStateForStatus(), runtimeActive: hasRuntimeCredentials() };
+  const hcloud = probeHcloud();
   return {
     target,
     credentialsConfigured: Boolean(credentials?.ak && credentials?.sk),
     credentialsPath: globalCredentialsPath(),
     obsConfigured: existsSync(obsConfigPath()),
     obsConfigPath: obsConfigPath(),
-    kooCliInstalled: hcloudInstalled(),
+    kooCliInstalled: hcloud.installed,
+    kooCliStatus: hcloud.status,
+    kooCliNextStep: hcloudProbeNextStep(hcloud),
     reconciled,
     agents: getAgentRegistrationStatuses(target).agents,
   };
@@ -85,11 +73,17 @@ export function syncAuth(target = 'all') {
     };
   }
 
-  if (!hcloudInstalled()) {
+  const hcloud = probeHcloud();
+  if (!hcloud.ok) {
     return {
       ok: false,
-      error: 'KooCLI not installed.',
-      nextStep: 'Install KooCLI or point HCLOUD_BIN at the hcloud executable.',
+      error:
+        hcloud.status === 'sandbox_home_failure'
+          ? 'KooCLI detected but cannot resolve the user home directory in this agent sandbox.'
+          : hcloud.status === 'privacy_pending'
+            ? 'KooCLI privacy agreement is pending.'
+            : 'KooCLI not ready.',
+      nextStep: hcloudProbeNextStep(hcloud),
       obs: { configured: true, path: obs.path, endpoint: obs.endpoint },
     };
   }
@@ -104,7 +98,7 @@ export function syncAuth(target = 'all') {
     };
   }
 
-  writeLastSync();
+  writeLastSync({ kooCliProfile: profile, s1Fingerprint: fingerprint(credentials.ak, credentials.sk) });
 
   return {
     ok: true,

--- a/plugins/huaweicloud-core/src/hcloud-cli.mjs
+++ b/plugins/huaweicloud-core/src/hcloud-cli.mjs
@@ -1,11 +1,11 @@
 import { spawn, spawnSync } from 'node:child_process';
 import { randomUUID } from 'node:crypto';
-import { existsSync, mkdirSync, writeFileSync } from 'node:fs';
-import { homedir } from 'node:os';
+import { mkdirSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { classifyHcloudArgs, redactSecrets, assertAllowed } from './safety-policy.mjs';
 import { getProxySettings } from './proxy/proxy-config.mjs';
+import { findHcloudBin, resolveHcloudCommand } from './hcloud-probe.mjs';
 
 const DEFAULT_TIMEOUT_MS = 60_000;
 const DEFAULT_FORCE_KILL_AFTER_MS = 2_000;
@@ -67,10 +67,10 @@ function preflightSecurityGroupCheck(normalizedArgs) {
   const findings = [];
   for (const sgId of sgIds) {
     try {
-      const hcloudBin = process.env.HCLOUD_BIN || 'hcloud';
+      const { executable, argsPrefix } = resolveHcloudCommand();
       const spawnArgs = ['VPC', 'ListSecurityGroupRules', `--security_group_id.1=${sgId}`];
       if (regionArg) spawnArgs.push(regionArg);
-      const r = spawnSync(hcloudBin, spawnArgs, {
+      const r = spawnSync(executable, [...argsPrefix, ...spawnArgs], {
         shell: false,
         windowsHide: true,
         stdio: 'pipe',
@@ -216,12 +216,7 @@ async function runtimeCurrentMismatchWarning() {
 }
 
 function discoverHcloudPath() {
-  if (process.env.HCLOUD_BIN && existsSync(process.env.HCLOUD_BIN)) return process.env.HCLOUD_BIN;
-  const candidates =
-    process.platform === 'win32'
-      ? [join(homedir(), 'hcloud', 'hcloud.exe')]
-      : [join(homedir(), '.local', 'bin', 'hcloud'), join(homedir(), 'hcloud', 'hcloud')];
-  return candidates.find((c) => existsSync(c)) || null;
+  return findHcloudBin();
 }
 
 function runHcloudOnce(plan, options) {

--- a/plugins/huaweicloud-core/src/hcloud-probe.mjs
+++ b/plugins/huaweicloud-core/src/hcloud-probe.mjs
@@ -1,0 +1,154 @@
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+
+import { compareVersion, getKooCliVersion, parseHcloudVersion } from './koocli-version.mjs';
+import { redactSecrets } from './safety-policy.mjs';
+
+const VERSION_RE = /KooCLI|Current.*version|当前KooCLI/i;
+
+export function findHcloudBin() {
+  if (process.env.HCLOUD_BIN && existsSync(process.env.HCLOUD_BIN)) return process.env.HCLOUD_BIN;
+  const candidates =
+    process.platform === 'win32'
+      ? [join(homedir(), 'hcloud', 'hcloud.exe')]
+      : [join(homedir(), '.local', 'bin', 'hcloud'), join(homedir(), 'hcloud', 'hcloud')];
+  const found = candidates.find((candidate) => existsSync(candidate));
+  if (found) return found;
+
+  const locator =
+    process.platform === 'win32'
+      ? spawnSync('where.exe', ['hcloud'], { windowsHide: true, stdio: 'pipe', encoding: 'utf8', timeout: 3000 })
+      : spawnSync('sh', ['-c', 'command -v hcloud'], {
+          windowsHide: true,
+          stdio: 'pipe',
+          encoding: 'utf8',
+          timeout: 3000,
+        });
+  if (locator.status === 0) {
+    const first = String(locator.stdout || '')
+      .split(/\r?\n/)
+      .map((line) => line.trim())
+      .find(Boolean);
+    if (first) return first;
+  }
+  return null;
+}
+
+function envHcloudArgs() {
+  if (!process.env.HCLOUD_BIN_ARGS_JSON) return [];
+  try {
+    const parsed = JSON.parse(process.env.HCLOUD_BIN_ARGS_JSON);
+    if (Array.isArray(parsed)) return parsed.map((item) => String(item));
+  } catch {}
+  return [];
+}
+
+export function resolveHcloudCommand(options = {}) {
+  return {
+    executable: options.executable || findHcloudBin() || 'hcloud',
+    argsPrefix: Array.isArray(options.executableArgs) ? options.executableArgs : envHcloudArgs(),
+  };
+}
+
+export function classifyHcloudProbe(result, requiredVersion = getKooCliVersion()) {
+  const stdout = String(result.stdout || '');
+  const stderr = String(result.stderr || '');
+  const output = `${stdout}${stderr}`;
+  const installedVersion = parseHcloudVersion(output);
+
+  if (result.error?.code === 'ENOENT') {
+    return {
+      status: 'not_found',
+      installed: false,
+      ok: false,
+      errorCode: 'HCLOUD_NOT_FOUND',
+    };
+  }
+
+  if (result.status === 0 && (VERSION_RE.test(output) || installedVersion)) {
+    const versionMismatch = !!(
+      requiredVersion &&
+      installedVersion &&
+      compareVersion(installedVersion, requiredVersion) !== 0
+    );
+    return {
+      status: versionMismatch ? 'version_mismatch' : 'ok',
+      installed: true,
+      ok: true,
+      installedVersion,
+      requiredVersion: requiredVersion || undefined,
+      versionMismatch,
+    };
+  }
+
+  if (/获取当前用户家目录失败|home\s+directory|user\s+home|home\s+dir|homedir/i.test(output)) {
+    return {
+      status: 'sandbox_home_failure',
+      installed: true,
+      ok: false,
+      errorCode: 'HCLOUD_SANDBOX_HOME_FAILURE',
+    };
+  }
+
+  if (
+    /同意并继续使用|不同意并退出|隐私协议|隐私声明|privacy agreement|privacy statement|invalid character|无效字符/i.test(
+      output,
+    )
+  ) {
+    return {
+      status: 'privacy_pending',
+      installed: true,
+      ok: false,
+      errorCode: 'HCLOUD_PRIVACY_PENDING',
+    };
+  }
+
+  return {
+    status: 'unavailable',
+    installed: false,
+    ok: false,
+    errorCode: 'HCLOUD_UNAVAILABLE',
+  };
+}
+
+export function probeHcloud(options = {}) {
+  const { executable, argsPrefix } = resolveHcloudCommand(options);
+  const r = spawnSync(executable, [...argsPrefix, 'version'], {
+    shell: false,
+    windowsHide: true,
+    stdio: 'pipe',
+    encoding: 'utf8',
+    timeout: options.timeoutMs ?? 5000,
+  });
+  const classified = classifyHcloudProbe(r, options.requiredVersion);
+  const stdout = redactSecrets(String(r.stdout || '').trim());
+  const stderr = redactSecrets(String(r.stderr || r.error?.message || '').trim());
+  return {
+    executable,
+    exitCode: r.status,
+    stdout,
+    stderr,
+    output: classified.ok ? stdout : stderr || stdout,
+    ...classified,
+  };
+}
+
+export function hcloudProbeNextStep(probe) {
+  if (probe.status === 'ok')
+    return 'Use huaweicloud_show_profile_redacted to inspect the active KooCLI profile safely.';
+  if (probe.status === 'version_mismatch') {
+    return `KooCLI version mismatch: installed ${probe.installedVersion}, this plugin is paired with ${probe.requiredVersion}. Reinstall the pinned version (see huaweicloud-cli-and-auth skill) and restart the agent.`;
+  }
+  if (probe.status === 'sandbox_home_failure') {
+    return 'KooCLI was found, but this agent sandbox cannot resolve the Windows user home directory. Set HCLOUD_BIN to the full hcloud path, restart Codex, or verify from a normal terminal.';
+  }
+  if (probe.status === 'privacy_pending') {
+    return 'KooCLI requires accepting its one-time privacy agreement. Run hcloud version in a real terminal and accept the prompt, then restart the agent.';
+  }
+  if (probe.status === 'not_found') {
+    return 'hcloud executable not found. Set HCLOUD_BIN to the full hcloud path, or install KooCLI: npx huaweicloud-devkit install-hcloud. Then restart the agent.';
+  }
+  return 'Install Huawei Cloud KooCLI: npx huaweicloud-devkit install-hcloud. Configure credentials outside the agent conversation.';
+}

--- a/plugins/huaweicloud-core/src/safety-policy.mjs
+++ b/plugins/huaweicloud-core/src/safety-policy.mjs
@@ -109,6 +109,14 @@ function applyCommandRiskRules(base, normalizedArgs, options = {}) {
   return mergeRiskDecision(base, risk);
 }
 
+function applyRawCommandRiskRules(base, command, options = {}) {
+  if (base.decision === 'deny' || options.skipRiskRules === true) {
+    return base;
+  }
+  const risk = evaluateCommandRisk(command);
+  return mergeRiskDecision(base, risk);
+}
+
 export function classifyHcloudArgs(args, options = {}) {
   const policy = options.policy || DEFAULT_POLICY;
   const { service, operation, args: normalizedArgs } = commandOperation(args);
@@ -340,11 +348,15 @@ export function classifyTextCommand(command, options = {}) {
     };
   }
 
-  return {
-    decision: 'allow',
-    risk: 'not_huaweicloud',
-    reason: 'No Huawei Cloud safety rule matched.',
-  };
+  return applyRawCommandRiskRules(
+    {
+      decision: 'allow',
+      risk: 'not_huaweicloud',
+      reason: 'No Huawei Cloud safety rule matched.',
+    },
+    text,
+    options,
+  );
 }
 
 export function assertAllowed(result) {

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -18,7 +18,7 @@ import { createRequire } from 'node:module';
 
 import { getAuthStatus, syncAuth } from './auth/service.mjs';
 import { SUPPORTED_AGENT_TARGETS } from './auth/agent-registration.mjs';
-import { resolveManagedProfile } from './auth/reconcile.mjs';
+import { fingerprint, resolveManagedProfile } from './auth/reconcile.mjs';
 import { redactSecrets } from './safety-policy.mjs';
 import {
   globalCredentialsPath,
@@ -36,13 +36,8 @@ import {
 } from './proxy/proxy-config.mjs';
 import { removeKooCli, removeObsConfig } from './sandbox/uninstall-cleanup.mjs';
 import { queryDistTagsSync, determineTarget, semverCompare } from './update-check.mjs';
-import {
-  getKooCliVersion,
-  parseHcloudVersion,
-  compareVersion,
-  kooCliDownloadBase,
-  KOO_CLI_BASE,
-} from './koocli-version.mjs';
+import { getKooCliVersion, compareVersion, kooCliDownloadBase, KOO_CLI_BASE } from './koocli-version.mjs';
+import { findHcloudBin, hcloudProbeNextStep, probeHcloud } from './hcloud-probe.mjs';
 
 const { DatabaseSync } = createRequire(import.meta.url)('node:sqlite');
 
@@ -420,23 +415,6 @@ function detectCodeartsSandbox() {
   }
 }
 
-// Locate an existing hcloud executable (HCLOUD_BIN, ~/hcloud on Windows, ~/.local/bin elsewhere).
-function findHcloudBin() {
-  if (process.env.HCLOUD_BIN && existsSync(process.env.HCLOUD_BIN)) return process.env.HCLOUD_BIN;
-  const isWin = platform() === 'win32';
-  const candidates = isWin
-    ? [join(homedir(), 'hcloud', 'hcloud.exe')]
-    : [
-        join(homedir(), '.local', 'bin', 'hcloud'),
-        join(homedir(), 'hcloud', 'hcloud'),
-        join(homedir(), 'hcloud', 'hcloud.exe'),
-      ];
-  for (const c of candidates) {
-    if (existsSync(c)) return c;
-  }
-  return null;
-}
-
 function printSandboxWarning(reason) {
   console.log(`\n\x1b[1m\x1b[31m⚠ 检测到码道沙箱模式 (bash_mode: sandbox)\x1b[0m`);
   console.log(`\x1b[31m  ${reason}\x1b[0m`);
@@ -630,23 +608,6 @@ function hasCodexCLI() {
   return false;
 }
 
-function checkHcloud() {
-  const bin = findHcloudBin() || process.env.HCLOUD_BIN || 'hcloud';
-  if (!existsSync(bin)) return false;
-  try {
-    if (statSync(bin).size < 1024) return false;
-  } catch {
-    return false;
-  }
-  try {
-    const r = spawnSync(`"${bin}" version`, [], { shell: true, windowsHide: true, stdio: 'pipe', timeout: 5000 });
-    const out = (r.stdout ? r.stdout.toString() : '') + (r.stderr ? r.stderr.toString() : '');
-    return r.status === 0 && /KooCLI|Current.*version|当前KooCLI/i.test(out);
-  } catch {
-    return false;
-  }
-}
-
 function getMarketplaceName() {
   const marketplacePath = join(PACKAGE_ROOT, '.agents', 'plugins', 'marketplace.json');
   try {
@@ -656,9 +617,24 @@ function getMarketplaceName() {
   return 'huaweicloud-devkit';
 }
 
+function getCodexPluginName() {
+  const marketplacePath = join(PACKAGE_ROOT, '.agents', 'plugins', 'marketplace.json');
+  try {
+    const marketplace = JSON.parse(readFileSync(marketplacePath, 'utf8'));
+    const pluginName = marketplace.plugins?.[0]?.name;
+    if (pluginName) return pluginName;
+  } catch {}
+  const codexManifestPath = join(PLUGIN_ROOT, '.codex-plugin', 'plugin.json');
+  try {
+    const manifest = JSON.parse(readFileSync(codexManifestPath, 'utf8'));
+    if (manifest.name) return manifest.name;
+  } catch {}
+  return 'huaweicloud-devkit';
+}
+
 function installCodex() {
   const marketplaceRoot = PACKAGE_ROOT;
-  const pluginName = 'huaweicloud-core';
+  const pluginName = getCodexPluginName();
   const marketplaceName = getMarketplaceName();
 
   console.log(`  Registering Codex marketplace: ${marketplaceRoot}`);
@@ -672,6 +648,10 @@ function installCodex() {
   if (r1.status !== 0 && /Access is denied/i.test((r1.stderr || '').toString())) {
     console.log(`  \x1b[33mWindowsApps codex.exe permission denied.\x1b[0m`);
     console.log(`  \x1b[33mUse: npx huaweicloud-devkit install --target codex-desktop\x1b[0m`);
+    return false;
+  }
+  if (r1.status !== 0) {
+    console.log(`  \x1b[31mCodex marketplace registration failed.\x1b[0m`);
     return false;
   }
 
@@ -688,20 +668,26 @@ function installCodex() {
     console.log(`  \x1b[33mUse: npx huaweicloud-devkit install --target codex-desktop\x1b[0m`);
     return false;
   }
+  if (r2.status !== 0) {
+    console.log(`  \x1b[31mCodex plugin installation failed.\x1b[0m`);
+    return false;
+  }
 
   return true;
 }
 
 function uninstallCodex() {
-  const pluginName = 'huaweicloud-core';
+  const pluginName = getCodexPluginName();
   const marketplaceName = getMarketplaceName();
-  console.log(`  Removing Codex plugin: ${pluginName}@${marketplaceName}`);
-  const r = spawnSync(`codex plugin remove "${pluginName}@${marketplaceName}"`, [], {
-    shell: true,
-    windowsHide: true,
-    stdio: 'pipe',
-  });
-  console.log(`  ${r.stdout ? r.stdout.toString().trim() : r.stderr.toString().trim()}`);
+  for (const name of new Set([pluginName, 'huaweicloud-core'])) {
+    console.log(`  Removing Codex plugin: ${name}@${marketplaceName}`);
+    const r = spawnSync(`codex plugin remove "${name}@${marketplaceName}"`, [], {
+      shell: true,
+      windowsHide: true,
+      stdio: 'pipe',
+    });
+    console.log(`  ${r.stdout ? r.stdout.toString().trim() : r.stderr.toString().trim()}`);
+  }
 
   for (const name of new Set([marketplaceName, 'HuaweiCloud-Devkit'])) {
     console.log(`  Removing Codex marketplace: ${name}`);
@@ -717,7 +703,7 @@ function uninstallCodex() {
 function codexStatus() {
   const r = spawnSync('codex plugin list', [], { shell: true, windowsHide: true, stdio: 'pipe' });
   const out = r.stdout ? r.stdout.toString() : '';
-  return out.includes('huaweicloud-core');
+  return out.includes(getCodexPluginName()) || out.includes('huaweicloud-core');
 }
 
 async function installOpenCode() {
@@ -3074,75 +3060,116 @@ function checkForUpdate() {
   }
 }
 
+function installMarkerDirForTarget(target) {
+  if (target === 'codex') return null;
+  if (target === 'dsh') return dshPluginsDir();
+  if (target === 'codearts') return codeartsPluginsDir();
+  if (target === 'codearts-work') return codeartsWorkPluginsDir();
+  if (target === 'workbuddy') return workbuddyPluginsDir();
+  if (target === 'officeace') return officeacePluginsDir();
+  if (target === 'hermes') return hermesPluginsDir();
+  if (target === 'openclaw') return openclawPluginsDir();
+  if (target === 'atomcode') return atomcodePluginsDir();
+  if (target === 'codex-desktop') return codexDesktopPluginsDir();
+  if (target === 'opencode') return opencodePluginsDir();
+  return null;
+}
+
+function writeInstallMarker(target) {
+  const markerDir = installMarkerDirForTarget(target);
+  if (!markerDir) return;
+  mkdirSync(markerDir, { recursive: true });
+  writeFileSync(join(markerDir, '.installed'), new Date().toISOString());
+}
+
 async function cmdInstall() {
   const target = parseTarget();
   console.log(BANNER);
   console.log(`Installing HuaweiCloud DevKit${target !== 'opencode' ? ` for ${target}` : ''}...\n`);
   checkNode();
   checkForUpdate();
+  const installFailures = [];
+
+  async function runInstallStep(stepTarget, title, fn) {
+    console.log(title);
+    try {
+      const result = await fn();
+      if (result === false) {
+        installFailures.push(stepTarget);
+        return false;
+      }
+      writeInstallMarker(stepTarget);
+      return true;
+    } catch (error) {
+      installFailures.push(stepTarget);
+      console.log(`  \x1b[31m${stepTarget} install failed: ${error.message}\x1b[0m`);
+      return false;
+    }
+  }
 
   if (target === 'opencode' || target === 'all') {
-    console.log('[OpenCode]');
-    await installOpenCode();
+    await runInstallStep('opencode', '[OpenCode]', installOpenCode);
   }
   if (target === 'codex-desktop' || target === 'all') {
-    console.log('\n[Codex Desktop]');
-    await installCodexDesktop();
+    await runInstallStep('codex-desktop', '\n[Codex Desktop]', installCodexDesktop);
   }
   if (target === 'codearts' || target === 'all') {
-    console.log('\n[CodeArts]');
-    await installCodeArts();
+    await runInstallStep('codearts', '\n[CodeArts]', installCodeArts);
   }
   if (target === 'codearts-work' || target === 'all') {
-    console.log('\n[CodeArts Work]');
-    await installCodeArtsWork();
+    await runInstallStep('codearts-work', '\n[CodeArts Work]', installCodeArtsWork);
   }
   if (target === 'workbuddy' || target === 'all') {
-    console.log('\n[WorkBuddy]');
-    await installWorkBuddy();
+    await runInstallStep('workbuddy', '\n[WorkBuddy]', installWorkBuddy);
   }
   if (target === 'dsh' || target === 'all') {
-    console.log('\n[DSH]');
-    await installDsh();
+    await runInstallStep('dsh', '\n[DSH]', installDsh);
   }
   if (target === 'officeace' || target === 'all') {
-    console.log('\n[OfficeAce]');
-    await installOfficeAce();
+    await runInstallStep('officeace', '\n[OfficeAce]', installOfficeAce);
   }
   if (target === 'hermes' || target === 'all') {
-    console.log('\n[Hermes Agent]');
-    await installHermes();
+    await runInstallStep('hermes', '\n[Hermes Agent]', installHermes);
   }
   if (target === 'openclaw' || target === 'all') {
-    console.log('\n[OpenClaw]');
-    await installOpenClaw();
+    await runInstallStep('openclaw', '\n[OpenClaw]', installOpenClaw);
   }
   if (target === 'atomcode' || target === 'all') {
-    console.log('\n[AtomCode]');
-    await installAtomCode();
+    await runInstallStep('atomcode', '\n[AtomCode]', installAtomCode);
   }
   if (target === 'codex' || target === 'all') {
-    console.log('\n[Codex]');
-    if (!hasCodexCLI()) {
-      if (target === 'codex') {
-        console.log(`  \x1b[31mCodex CLI not found.\x1b[0m`);
-        if (process.platform === 'win32') {
-          console.log(`  \x1b[33mTip: Codex Desktop on Windows installs codex.exe under WindowsApps,\x1b[0m`);
-          console.log(`  \x1b[33m     which may fail with "Access is denied". Try instead:\x1b[0m`);
-          console.log(`  \x1b[33m     npx huaweicloud-devkit install --target codex-desktop\x1b[0m`);
+    await runInstallStep('codex', '\n[Codex]', () => {
+      if (!hasCodexCLI()) {
+        if (target === 'codex') {
+          console.log(`  \x1b[31mCodex CLI not found.\x1b[0m`);
+          if (process.platform === 'win32') {
+            console.log(`  \x1b[33mTip: Codex Desktop on Windows installs codex.exe under WindowsApps,\x1b[0m`);
+            console.log(`  \x1b[33m     which may fail with "Access is denied". Try instead:\x1b[0m`);
+            console.log(`  \x1b[33m     npx huaweicloud-devkit install --target codex-desktop\x1b[0m`);
+          }
+          console.log(`  \x1b[31mOr install Codex CLI: https://github.com/openai/codex-cli\x1b[0m`);
+          return false;
         }
-        console.log(`  \x1b[31mOr install Codex CLI: https://github.com/openai/codex-cli\x1b[0m`);
-        process.exit(1);
+        console.log(`  \x1b[33mCodex CLI not found. Skipping Codex.\x1b[0m`);
+        if (process.platform === 'win32') {
+          console.log('  \x1b[33mTip: try --target codex-desktop for Codex Desktop on Windows\x1b[0m');
+        } else {
+          console.log('  Install Codex CLI to enable: npx huaweicloud-devkit install --target codex');
+        }
+        return true;
       }
-      console.log(`  \x1b[33mCodex CLI not found. Skipping Codex.\x1b[0m`);
-      if (process.platform === 'win32') {
-        console.log('  \x1b[33mTip: try --target codex-desktop for Codex Desktop on Windows\x1b[0m');
-      } else {
-        console.log('  Install Codex CLI to enable: npx huaweicloud-devkit install --target codex');
-      }
-    } else {
-      installCodex();
+      return installCodex();
+    });
+  }
+
+  if (installFailures.length > 0) {
+    console.log(`\n\x1b[31mInstallation failed for: ${installFailures.join(', ')}\x1b[0m`);
+    if (target === 'all') {
+      console.log(
+        '\x1b[33mSome targets may have been installed before the failure. Re-run status/doctor per target.\x1b[0m',
+      );
     }
+    process.exit(1);
   }
 
   console.log(`\n\x1b[32mInstallation complete!\x1b[0m`);
@@ -3197,10 +3224,15 @@ async function cmdInstall() {
     console.log(`\x1b[1m\x1b[33m╚══════════════════════════════════════════════════════╝\x1b[0m`);
   }
 
-  const hcloudOk = checkHcloud();
-  if (!hcloudOk) {
-    console.log(`\n\x1b[33mKooCLI (hcloud) is not installed.`);
-    console.log(`  Run: npx huaweicloud-devkit install-hcloud\x1b[0m`);
+  const hcloudProbe = probeHcloud();
+  if (!hcloudProbe.ok) {
+    if (hcloudProbe.status === 'sandbox_home_failure') {
+      console.log(`\n\x1b[33mKooCLI (hcloud) detected, but cannot run in this sandbox.`);
+      console.log(`  ${hcloudProbeNextStep(hcloudProbe)}\x1b[0m`);
+    } else {
+      console.log(`\n\x1b[33mKooCLI (hcloud) is not ready.`);
+      console.log(`  ${hcloudProbeNextStep(hcloudProbe)}\x1b[0m`);
+    }
   } else {
     console.log(`\nKooCLI (hcloud) detected.`);
   }
@@ -3219,27 +3251,6 @@ async function cmdInstall() {
   }
   console.log(`  4. 运行自检：npx huaweicloud-devkit doctor`);
 
-  // Write install marker for doctor to detect
-  const markerDir =
-    target === 'dsh'
-      ? dshPluginsDir()
-      : target === 'codearts'
-        ? codeartsPluginsDir()
-        : target === 'codearts-work'
-          ? codeartsWorkPluginsDir()
-          : target === 'workbuddy'
-            ? workbuddyPluginsDir()
-            : target === 'officeace'
-              ? officeacePluginsDir()
-              : target === 'openclaw'
-                ? codexDesktopPluginsDir()
-                : target === 'atomcode'
-                  ? atomcodePluginsDir()
-                  : target === 'codex-desktop'
-                    ? codexDesktopPluginsDir()
-                    : opencodePluginsDir();
-  mkdirSync(markerDir, { recursive: true });
-  writeFileSync(join(markerDir, '.installed'), new Date().toISOString());
   if (target === 'opencode' || target === 'all') {
     console.log('Or describe your Huawei Cloud task in OpenCode');
   }
@@ -3250,7 +3261,7 @@ async function cmdInstall() {
     console.log('Or describe your Huawei Cloud task in CodeArts Work');
   }
   if (target === 'codex' || target === 'all') {
-    console.log('Or mention @huaweicloud-core in Codex');
+    console.log('Or mention @huaweicloud-devkit in Codex');
   }
   if (target === 'workbuddy' || target === 'all') {
     console.log('Or describe your Huawei Cloud task in WorkBuddy');
@@ -3553,6 +3564,21 @@ async function cmdDoctor() {
     existsSync(join(atomcodePluginDir, 'safety', 'policy.json'));
   check('Safety policy installed', safetyOk, 'Run: npx huaweicloud-devkit install');
 
+  const hookConfigPath = join(PLUGIN_ROOT, 'hooks', 'hooks.json');
+  const hookNodePath = join(PLUGIN_ROOT, 'hooks', 'huaweicloud-safety.mjs');
+  let hookConfigUsesNode = false;
+  let hookConfigUsesPython = false;
+  try {
+    const hookConfigText = readFileSync(hookConfigPath, 'utf8');
+    hookConfigUsesNode = hookConfigText.includes('huaweicloud-safety.mjs') && /\bnode\b/.test(hookConfigText);
+    hookConfigUsesPython = /\bpython3?\b/.test(hookConfigText);
+  } catch {}
+  check(
+    'Safety hook runtime (Node)',
+    existsSync(hookNodePath) && hookConfigUsesNode && !hookConfigUsesPython,
+    'hooks/hooks.json should invoke node hooks/huaweicloud-safety.mjs, not python3',
+  );
+
   // MCP config — check OpenCode, Codex Desktop, CodeArts, WorkBuddy, and DSH
   let mcpConfigured = false;
   let mcpCfgTarget = '';
@@ -3664,20 +3690,23 @@ async function cmdDoctor() {
   }
 
   // hcloud CLI
-  const hcloudBin = findHcloudBin() || process.env.HCLOUD_BIN || 'hcloud';
-  const hcloudCheck = spawnSync(`"${hcloudBin}" version`, [], {
-    shell: true,
-    windowsHide: true,
-    stdio: 'pipe',
-    timeout: 5000,
-  });
-  const hcloudOut = (hcloudCheck.stdout || '').toString() + (hcloudCheck.stderr || '').toString();
-  const hcloudOk = hcloudCheck.status === 0 && /KooCLI|Current.*version|当前KooCLI/i.test(hcloudOut);
-  check('hcloud CLI installed', hcloudOk, 'Run: npx huaweicloud-devkit install-hcloud');
+  const hcloudProbe = probeHcloud();
+  const hcloudBin = hcloudProbe.executable;
+  const hcloudOk = hcloudProbe.ok;
+  check('hcloud CLI installed', hcloudProbe.installed, hcloudProbeNextStep(hcloudProbe));
+  if (hcloudProbe.status === 'sandbox_home_failure') {
+    warn++;
+    console.log(`  \x1b[33m[WARN]\x1b[0m hcloud cannot resolve the Windows user home in this agent sandbox.`);
+    console.log(`        ${hcloudProbeNextStep(hcloudProbe)}`);
+  } else if (hcloudProbe.status === 'privacy_pending') {
+    warn++;
+    console.log(`  \x1b[33m[WARN]\x1b[0m KooCLI privacy agreement is pending.`);
+    console.log(`        ${hcloudProbeNextStep(hcloudProbe)}`);
+  }
 
   const kooCliTarget = getKooCliVersion();
   if (hcloudOk && kooCliTarget) {
-    const installed = parseHcloudVersion(hcloudOut);
+    const installed = hcloudProbe.installedVersion;
     if (installed && compareVersion(installed, kooCliTarget) !== 0) {
       warn++;
       console.log(
@@ -3701,7 +3730,7 @@ async function cmdDoctor() {
   }
 
   if (hcloudOk) {
-    const ver = (hcloudCheck.stdout.toString().match(/(\d+\.\d+\.\d+)/) || [])[1] || 'unknown';
+    const ver = hcloudProbe.installedVersion || 'unknown';
     console.log(`    Version: ${ver}`);
 
     // Check auth
@@ -4373,12 +4402,18 @@ async function cmdAuthReconcile() {
     console.log(`OBS sync failed: ${error.message}`);
   }
   const profile = resolveManagedProfile();
+  let hcloudSynced = false;
   if (profile) {
     const r = runHcloudConfigure(profile, credentials.ak, credentials.sk, credentials.region);
+    hcloudSynced = r.ok;
     console.log(`  KooCLI ${r.ok ? 'synced' : 'sync failed'}: profile=${profile} ${r.error || ''}`);
   }
-  writeLastSync();
-  console.log('Done. .last_sync refreshed.');
+  if (hcloudSynced) {
+    writeLastSync({ kooCliProfile: profile, s1Fingerprint: fingerprint(credentials.ak, credentials.sk) });
+    console.log('Done. .last_sync refreshed.');
+  } else {
+    console.log('Done. .last_sync was not refreshed because KooCLI sync did not complete.');
+  }
 }
 
 async function cmdAuthSync() {

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -57,7 +57,7 @@ import {
   resolveSkipFilePath,
   upgradePackage,
 } from './update-check.mjs';
-import { getKooCliVersion, parseHcloudVersion, compareVersion } from './koocli-version.mjs';
+import { hcloudProbeNextStep, probeHcloud } from './hcloud-probe.mjs';
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const SKILLS_ROOT_DEV = join(__dirname, '..', 'skills');
@@ -984,7 +984,9 @@ function persistCredentials(ak, sk, securityToken, region) {
   } else {
     hcloud = runHcloudConfigure(profile, ak, sk, region);
   }
-  writeLastSync();
+  if (hcloud.ok) {
+    writeLastSync({ kooCliProfile: profile, s1Fingerprint: fingerprint(ak, sk) });
+  }
   return {
     status: 'ok',
     scope: 'persist',
@@ -1382,35 +1384,17 @@ function hookResult(result) {
 }
 
 export async function runVersionCheck(options = {}) {
-  const result = await runHcloud(['version'], {
-    ...options,
-    maxRetries: options.maxRetries ?? 0,
-  });
-  const errorText = result.error || result.stderr || '';
-  const isSpawnError = /ENOENT|SPAWN_ERROR/i.test(errorText) || result.code === 'SPAWN_ERROR';
-  const requiredVersion = getKooCliVersion();
-  const installedVersion = parseHcloudVersion(result.stdout || '');
-  const versionMismatch = !!(
-    result.ok &&
-    requiredVersion &&
-    installedVersion &&
-    compareVersion(installedVersion, requiredVersion) !== 0
-  );
+  const result = probeHcloud(options);
   return {
-    installed: result.ok,
-    authenticated: result.ok && !/配置文件中不存在配置项|USE_ERROR.*配置/i.test(result.stdout || ''),
-    errorCode: isSpawnError ? 'HCLOUD_NOT_FOUND' : undefined,
-    output: result.ok ? result.stdout : errorText,
-    kooCliVersion: requiredVersion || undefined,
-    installedVersion: installedVersion || undefined,
-    versionMismatch,
-    nextStep: result.ok
-      ? versionMismatch
-        ? `KooCLI version mismatch: installed ${installedVersion}, this plugin is paired with ${requiredVersion}. Reinstall the pinned version (see huaweicloud-cli-and-auth skill) and restart the agent.`
-        : 'Use huaweicloud_show_profile_redacted to inspect the active KooCLI profile safely.'
-      : isSpawnError
-        ? 'hcloud executable not found. Set HCLOUD_BIN to the full hcloud path, or install KooCLI: npx huaweicloud-devkit install-hcloud. Then restart the agent.'
-        : 'Install Huawei Cloud KooCLI: npx huaweicloud-devkit install-hcloud. Configure credentials outside the agent conversation.',
+    installed: result.installed,
+    authenticated: result.ok && !/配置文件中不存在配置项|USE_ERROR.*配置/i.test(result.output || ''),
+    errorCode: result.errorCode,
+    status: result.status,
+    output: result.output,
+    kooCliVersion: result.requiredVersion || undefined,
+    installedVersion: result.installedVersion || undefined,
+    versionMismatch: Boolean(result.versionMismatch),
+    nextStep: hcloudProbeNextStep(result),
     authHint:
       'If hcloud is installed but commands fail with "配置文件中不存在配置项", run `npx huaweicloud-devkit auth init` outside agent chat to configure credentials.',
   };

--- a/test/agent-install.test.mjs
+++ b/test/agent-install.test.mjs
@@ -1,8 +1,17 @@
 import assert from 'node:assert/strict';
 import { spawnSync } from 'node:child_process';
-import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs';
+import {
+  chmodSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
+import { delimiter, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import test from 'node:test';
 
@@ -10,28 +19,72 @@ const root = fileURLToPath(new URL('..', import.meta.url));
 const setupCli = join(root, 'bin', 'setup.cjs');
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
 
-function makeEnv(home) {
+function makeEnv(home, extra = {}) {
   const env = {
     ...process.env,
     USERPROFILE: home,
     HOME: home,
     HOMEDRIVE: home.slice(0, 2),
     HOMEPATH: home.slice(2),
+    HERMES_HOME: join(home, '.hermes'),
   };
   // Clear agent home overrides so installs land in the temp home, not the real one.
-  for (const key of ['ATOMCODE_HOME', 'DSH_HOME', 'HERMES_HOME', 'HUAWEICLOUD_HOME', 'OFFICE_CLAW_CONFIG_ROOT']) {
+  for (const key of ['ATOMCODE_HOME', 'DSH_HOME', 'HUAWEICLOUD_HOME', 'OFFICE_CLAW_CONFIG_ROOT']) {
     delete env[key];
   }
-  return env;
+  return { ...env, ...extra };
 }
 
-function run(target, home, cwd, cmd) {
+function run(target, home, cwd, cmd, extraEnv = {}) {
   return spawnSync(process.execPath, [setupCli, cmd, '--target', target], {
     cwd,
-    env: makeEnv(home),
+    env: makeEnv(home, extraEnv),
     encoding: 'utf8',
     timeout: 60000,
   });
+}
+
+function fakeCodexEnv(cwd, options = {}) {
+  const binDir = join(cwd, 'fake-bin');
+  mkdirSync(binDir, { recursive: true });
+  const logPath = join(cwd, 'codex.log');
+  const scriptPath = join(cwd, 'fake-codex.mjs');
+  writeFileSync(
+    scriptPath,
+    `
+import { appendFileSync } from 'node:fs';
+const args = process.argv.slice(2);
+appendFileSync(process.env.FAKE_CODEX_LOG, JSON.stringify(args) + '\\n');
+if (args[0] === '--version') {
+  console.log('codex 0.0.0');
+  process.exit(0);
+}
+if (args[0] === 'plugin' && args[1] === 'list') {
+  console.log(process.env.FAKE_CODEX_LIST_OUTPUT || '');
+  process.exit(0);
+}
+if (process.env.FAKE_CODEX_FAIL_PLUGIN_ADD === '1' && args[0] === 'plugin' && args[1] === 'add') {
+  console.error('fake plugin add failed');
+  process.exit(1);
+}
+process.exit(0);
+`,
+    'utf8',
+  );
+  const commandPath = join(binDir, process.platform === 'win32' ? 'codex.cmd' : 'codex');
+  if (process.platform === 'win32') {
+    writeFileSync(commandPath, `@echo off\r\n"${process.execPath}" "${scriptPath}" %*\r\n`, 'utf8');
+  } else {
+    writeFileSync(commandPath, `#!/usr/bin/env sh\n"${process.execPath}" "${scriptPath}" "$@"\n`, 'utf8');
+    chmodSync(commandPath, 0o755);
+  }
+  return {
+    PATH: `${binDir}${delimiter}${process.env.PATH || ''}`,
+    FAKE_CODEX_LOG: logPath,
+    ...(options.failPluginAdd ? { FAKE_CODEX_FAIL_PLUGIN_ADD: '1' } : {}),
+    ...(options.listOutput ? { FAKE_CODEX_LIST_OUTPUT: options.listOutput } : {}),
+    logPath,
+  };
 }
 
 function countSkills(dir) {
@@ -393,8 +446,85 @@ test('codex target does not crash without Codex CLI', () => {
   const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
   const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
   try {
-    const res = run('codex', home, cwd, 'install');
+    const emptyPath = join(cwd, 'empty-path');
+    mkdirSync(emptyPath, { recursive: true });
+    const res = run('codex', home, cwd, 'install', { PATH: emptyPath });
+    assert.notEqual(res.status, 0);
     assert.match(res.stdout, /Codex CLI not found/);
+    assert.doesNotMatch(res.stdout, /Installation complete/);
+    assert.ok(!existsSync(join(home, '.config', 'opencode', 'huaweicloud-plugins', '.installed')));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('codex install uses DevKit plugin id and skips OpenCode marker', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+  try {
+    const env = fakeCodexEnv(cwd);
+    const res = run('codex', home, cwd, 'install', env);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /@huaweicloud-devkit/);
+    assert.match(res.stdout, /Installation complete/);
+
+    const log = readFileSync(env.logPath, 'utf8');
+    assert.match(log, /"plugin","add","huaweicloud-devkit@huaweicloud-devkit"/);
+    assert.doesNotMatch(log, /huaweicloud-core@huaweicloud-devkit/);
+    assert.ok(!existsSync(join(home, '.config', 'opencode', 'huaweicloud-plugins', '.installed')));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('codex install fails fast when plugin add fails', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+  try {
+    const env = fakeCodexEnv(cwd, { failPluginAdd: true });
+    const res = run('codex', home, cwd, 'install', env);
+    assert.notEqual(res.status, 0);
+    assert.match(res.stdout, /Codex plugin installation failed/);
+    assert.match(res.stdout, /Installation failed for: codex/);
+    assert.doesNotMatch(res.stdout, /Installation complete/);
+    assert.ok(!existsSync(join(home, '.config', 'opencode', 'huaweicloud-plugins', '.installed')));
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('codex status recognizes current and legacy plugin names', () => {
+  for (const listOutput of ['huaweicloud-devkit@huaweicloud-devkit', 'huaweicloud-core@huaweicloud-devkit']) {
+    const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+    const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+    try {
+      const env = fakeCodexEnv(cwd, { listOutput });
+      const res = run('codex', home, cwd, 'status', env);
+      assert.equal(res.status, 0, res.stderr);
+      assert.match(res.stdout, /Plugin:.*Installed/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }
+});
+
+test('codex uninstall removes current and legacy plugin ids', () => {
+  const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+  try {
+    const env = fakeCodexEnv(cwd);
+    const res = run('codex', home, cwd, 'uninstall', env);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /Removing Codex plugin: huaweicloud-devkit@huaweicloud-devkit/);
+    assert.match(res.stdout, /Removing Codex plugin: huaweicloud-core@huaweicloud-devkit/);
+
+    const log = readFileSync(env.logPath, 'utf8');
+    assert.match(log, /"plugin","remove","huaweicloud-devkit@huaweicloud-devkit"/);
+    assert.match(log, /"plugin","remove","huaweicloud-core@huaweicloud-devkit"/);
   } finally {
     rmSync(home, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });

--- a/test/auth-credentials.test.mjs
+++ b/test/auth-credentials.test.mjs
@@ -37,6 +37,7 @@ function withTempHome(fn) {
     HUAWEICLOUD_REGION: process.env.HUAWEICLOUD_REGION,
     DSH_HOME: process.env.DSH_HOME,
     HCLOUD_BIN: process.env.HCLOUD_BIN,
+    HCLOUD_BIN_ARGS_JSON: process.env.HCLOUD_BIN_ARGS_JSON,
     HCLOUD_FAKE_LOG: process.env.HCLOUD_FAKE_LOG,
   };
   process.env.HUAWEICLOUD_HOME = dir;
@@ -47,6 +48,7 @@ function withTempHome(fn) {
   delete process.env.HUAWEICLOUD_REGION;
   delete process.env.DSH_HOME;
   delete process.env.HCLOUD_BIN;
+  delete process.env.HCLOUD_BIN_ARGS_JSON;
   delete process.env.HCLOUD_FAKE_LOG;
   try {
     return fn(dir);
@@ -105,7 +107,8 @@ test('writeObsConfig creates obsutilconfig content from vault', () => {
 
 test('auth sync writes OBS and reports all agent registration targets', () => {
   withTempHome((home) => {
-    process.env.HCLOUD_BIN = FAKE_HCLOUD;
+    process.env.HCLOUD_BIN = process.execPath;
+    process.env.HCLOUD_BIN_ARGS_JSON = JSON.stringify([FAKE_HCLOUD]);
     process.env.HCLOUD_FAKE_LOG = join(home, 'hcloud.log');
     mkdirSync(join(home, '.hcloud'), { recursive: true });
     writeFileSync(
@@ -420,10 +423,20 @@ test('resolveCredentials reads CodeArts credentials from CODEARTS_PROJECT_DIR', 
 test('last_sync write/read round-trip', () => {
   withTempHome((_home) => {
     assert.equal(readLastSync(), null);
-    writeLastSync();
+    writeLastSync({ kooCliProfile: 'deploy', s1Fingerprint: 'fp123456' });
     const sync = readLastSync();
     assert.ok(sync && typeof sync.ts === 'number');
+    assert.equal(sync.kooCliProfile, 'deploy');
+    assert.equal(sync.s1Fingerprint, 'fp123456');
     assert.ok(Date.now() - sync.ts < 5000);
+  });
+});
+
+test('last_sync old timestamp-only format remains readable', () => {
+  withTempHome((_home) => {
+    mkdirSync(join(process.env.HUAWEICLOUD_HOME, '.config', 'huaweicloud'), { recursive: true });
+    writeFileSync(join(process.env.HUAWEICLOUD_HOME, '.config', 'huaweicloud', '.last_sync'), '{"ts":12345}', 'utf8');
+    assert.deepEqual(readLastSync(), { ts: 12345 });
   });
 });
 

--- a/test/cred-reconcile-e2e.test.mjs
+++ b/test/cred-reconcile-e2e.test.mjs
@@ -22,6 +22,7 @@ import {
   restoreGlobalCredentialsBackup,
   setRuntimeCredentials,
   writeGlobalCredentials,
+  writeLastSync,
   writeObsConfig,
 } from '../plugins/huaweicloud-core/src/auth/credentials.mjs';
 import { fingerprint, runHcloudConfigure, scanState } from '../plugins/huaweicloud-core/src/auth/reconcile.mjs';
@@ -39,11 +40,12 @@ const ENV_KEYS = [
   'HW_REGION',
   'HUAWEICLOUD_REGION',
   'HCLOUD_BIN',
+  'HCLOUD_BIN_ARGS_JSON',
   'HCLOUD_FAKE_LOG',
   'CODEARTS_PROJECT_DIR',
 ];
 
-async function withTempHome(fn) {
+function withTempHome(fn) {
   const dir = mkdtempSync(join(tmpdir(), 'huaweicloud-e2e-'));
   const prev = {};
   for (const key of ENV_KEYS) prev[key] = process.env[key];
@@ -52,15 +54,24 @@ async function withTempHome(fn) {
     if (key !== 'HUAWEICLOUD_HOME') delete process.env[key];
   }
   clearRuntimeCredentials();
-  try {
-    return await fn(dir);
-  } finally {
+  const cleanup = () => {
     clearRuntimeCredentials();
     for (const key of ENV_KEYS) {
       if (prev[key] === undefined) delete process.env[key];
       else process.env[key] = prev[key];
     }
     rmSync(dir, { recursive: true, force: true });
+  };
+  try {
+    const result = fn(dir);
+    if (result && typeof result.then === 'function') {
+      return result.finally(cleanup);
+    }
+    cleanup();
+    return result;
+  } catch (error) {
+    cleanup();
+    throw error;
   }
 }
 
@@ -73,8 +84,9 @@ function writeFakeKooCli(current, profiles) {
   return p;
 }
 
-function setFakeHcloud(logPath) {
-  process.env.HCLOUD_BIN = FAKE_HCLOUD;
+function setFakeHcloud(logPath, fixture = FAKE_HCLOUD) {
+  process.env.HCLOUD_BIN = process.execPath;
+  process.env.HCLOUD_BIN_ARGS_JSON = JSON.stringify([fixture]);
   process.env.HCLOUD_FAKE_LOG = logPath;
 }
 
@@ -113,7 +125,6 @@ test('02 manual edit of KooCLI current profile reports S2-current manualModified
     const scan = scanState();
     const inc = scan.inconsistencies.find((i) => i.store === 'S2-current');
     assert.ok(inc, 'expected an S2-current inconsistency');
-    assert.equal(inc.manualModified, true);
   });
 });
 
@@ -434,8 +445,7 @@ test('19 malformed creds-import.json is still wiped even though the import is re
 
 test('20 syncAuth returns ok:false and skips .last_sync when S2 configure fails', () => {
   withTempHome((dir) => {
-    process.env.HCLOUD_BIN = FAKE_HCLOUD_FAIL;
-    process.env.HCLOUD_FAKE_LOG = join(dir, 'hcloud.log');
+    setFakeHcloud(join(dir, 'hcloud.log'), FAKE_HCLOUD_FAIL);
     writeFakeKooCli('deploy', [
       { name: 'deploy', accessKeyId: 'E2E20_OLD_AK', secretAccessKey: 'E2E20_OLD_SK', region: 'cn-north-4' },
     ]);
@@ -445,5 +455,64 @@ test('20 syncAuth returns ok:false and skips .last_sync when S2 configure fails'
     assert.equal(res.ok, false);
     assert.ok(res.error, 'failure must carry an error message');
     assert.equal(existsSync(lastSyncPath()), false, 'no .last_sync marker may be stamped when S2 sync failed');
+  });
+});
+
+test('21 scanState trusts fresh DevKit sync marker when KooCLI stores transformed SK', () => {
+  withTempHome(() => {
+    const ak = 'E2E21_AK';
+    const sk = 'E2E21_SK';
+    const region = 'cn-north-4';
+    writeGlobalCredentials({ ak, sk, region });
+    writeFakeKooCli('deploy', [
+      { name: 'deploy', accessKeyId: ak, secretAccessKey: 'encrypted-or-transformed-by-koocli', region },
+    ]);
+    writeLastSync({ kooCliProfile: 'deploy', s1Fingerprint: fingerprint(ak, sk) });
+
+    const scan = scanState();
+    assert.equal(scan.stores.currentFingerprint, fingerprint(ak, sk));
+    assert.equal(
+      scan.inconsistencies.some((i) => i.store === 'S2-current'),
+      false,
+    );
+  });
+});
+
+test('22 scanState still reports S2-current mismatch when KooCLI AK differs from S1', () => {
+  withTempHome(() => {
+    const ak = 'E2E22_AK';
+    const sk = 'E2E22_SK';
+    const region = 'cn-north-4';
+    writeGlobalCredentials({ ak, sk, region });
+    writeFakeKooCli('deploy', [
+      { name: 'deploy', accessKeyId: 'E2E22_OTHER_AK', secretAccessKey: 'encrypted-or-transformed-by-koocli', region },
+    ]);
+    writeLastSync({ kooCliProfile: 'deploy', s1Fingerprint: fingerprint(ak, sk) });
+
+    const scan = scanState();
+    const inc = scan.inconsistencies.find((i) => i.store === 'S2-current');
+    assert.ok(inc, 'expected an S2-current inconsistency');
+  });
+});
+
+test('23 scanState reports manualModified when KooCLI config is newer than .last_sync', () => {
+  withTempHome(() => {
+    const ak = 'E2E23_AK';
+    const sk = 'E2E23_SK';
+    const region = 'cn-north-4';
+    writeGlobalCredentials({ ak, sk, region });
+    writeFileSync(
+      lastSyncPath(),
+      JSON.stringify({ ts: Date.now() - 60_000, kooCliProfile: 'deploy', s1Fingerprint: fingerprint(ak, sk) }),
+      'utf8',
+    );
+    writeFakeKooCli('deploy', [
+      { name: 'deploy', accessKeyId: ak, secretAccessKey: 'encrypted-or-transformed-by-koocli', region },
+    ]);
+
+    const scan = scanState();
+    const inc = scan.inconsistencies.find((i) => i.store === 'S2-current');
+    assert.ok(inc, 'expected an S2-current inconsistency after manual KooCLI edit');
+    assert.equal(inc.manualModified, true);
   });
 });

--- a/test/hcloud-probe.test.mjs
+++ b/test/hcloud-probe.test.mjs
@@ -1,0 +1,49 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+
+import { classifyHcloudProbe, hcloudProbeNextStep } from '../plugins/huaweicloud-core/src/hcloud-probe.mjs';
+import { getKooCliVersion } from '../plugins/huaweicloud-core/src/koocli-version.mjs';
+
+test('hcloud probe classifies matching KooCLI version as ok', () => {
+  const result = classifyHcloudProbe({ status: 0, stdout: `当前KooCLI版本:${getKooCliVersion()}`, stderr: '' });
+  assert.equal(result.status, 'ok');
+  assert.equal(result.installed, true);
+  assert.equal(result.ok, true);
+  assert.equal(result.versionMismatch, false);
+});
+
+test('hcloud probe classifies version mismatch separately from not installed', () => {
+  const result = classifyHcloudProbe({ status: 0, stdout: '当前KooCLI版本:7.0.0', stderr: '' }, '7.2.12');
+  assert.equal(result.status, 'version_mismatch');
+  assert.equal(result.installed, true);
+  assert.equal(result.ok, true);
+  assert.equal(result.versionMismatch, true);
+  assert.match(hcloudProbeNextStep(result), /version mismatch/i);
+});
+
+test('hcloud probe classifies privacy agreement pending', () => {
+  const result = classifyHcloudProbe({ status: 1, stdout: '', stderr: '请阅读并同意隐私声明' });
+  assert.equal(result.status, 'privacy_pending');
+  assert.equal(result.installed, true);
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'HCLOUD_PRIVACY_PENDING');
+  assert.match(hcloudProbeNextStep(result), /privacy/i);
+});
+
+test('hcloud probe classifies Codex Windows sandbox home failures', () => {
+  const result = classifyHcloudProbe({ status: 1, stdout: '', stderr: '获取当前用户家目录失败' });
+  assert.equal(result.status, 'sandbox_home_failure');
+  assert.equal(result.installed, true);
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'HCLOUD_SANDBOX_HOME_FAILURE');
+  assert.match(hcloudProbeNextStep(result), /HCLOUD_BIN|Codex|sandbox/i);
+});
+
+test('hcloud probe classifies executable not found', () => {
+  const result = classifyHcloudProbe({ error: { code: 'ENOENT' }, stdout: '', stderr: '' });
+  assert.equal(result.status, 'not_found');
+  assert.equal(result.installed, false);
+  assert.equal(result.ok, false);
+  assert.equal(result.errorCode, 'HCLOUD_NOT_FOUND');
+  assert.match(hcloudProbeNextStep(result), /install KooCLI/i);
+});

--- a/test/hook-node.test.mjs
+++ b/test/hook-node.test.mjs
@@ -1,0 +1,67 @@
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import test from 'node:test';
+
+const hookPath = join(process.cwd(), 'plugins', 'huaweicloud-core', 'hooks', 'huaweicloud-safety.mjs');
+
+function runHook(payload) {
+  return spawnSync(process.execPath, [hookPath], {
+    input: JSON.stringify(payload),
+    encoding: 'utf8',
+  });
+}
+
+test('node hook file exists', () => {
+  assert.ok(existsSync(hookPath));
+});
+
+test('node hook blocks public admin port through shared rules', () => {
+  const result = runHook({
+    tool_name: 'mcp__huaweicloud__create_security_group_rule',
+    tool_input: {
+      command:
+        'hcloud VPC CreateSecurityGroupRule --security_group_rule.port_range_min=22 --security_group_rule.remote_ip_prefix=0.0.0.0/0',
+    },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(output.hookSpecificOutput.permissionDecisionReason, /blocked this action/i);
+});
+
+test('node hook blocks credential file reads', () => {
+  const result = runHook({
+    tool_name: 'Bash',
+    tool_input: { command: 'Get-Content ~/.hcloud/config.json' },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(output.hookSpecificOutput.permissionDecisionReason, /credential|profile/i);
+});
+
+test('node hook blocks encoded shell payload execution through shared rules', () => {
+  const result = runHook({
+    tool_name: 'Bash',
+    tool_input: { command: 'echo ZWNobyBoaQ== | base64 -d | bash' },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(output.hookSpecificOutput.permissionDecisionReason, /encoded payload|interpreter/i);
+});
+
+test('node hook allows safe commands with empty stdout', () => {
+  const result = runHook({
+    tool_name: 'Bash',
+    tool_input: { command: 'git status --short' },
+  });
+
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(result.stdout.trim(), '');
+});

--- a/test/hook-python.test.mjs
+++ b/test/hook-python.test.mjs
@@ -51,6 +51,19 @@ test('python hook still blocks credential files', () => {
   assert.match(output.hookSpecificOutput.permissionDecisionReason, /credential|profile/i);
 });
 
+test('python hook blocks encoded shell payload execution through shared rules', () => {
+  const result = runHook({
+    tool_name: 'Bash',
+    tool_input: { command: 'echo ZWNobyBoaQ== | base64 -d | bash' },
+  });
+  if (pythonUnavailable(result)) return;
+
+  assert.equal(result.status, 0);
+  const output = JSON.parse(result.stdout);
+  assert.equal(output.hookSpecificOutput.permissionDecision, 'deny');
+  assert.match(output.hookSpecificOutput.permissionDecisionReason, /encoded payload|interpreter/i);
+});
+
 test('python hook outputs Hermes format when hook_event_name is present', () => {
   const result = runHook({
     hook_event_name: 'pre_tool_call',

--- a/test/issue-443-fix.test.mjs
+++ b/test/issue-443-fix.test.mjs
@@ -1,15 +1,23 @@
 import assert from 'node:assert/strict';
-import { chmodSync, mkdtempSync, writeFileSync } from 'node:fs';
+import { mkdtempSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { randomBytes } from 'node:crypto';
 import test from 'node:test';
 
-function mkShim(dir, nodeScript) {
-  const shim = join(dir, 'hcloud-shim');
-  writeFileSync(shim, `#!/bin/bash\nexec ${process.execPath} ${nodeScript} "$@"`, 'utf8');
-  chmodSync(shim, 0o755);
-  return shim;
+function setFakeHcloud(nodeScript) {
+  const oldEnv = {
+    HCLOUD_BIN: process.env.HCLOUD_BIN,
+    HCLOUD_BIN_ARGS_JSON: process.env.HCLOUD_BIN_ARGS_JSON,
+  };
+  process.env.HCLOUD_BIN = process.execPath;
+  process.env.HCLOUD_BIN_ARGS_JSON = JSON.stringify([nodeScript]);
+  return () => {
+    if (oldEnv.HCLOUD_BIN === undefined) delete process.env.HCLOUD_BIN;
+    else process.env.HCLOUD_BIN = oldEnv.HCLOUD_BIN;
+    if (oldEnv.HCLOUD_BIN_ARGS_JSON === undefined) delete process.env.HCLOUD_BIN_ARGS_JSON;
+    else process.env.HCLOUD_BIN_ARGS_JSON = oldEnv.HCLOUD_BIN_ARGS_JSON;
+  };
 }
 
 test('preflightSecurityGroupCheck catches dangerous SG via --server.security_groups.N.id (B1+B2 fix)', async () => {
@@ -34,9 +42,7 @@ console.log(JSON.stringify({
     'utf8',
   );
 
-  const shim = mkShim(dir, script);
-  const oldEnv = process.env.HCLOUD_BIN;
-  process.env.HCLOUD_BIN = shim;
+  const restoreHcloud = setFakeHcloud(script);
 
   try {
     const { planHcloudCommand } = await import('../plugins/huaweicloud-core/src/hcloud-cli.mjs');
@@ -59,7 +65,7 @@ console.log(JSON.stringify({
     assert.match(plan.sgFindings[0].message, /22/);
     assert.match(plan.sgFindings[0].message, /77216397/);
   } finally {
-    process.env.HCLOUD_BIN = oldEnv;
+    restoreHcloud();
     try {
       require('node:fs').rmSync(dir, { recursive: true, force: true });
     } catch {}
@@ -88,9 +94,7 @@ console.log(JSON.stringify({
     'utf8',
   );
 
-  const shim = mkShim(dir, script);
-  const oldEnv = process.env.HCLOUD_BIN;
-  process.env.HCLOUD_BIN = shim;
+  const restoreHcloud = setFakeHcloud(script);
 
   try {
     const { planHcloudCommand } = await import('../plugins/huaweicloud-core/src/hcloud-cli.mjs');
@@ -111,7 +115,7 @@ console.log(JSON.stringify({
     assert.equal(plan.sgFindings.length, 0, 'egress rules should be ignored');
     assert.equal(plan.classification.decision, 'allow');
   } finally {
-    process.env.HCLOUD_BIN = oldEnv;
+    restoreHcloud();
     try {
       require('node:fs').rmSync(dir, { recursive: true, force: true });
     } catch {}
@@ -140,9 +144,7 @@ console.log(JSON.stringify({
     'utf8',
   );
 
-  const shim = mkShim(dir, script);
-  const oldEnv = process.env.HCLOUD_BIN;
-  process.env.HCLOUD_BIN = shim;
+  const restoreHcloud = setFakeHcloud(script);
 
   try {
     const { planHcloudCommand } = await import('../plugins/huaweicloud-core/src/hcloud-cli.mjs');
@@ -163,7 +165,7 @@ console.log(JSON.stringify({
     assert.ok(plan.sgFindings.length > 0, 'old format should still work');
     assert.equal(plan.classification.decision, 'deny');
   } finally {
-    process.env.HCLOUD_BIN = oldEnv;
+    restoreHcloud();
     try {
       require('node:fs').rmSync(dir, { recursive: true, force: true });
     } catch {}

--- a/test/officeace-adaptation.test.mjs
+++ b/test/officeace-adaptation.test.mjs
@@ -35,6 +35,10 @@ function countSkills(dir) {
   return readdirSync(dir, { withFileTypes: true }).filter((d) => d.isDirectory() && d.name.startsWith('huawei')).length;
 }
 
+function removeTempDir(path) {
+  rmSync(path, { recursive: true, force: true, maxRetries: 5, retryDelay: 100 });
+}
+
 test('officeace install copies skills, MCP server, and safety policy', () => {
   const home = mkdtempSync(join(tmpdir(), 'oa-home-'));
   const cwd = mkdtempSync(join(tmpdir(), 'oa-proj-'));
@@ -56,8 +60,8 @@ test('officeace install copies skills, MCP server, and safety policy', () => {
       'officeace plugin package.json version matches package',
     );
   } finally {
-    rmSync(home, { recursive: true, force: true });
-    rmSync(cwd, { recursive: true, force: true });
+    removeTempDir(home);
+    removeTempDir(cwd);
   }
 });
 
@@ -74,7 +78,7 @@ test('officeace uninstall removes installed files', () => {
     assert.equal(countSkills(join(oaHome, 'skills')), 0);
     assert.ok(!existsSync(join(oaHome, 'huaweicloud-plugins')));
   } finally {
-    rmSync(home, { recursive: true, force: true });
-    rmSync(cwd, { recursive: true, force: true });
+    removeTempDir(home);
+    removeTempDir(cwd);
   }
 });

--- a/test/remote-mcp-server.test.mjs
+++ b/test/remote-mcp-server.test.mjs
@@ -1,6 +1,6 @@
 import assert from 'node:assert/strict';
 import { spawn } from 'node:child_process';
-import { fileURLToPath } from 'node:url';
+import { fileURLToPath, pathToFileURL } from 'node:url';
 import { join } from 'node:path';
 import test from 'node:test';
 
@@ -13,7 +13,7 @@ let base;
 let startRemoteServer;
 
 test.before(async () => {
-  const mod = await import(join(srcDir, 'mcp-server-remote.mjs'));
+  const mod = await import(pathToFileURL(join(srcDir, 'mcp-server-remote.mjs')).href);
   startRemoteServer = mod.startRemoteServer;
   const started = await startRemoteServer({ port: 0 });
   server = started.server;
@@ -107,7 +107,7 @@ test('remote MCP server falls back to SSE when client only accepts text/event-st
 });
 
 test('exports DEFAULT_PORT 9528 to avoid IACMCPServer port 9527 conflict', async () => {
-  const mod = await import(`${srcDir}/mcp-server-remote.mjs`);
+  const mod = await import(pathToFileURL(join(srcDir, 'mcp-server-remote.mjs')).href);
   assert.equal(mod.DEFAULT_PORT, 9528);
 });
 

--- a/test/safety-policy.test.mjs
+++ b/test/safety-policy.test.mjs
@@ -153,6 +153,13 @@ test('classifyTextCommand blocks approved public admin port exposure', () => {
   assert.equal(result.findings[0].ruleId, 'hwc-network-public-admin-port');
 });
 
+test('classifyTextCommand applies shared risk rules to non-hcloud commands', () => {
+  const result = classifyTextCommand('echo ZWNobyBoaQ== | base64 -d | bash');
+  assert.equal(result.decision, 'deny');
+  assert.equal(result.blockedByRiskRule, true);
+  assert.equal(result.findings[0].ruleId, 'hwc-command-encoded-shell-exec');
+});
+
 test('classifyTextCommand carries warnings for high-cost shapes', () => {
   const result = classifyTextCommand(
     'hcloud CCE CreateCluster --node_pool.max_node_count=80 --node_pool.name=preview',

--- a/test/structure.test.mjs
+++ b/test/structure.test.mjs
@@ -245,10 +245,17 @@ test('cloud risk rules are present and public-safe', () => {
   }
 });
 
-test('hooks.json references existing Python hook', () => {
+test('hooks.json uses Node hook and keeps Python hook for Hermes compatibility', () => {
   const hooksDir = join(pluginRoot, 'hooks');
-  assert.ok(existsSync(join(hooksDir, 'hooks.json')));
+  const hooksJsonPath = join(hooksDir, 'hooks.json');
+  assert.ok(existsSync(hooksJsonPath));
+  assert.ok(existsSync(join(hooksDir, 'huaweicloud-safety.mjs')));
   assert.ok(existsSync(join(hooksDir, 'huaweicloud-safety.py')));
+
+  const hooksJson = readFileSync(hooksJsonPath, 'utf8');
+  assert.match(hooksJson, /\bnode\b/);
+  assert.match(hooksJson, /huaweicloud-safety\.mjs/);
+  assert.doesNotMatch(hooksJson, /\bpython3?\b/);
 });
 
 test('hook rule model documentation exists', () => {
@@ -299,10 +306,10 @@ test('setup-cli.mjs supports the codearts target end to end', () => {
   const branches = setup.match(/target === 'codearts' \|\| target === 'all'/g);
   assert.ok(branches && branches.length >= 3, `codearts dispatch branches: ${branches?.length}`);
   // .installed marker goes to the codearts plugins dir
-  assert.match(
-    setup,
-    /const markerDir =[\s\S]*?target === 'dsh'[\s\S]*?dshPluginsDir\(\)[\s\S]*?target === 'codearts'[\s\S]*?codeartsPluginsDir\(\)[\s\S]*?target === 'codearts-work'[\s\S]*?codeartsWorkPluginsDir\(\)[\s\S]*?target === 'workbuddy'[\s\S]*?workbuddyPluginsDir\(\)[\s\S]*?target === 'codex-desktop'[\s\S]*?codexDesktopPluginsDir\(\)[\s\S]*?;/,
-  );
+  assert.match(setup, /function installMarkerDirForTarget\(target\)/);
+  assert.match(setup, /if \(target === 'codex'\) return null;/);
+  assert.match(setup, /if \(target === 'codearts'\) return codeartsPluginsDir\(\);/);
+  assert.match(setup, /function writeInstallMarker\(target\)/);
   // doctor checks the codearts skills dir alongside opencode
   assert.match(
     setup,
@@ -332,14 +339,17 @@ test('tools.mjs resolves skills from the codearts directory', () => {
 
 test('setup-cli.mjs handles KooCLI sandbox blockers and privacy agreement', () => {
   const setup = readFileSync(join(pluginRoot, 'src', 'setup-cli.mjs'), 'utf8');
+  const hcloudProbe = readFileSync(join(pluginRoot, 'src', 'hcloud-probe.mjs'), 'utf8');
   // sandbox detection reads the CodeArts permission config
   assert.match(setup, /function detectCodeartsSandbox\(\)/);
   assert.match(setup, /codearts-data', 'storage', 'permission', 'config\.json'/);
   assert.match(setup, /config\.bash_mode/);
   // hcloud lookup covers HCLOUD_BIN and ~/hcloud on Windows
-  assert.match(setup, /function findHcloudBin\(\)/);
-  assert.match(setup, /process\.env\.HCLOUD_BIN/);
-  assert.match(setup, /homedir\(\), 'hcloud', 'hcloud\.exe'/);
+  assert.match(setup, /from '\.\/hcloud-probe\.mjs'/);
+  assert.match(hcloudProbe, /function findHcloudBin\(\)/);
+  assert.match(hcloudProbe, /process\.env\.HCLOUD_BIN/);
+  assert.match(hcloudProbe, /homedir\(\), 'hcloud', 'hcloud\.exe'/);
+  assert.match(hcloudProbe, /sandbox_home_failure/);
   // sandbox warning prompts user to install externally or disable sandbox
   assert.match(setup, /function printSandboxWarning\(/);
   assert.match(setup, /检测到码道沙箱模式/);
@@ -389,7 +399,7 @@ test('setup-cli.mjs supports the dsh target end to end', () => {
   const branches = setup.match(/target === 'dsh' \|\| target === 'all'/g);
   assert.ok(branches && branches.length >= 4, `dsh dispatch branches: ${branches?.length}`);
   // .installed marker goes to the dsh plugins dir
-  assert.match(setup, /target === 'dsh'\s+\?\s+dshPluginsDir\(\)/);
+  assert.match(setup, /if \(target === 'dsh'\) return dshPluginsDir\(\);/);
   // doctor checks DSH plugin dir, patch, and skills dir
   assert.match(setup, /const dshPluginDir = dshPluginsDir\(\);/);
   assert.match(setup, /dshPatchConfigured\(\)/);

--- a/test/telemetry.test.mjs
+++ b/test/telemetry.test.mjs
@@ -1,7 +1,23 @@
 import assert from 'node:assert/strict';
 import test from 'node:test';
 
+import { AGENTS } from '../plugins/huaweicloud-core/src/telemetry/agent-registry.mjs';
 import { detectAgentHarness } from '../plugins/huaweicloud-core/src/telemetry/agent-detect.mjs';
+
+const DETECTION_ENV_KEYS = ['AGENT_HARNESS', ...new Set(AGENTS.flatMap((agent) => agent.envVars || []))];
+
+function withNoAgentEnv(fn) {
+  const prev = Object.fromEntries(DETECTION_ENV_KEYS.map((key) => [key, process.env[key]]));
+  for (const key of DETECTION_ENV_KEYS) delete process.env[key];
+  try {
+    return fn();
+  } finally {
+    for (const [key, value] of Object.entries(prev)) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+}
 
 test('detectAgentHarness returns known when no env set', () => {
   const result = detectAgentHarness();
@@ -31,7 +47,9 @@ test('detectAgentHarness detects opencode from env', () => {
 });
 
 test('detectAgentHarness returns null when nothing matches', () => {
-  assert.equal(detectAgentHarness(), null);
+  withNoAgentEnv(() => {
+    assert.equal(detectAgentHarness(), null);
+  });
 });
 
 test('generateOrRecoverInstallId returns consistent string', async () => {

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -29,7 +29,7 @@ test('runVersionCheck uses hcloud version instead of --version', async () => {
   });
 
   assert.equal(result.installed, true);
-  assert.match(result.output, /"version": "7.0.0"/);
+  assert.match(result.output, /"version":\s*"7\.0\.0"/);
   assert.doesNotMatch(result.output, /--version/);
 });
 

--- a/test/update-check.test.mjs
+++ b/test/update-check.test.mjs
@@ -280,7 +280,7 @@ test('upgradePackage 成功路径: 目标版本/重启/文案/缓存失效', asy
   assert.equal(r.installedVersion, '1.1.1');
   assert.equal(r.requiresRestart, true);
   assert.match(r.message, /重启当前会话/);
-  assert.equal(spawned.cmd, 'npx');
+  assert.equal(spawned.cmd, process.platform === 'win32' ? 'npx.cmd' : 'npx');
   assert.deepEqual(spawned.args, ['--yes', 'huaweicloud-devkit@latest', 'update', '--target', 'opencode']);
   assert.equal(spawned.opts.timeout, 300000);
   // 升级后缓存失效 → 下一次检测重新查询（此处不 fetch，只验证 invalidate 生效）


### PR DESCRIPTION
## Summary

Fixes Codex native plugin installation, Windows/Codex KooCLI diagnostics, auth reconciliation false positives, and repeated Codex safety hook failures.

Closes #519, closes #542, closes #544

## Changes

- Use the Codex plugin name from `.agents/plugins/marketplace.json`, falling back to `.codex-plugin/plugin.json` and `huaweicloud-devkit`; keep legacy `huaweicloud-core` recognition/removal for migration.
- Make `install --target codex` fail with a non-zero exit when marketplace/plugin registration fails, and skip OpenCode install markers for native Codex installs.
- Collect per-target install failures for `--target all` and report partial failures without printing a successful completion message.
- Add shared KooCLI probe logic for `HCLOUD_BIN`, Windows `~/hcloud/hcloud.exe`, and PATH lookup, with separate states for not found, version OK, privacy pending, sandbox home failure, and version mismatch.
- Refresh `.last_sync` only after successful KooCLI configure writes, recording `{ ts, kooCliProfile, s1Fingerprint }` while preserving old `{ ts }` compatibility.
- Treat fresh DevKit sync markers as authoritative when KooCLI 7.x transforms the stored SK but the current AK/profile/fingerprint still match S1; continue reporting AK mismatches and manual edits.
- Add a Node safety hook for Codex native hooks and update `hooks/hooks.json` to call Node instead of `python3`; keep the Python hook for Hermes/Python compatibility.
- Update README and safety docs for `@huaweicloud-devkit` verification and Node hook behavior.
- Fix related Windows test portability for fake hcloud invocations, remote MCP imports, telemetry env isolation, OfficeAce temp cleanup, and npx command naming.

## Validation

- `node --test test/structure.test.mjs test/agent-install.test.mjs test/cred-reconcile-e2e.test.mjs test/hook-python.test.mjs test/hook-node.test.mjs test/hcloud-probe.test.mjs test/tools.test.mjs test/safety-policy.test.mjs test/risk-rule-engine.test.mjs`
- `npm run validate`
- `npm test`
- `npm run lint:js`
- `npx prettier --check <changed files>`

Note: `npm run format:check` still reports existing repository-wide formatting drift in unrelated files. I did not format the whole repository to keep this PR focused.