### PR TITLE
Clarify CLI and installed plugin version output

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Supports OpenCode, Codex, CodeArts Agent, WorkBuddy, DeepSeek Harness (DSH), Off
 > If `--target` is omitted, the installer auto-detects agents on your machine. When multiple agents are detected, **all of them** will be installed. Specify `--target` to control which agent receives the install.
 
 ```bash
-npx --yes huaweicloud-devkit version  # print the installed plugin version per agent
+npx --yes huaweicloud-devkit version  # print CLI version and installed plugin versions per agent
 npx --yes huaweicloud-devkit uninstall --target all --clean-global  # also remove KooCLI + OBS config
 ```
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -34,7 +34,7 @@
 > 省略 `--target` 时，安装器会自动检测机器上的 agent，检测到多个时**全部安装**。建议始终指定 `--target` 以明确安装目标。
 
 ```bash
-npx --yes huaweicloud-devkit version  # 查看各 agent 已安装的插件版本
+npx --yes huaweicloud-devkit version  # 查看 CLI 版本和各 agent 已安装的插件版本
 npx --yes huaweicloud-devkit uninstall --target all --clean-global  # 一并删除 KooCLI 与 OBS 配置
 ```
 

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -4565,6 +4565,8 @@ function readInstalledVersion(pluginsDir) {
 }
 
 function cmdVersion() {
+  console.log(`HuaweiCloud DevKit CLI: ${pkgVersion}`);
+
   const agents = [
     ['OpenCode', opencodePluginsDir()],
     ['Codex Desktop', codexDesktopPluginsDir()],
@@ -4577,16 +4579,24 @@ function cmdVersion() {
     ['Hermes', hermesPluginsDir()],
     ['AtomCode', atomcodePluginsDir()],
   ];
-  let found = 0;
+  const installed = [];
   for (const [label, dir] of agents) {
     const v = dir ? readInstalledVersion(dir) : null;
     if (!v) continue;
-    console.log(`${label}: ${v}`);
-    found += 1;
+    installed.push([label, v]);
   }
-  if (found === 0) {
+
+  if (installed.length === 0) {
+    console.log('');
     console.log('No Huawei Cloud DevKit plugin installed. Run `npx huaweicloud-devkit install --target <agent>`.');
+    return;
   }
+
+  console.log('\nInstalled agent plugins:');
+  for (const [label, version] of installed) {
+    console.log(`${label}: ${version}`);
+  }
+  console.log('\nRun `npx huaweicloud-devkit update --target <agent>` to refresh installed agent plugins.');
 }
 
 async function main() {
@@ -4649,13 +4659,13 @@ async function main() {
       console.log('  install-hcloud  Show KooCLI install commands for your OS');
       console.log('  auth         Manage unified auth: init | sync | status | reconcile');
       console.log('  proxy        Manage proxy config: init | show | clear');
-      console.log('  version      Print installed plugin version per agent');
+      console.log('  version      Print CLI version and installed plugin version per agent');
       console.log('  help         Show this help');
       console.log('\nOptions:');
       console.log(
         '  --target     Target agent: opencode (default), codex, codearts, codearts-work, workbuddy, dsh, officeace, hermes, openclaw, atomcode, all',
       );
-      console.log('  --version    Print installed plugin version per agent');
+      console.log('  --version    Print CLI version and installed plugin version per agent');
       console.log('  --clean-kocli   (with: uninstall --target all) also remove KooCLI');
       console.log('  --clean-obs     (with: uninstall --target all) also remove OBS config');
       console.log('  --clean-global  (with: uninstall --target all) also remove KooCLI + OBS config');

--- a/test/codearts-adaptation.test.mjs
+++ b/test/codearts-adaptation.test.mjs
@@ -11,13 +11,16 @@ const setupCli = join(root, 'bin', 'setup.cjs');
 const pkg = JSON.parse(readFileSync(join(root, 'package.json'), 'utf8'));
 
 function makeEnv(home, _cwd) {
-  return {
+  const env = {
     ...process.env,
     USERPROFILE: home,
     HOME: home,
     HOMEDRIVE: home.slice(0, 2),
     HOMEPATH: home.slice(2),
+    HUAWEICLOUD_HOME: home,
   };
+  delete env.HCLOUD_BIN;
+  return env;
 }
 
 function runCli(home, cwd, args) {

--- a/test/cross-platform-install.test.mjs
+++ b/test/cross-platform-install.test.mjs
@@ -10,7 +10,14 @@ const root = fileURLToPath(new URL('..', import.meta.url));
 const setupCli = join(root, 'bin', 'setup.cjs');
 
 function makeEnv(home) {
-  return { ...process.env, USERPROFILE: home, HOME: home, HOMEDRIVE: home.slice(0, 2), HOMEPATH: home.slice(2) };
+  return {
+    ...process.env,
+    USERPROFILE: home,
+    HOME: home,
+    HOMEDRIVE: home.slice(0, 2),
+    HOMEPATH: home.slice(2),
+    HUAWEICLOUD_HOME: home,
+  };
 }
 
 function runCli(home, cwd, args) {
@@ -138,15 +145,35 @@ test('uninstall cleans up all platform directories', () => {
   }
 });
 
-test('version reports installed plugin version per agent', () => {
+test('version reports CLI version and installed plugin version per agent', () => {
   const home = mkdtempSync(join(tmpdir(), 'cp-verinst-'));
   const cwd = mkdtempSync(join(tmpdir(), 'cp-proj-'));
   try {
     assert.equal(runCli(home, cwd, ['install', '--target', 'opencode']).status, 0);
     const res = runCli(home, cwd, ['version']);
     assert.equal(res.status, 0, res.stderr);
-    assert.match(res.stdout, /OpenCode: \d+\.\d+\.\d+/);
-    assert.doesNotMatch(res.stdout, /not installed/);
+    assert.match(res.stdout, /HuaweiCloud DevKit CLI: \d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?/);
+    assert.match(res.stdout, /Installed agent plugins:/);
+    assert.match(res.stdout, /OpenCode: \d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?/);
+    assert.match(res.stdout, /update --target <agent>/);
+    assert.doesNotMatch(res.stdout, /No Huawei Cloud DevKit plugin installed/);
+  } finally {
+    rmSync(home, { recursive: true, force: true });
+    rmSync(cwd, { recursive: true, force: true });
+  }
+});
+
+test('version reports CLI version and install hint when no agent plugin is installed', () => {
+  const home = mkdtempSync(join(tmpdir(), 'cp-verempty-'));
+  const cwd = mkdtempSync(join(tmpdir(), 'cp-proj-'));
+  try {
+    const res = runCli(home, cwd, ['version']);
+    assert.equal(res.status, 0, res.stderr);
+    assert.match(res.stdout, /HuaweiCloud DevKit CLI: \d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?/);
+    assert.match(res.stdout, /No Huawei Cloud DevKit plugin installed/);
+    assert.match(res.stdout, /install --target <agent>/);
+    assert.doesNotMatch(res.stdout, /Installed agent plugins:/);
+    assert.doesNotMatch(res.stdout, /update --target <agent>/);
   } finally {
     rmSync(home, { recursive: true, force: true });
     rmSync(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes the confusing `version` command output reported in #516.

Before this change, `npx huaweicloud-devkit version` only printed versions from installed agent plugin copies, so users could run the latest CLI package through `npx` while still seeing an older version such as `OpenCode: 1.1.0`. That made it look like the latest package was not installed.

After this change, `version` clearly separates the current CLI package version from installed agent plugin copy versions:

```text
HuaweiCloud DevKit CLI: 1.1.2-next.4

Installed agent plugins:
OpenCode: 1.1.0

Run `npx huaweicloud-devkit update --target <agent>` to refresh installed agent plugins.
```

When no agent plugin is installed, the command now prints the CLI version and an install hint instead of an update hint:

```text
HuaweiCloud DevKit CLI: 1.1.2-next.4

No Huawei Cloud DevKit plugin installed. Run `npx huaweicloud-devkit install --target <agent>`.
```

Closes #516

## Changes

- Print the current HuaweiCloud DevKit CLI package version at the top of `version` output.
- Group installed agent plugin versions under `Installed agent plugins:`.
- Show `install --target <agent>` guidance when no installed plugin copy exists.
- Show `update --target <agent>` guidance only when installed plugin copies exist.
- Update README / README.zh-CN comments for the `version` command.
- Isolate related tests from host `HUAWEICLOUD_HOME` and `HCLOUD_BIN` so local machine configuration does not affect fixtures.

## Validation

- `node --test test/codearts-adaptation.test.mjs test/cross-platform-install.test.mjs test/structure.test.mjs`
- `npm run validate`
- `npm run lint:js`
- `npx prettier --check README.md README.zh-CN.md plugins/huaweicloud-core/src/setup-cli.mjs test/cross-platform-install.test.mjs test/codearts-adaptation.test.mjs`
- `npm test` — 363/363 passed
