### PR TITLE
docs: note mirror-lag fallback to official registry (#518)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), Off
 > ```
 >
 > Restore the default registry: `npm config delete registry`
+>
+> **Mirror lag**: npm mirrors (npmmirror, mirrors.huaweicloud.com) may lag behind the official registry for hours after a new release. If install fails with `ETARGET` or you get an older version, install via the official registry instead:
+>
+> ```bash
+> npx --yes --registry=https://registry.npmjs.org huaweicloud-devkit install --target <target>
+> ```
 
 ## Quick Start
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -22,6 +22,12 @@
 > ```
 >
 > 恢复默认镜像：`npm config delete registry`
+>
+> **镜像滞后**：npm 镜像（npmmirror、mirrors.huaweicloud.com）在新版本发布后可能滞后官方源数小时。若安装报 `ETARGET` 或拿到旧版本，改用官方源安装：
+>
+> ```bash
+> npx --yes --registry=https://registry.npmjs.org huaweicloud-devkit install --target <target>
+> ```
 
 ## 快速开始
 


### PR DESCRIPTION
## 动机

关闭 issue #518 的残留文档项。核心「版本倒退误报」已由 PR #525 修复，本 PR 补充 README 镜像滞后兜底说明。

## 改动

- `README.md` / `README.zh-CN.md`：在 npm 镜像配置说明后新增「镜像滞后」提示——新版本发布后镜像（npmmirror / mirrors.huaweicloud.com）可能滞后官方源数小时，安装报 `ETARGET` 或拿到旧版本时，改用官方源安装：

```bash
npx --yes --registry=https://registry.npmjs.org huaweicloud-devkit install --target <target>
```

## 说明

- 更新检测的 registry 固定（issue 建议②）与发版清单镜像同步确认（P3）经评估为低价值/有副作用，未实施：镜像滞后在版本比较保护（PR #525）下仅表现为延迟提醒而非错误；硬编码官方源会让国内连不上 npmjs.org 的用户更新检测静默失效。

## 验证

- `npm run lint:md` 通过（0 issues）