### PR TITLE
feat(telemetry): classify MCP client names and route upload through proxy

### DIFF
--- a/plugins/huaweicloud-core/src/proxy/proxy-agent.mjs
+++ b/plugins/huaweicloud-core/src/proxy/proxy-agent.mjs
@@ -26,6 +26,13 @@ export async function getProxyDispatcher(targetUrl) {
   return cachedDispatcher;
 }
 
+export async function fetchWithProxy(url, options = {}) {
+  const dispatcher = await getProxyDispatcher(url);
+  if (!dispatcher) return fetch(url, options);
+  const { fetch: undiciFetch } = await import('undici');
+  return undiciFetch(url, { ...options, dispatcher });
+}
+
 export function clearProxyDispatcherCache() {
   cachedDispatcher = undefined;
   cachedDispatcherProxyUrl = null;

--- a/plugins/huaweicloud-core/src/telemetry/agent-detect.mjs
+++ b/plugins/huaweicloud-core/src/telemetry/agent-detect.mjs
@@ -7,7 +7,7 @@ import { AGENTS, matchAgent, detectVersion, installSegment } from './agent-regis
 export function detectAgentHarness(clientInfo = {}) {
   if (process.env.AGENT_HARNESS) return process.env.AGENT_HARNESS;
   for (const agent of AGENTS) {
-    if (matchAgent(agent)) return agent.id;
+    if (matchAgent(agent, clientInfo)) return agent.id;
   }
   return clientInfo.name || null;
 }
@@ -22,7 +22,7 @@ export function detectAgent(clientInfo = {}) {
   }
 
   for (const agent of AGENTS) {
-    if (matchAgent(agent)) {
+    if (matchAgent(agent, clientInfo)) {
       return {
         harness: agent.id,
         version: detectVersion(agent.version) || clientInfo.version || '0.0.0',

--- a/plugins/huaweicloud-core/src/telemetry/agent-registry.mjs
+++ b/plugins/huaweicloud-core/src/telemetry/agent-registry.mjs
@@ -43,6 +43,7 @@ export const AGENTS = [
     id: 'codex',
     pathPatterns: null,
     envVars: ['CODEX_SESSION_ID', 'CODEX_CLI_VERSION', 'CODEX_SANDBOX', 'CODEX_THREAD_ID'],
+    clientNames: ['codex-mcp-client'],
     version: null,
   },
   {
@@ -67,6 +68,7 @@ export const AGENTS = [
     id: 'officeace',
     pathPatterns: ['/.office-claw/', '/.officeace/'],
     envVars: ['OFFICEACE_SESSION_ID', 'OFFICE_CLAW_CONFIG_ROOT'],
+    clientNames: ['office-claw-mcp-connector-probe'],
     version: { type: 'officeace' },
   },
   {
@@ -85,6 +87,7 @@ export const AGENTS = [
     id: 'openclaw',
     pathPatterns: ['/.openclaw/', '/.agents/huaweicloud-plugins/'],
     envVars: ['OPENCLAW_SESSION_ID', 'OPENCLAW_CONFIG_ROOT'],
+    clientNames: ['openclaw-bundle-mcp'],
     version: null,
   },
   {
@@ -161,9 +164,14 @@ export const AGENTS = [
   },
 ];
 
-export function matchAgent(agent) {
+export function matchAgent(agent, clientInfo = {}) {
   if (agent.pathPatterns && agent.pathPatterns.some((p) => selfPath.includes(p))) return true;
   if (agent.envVars && agent.envVars.some((v) => process.env[v])) return true;
+  const name = clientInfo.name;
+  if (!name) return false;
+  const lower = String(name).toLowerCase();
+  if (agent.id.toLowerCase() === lower) return true;
+  if (agent.clientNames && agent.clientNames.some((n) => n.toLowerCase() === lower)) return true;
   return false;
 }
 

--- a/plugins/huaweicloud-core/src/telemetry/telemetry.mjs
+++ b/plugins/huaweicloud-core/src/telemetry/telemetry.mjs
@@ -13,6 +13,8 @@ import { homedir, hostname, type as osType, networkInterfaces, release as osRele
 import { createHash, randomUUID } from 'node:crypto';
 import { fileURLToPath } from 'node:url';
 
+import { fetchWithProxy } from '../proxy/proxy-agent.mjs';
+
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 const PLUGIN_DIR = join(__dirname, '..', '..');
@@ -315,7 +317,7 @@ function flushEvents() {
   const controller = new AbortController();
   const timer = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
 
-  fetch(endpoint, {
+  fetchWithProxy(endpoint, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(batch),

--- a/test/telemetry.test.mjs
+++ b/test/telemetry.test.mjs
@@ -52,6 +52,34 @@ test('detectAgentHarness returns null when nothing matches', () => {
   });
 });
 
+test('detectAgentHarness classifies MCP client names to canonical harness', () => {
+  const keys = [
+    'OPENCODE_SESSION_ID',
+    'OPENCODE_CONFIG_PATH',
+    'CODEX_SESSION_ID',
+    'CODEX_CLI_VERSION',
+    'CODEX_SANDBOX',
+    'CODEX_THREAD_ID',
+    'OFFICEACE_SESSION_ID',
+    'OFFICE_CLAW_CONFIG_ROOT',
+    'OPENCLAW_SESSION_ID',
+    'OPENCLAW_CONFIG_ROOT',
+  ];
+  const saved = keys.map((k) => [k, process.env[k]]);
+  keys.forEach((k) => delete process.env[k]);
+  try {
+    assert.equal(detectAgentHarness({ name: 'codex-mcp-client' }), 'codex');
+    assert.equal(detectAgentHarness({ name: 'office-claw-mcp-connector-probe' }), 'officeace');
+    assert.equal(detectAgentHarness({ name: 'openclaw-bundle-mcp' }), 'openclaw');
+    assert.equal(detectAgentHarness({ name: 'opencode' }), 'opencode');
+  } finally {
+    for (const [k, v] of saved) {
+      if (v === undefined) delete process.env[k];
+      else process.env[k] = v;
+    }
+  }
+});
+
 test('generateOrRecoverInstallId returns consistent string', async () => {
   const { generateOrRecoverInstallId } = await import('../plugins/huaweicloud-core/src/telemetry/telemetry.mjs');
   const id1 = generateOrRecoverInstallId();


### PR DESCRIPTION
## Summary

Two telemetry improvements.

### 1. Classify MCP client names to canonical agent harness

Unrecognized agents fall back to clientInfo.name|installSegment, which surfaces raw MCP client names like codex-mcp-client, office-claw-mcp-connector-probe, and openclaw-bundle-mcp instead of the canonical harness. matchAgent now also matches clientInfo.name against gent.id and a new clientNames alias list:

- codex << codex-mcp-client
- officeace << office-claw-mcp-connector-probe
- openclaw << openclaw-bundle-mcp

The opencode case is covered by the gent.id match. Added a test asserting these mappings.

### 2. Route telemetry upload through proxy

lushEvents used a bare etch, which bypasses proxy settings (env vars and `~/.config/huaweicloud/proxy.json`). Extracted a shared etchWithProxy(url, options) into proxy-agent.mjs (uses undici ProxyAgent when a proxy applies, native etch otherwise) and switched telemetry upload to it, so event delivery respects the same proxy configuration as the rest of the devkit.