### PR TITLE
fix(skills): teach agents to self-discover cli-domain-id via STS GetCallerIdentity (#574)

### DIFF
--- a/plugins/huaweicloud-core/skills/huawei-billing/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-billing/SKILL.md
@@ -22,6 +22,7 @@ Domain expertise for billing queries (BSS). Covers cost tracking, bill details, 
 | BSS Admin role needed      | IAM user must have BSS Administrator or Finance role                                                                                                |
 | Currency conversion varies | Cross-region costs use daily exchange rates                                                                                                         |
 | Region fixed to cn-north-1 | BSS operations only support `--cli-region=cn-north-1` in KooCLI. This is a KooCLI metadata limitation — the billing data itself covers all regions. |
+| Global service needs domain-id | BSS is a global service: AK/SK mode requires `--cli-domain-id`. If unknown, run `hcloud STS GetCallerIdentity --cli-region=<region>` and use `account_id` (see `huaweicloud-cli-and-auth`). |
 
 ## Common Workflows
 
@@ -31,7 +32,7 @@ Domain expertise for billing queries (BSS). Covers cost tracking, bill details, 
 | List customer bills  | `ListCustomerBillsFeeRecords --cli-region=cn-north-1 --project_id=<p>` |
 | List resource usage  | `ListResourceUsage --cli-region=cn-north-1 --project_id=<p>`           |
 | List sub-customers   | `ListConsumeSubCustomers --cli-region=cn-north-1 --project_id=<p>`     |
-| Show account balance | `ShowCustomerAccountBalances --cli-region=cn-north-1 --project_id=<p>` |
+| Show account balance | `ShowCustomerAccountBalances --cli-region=cn-north-1 --cli-domain-id=<domain_id>` |
 | List conversions     | `ListConversions --cli-region=cn-north-1 --project_id=<p>`             |
 
 Discover exact parameters with `--help` before executing any command. All BSS operations are read-only.

--- a/plugins/huaweicloud-core/skills/huawei-billing/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-billing/SKILL.md
@@ -16,24 +16,24 @@ Domain expertise for billing queries (BSS). Covers cost tracking, bill details, 
 
 ## Critical Warnings
 
-| Trap                       | Why                                                                                                                                                 |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Bills delayed ~24h         | Yesterday's costs may not appear until the next day                                                                                                 |
-| BSS Admin role needed      | IAM user must have BSS Administrator or Finance role                                                                                                |
-| Currency conversion varies | Cross-region costs use daily exchange rates                                                                                                         |
-| Region fixed to cn-north-1 | BSS operations only support `--cli-region=cn-north-1` in KooCLI. This is a KooCLI metadata limitation — the billing data itself covers all regions. |
+| Trap                           | Why                                                                                                                                                                                         |
+| ------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Bills delayed ~24h             | Yesterday's costs may not appear until the next day                                                                                                                                         |
+| BSS Admin role needed          | IAM user must have BSS Administrator or Finance role                                                                                                                                        |
+| Currency conversion varies     | Cross-region costs use daily exchange rates                                                                                                                                                 |
+| Region fixed to cn-north-1     | BSS operations only support `--cli-region=cn-north-1` in KooCLI. This is a KooCLI metadata limitation — the billing data itself covers all regions.                                         |
 | Global service needs domain-id | BSS is a global service: AK/SK mode requires `--cli-domain-id`. If unknown, run `hcloud STS GetCallerIdentity --cli-region=<region>` and use `account_id` (see `huaweicloud-cli-and-auth`). |
 
 ## Common Workflows
 
-| Task                 | Operation                                                              |
-| -------------------- | ---------------------------------------------------------------------- |
-| List costs           | `ListCosts --cli-region=cn-north-1 --project_id=<p>`                   |
-| List customer bills  | `ListCustomerBillsFeeRecords --cli-region=cn-north-1 --project_id=<p>` |
-| List resource usage  | `ListResourceUsage --cli-region=cn-north-1 --project_id=<p>`           |
-| List sub-customers   | `ListConsumeSubCustomers --cli-region=cn-north-1 --project_id=<p>`     |
+| Task                 | Operation                                                                         |
+| -------------------- | --------------------------------------------------------------------------------- |
+| List costs           | `ListCosts --cli-region=cn-north-1 --project_id=<p>`                              |
+| List customer bills  | `ListCustomerBillsFeeRecords --cli-region=cn-north-1 --project_id=<p>`            |
+| List resource usage  | `ListResourceUsage --cli-region=cn-north-1 --project_id=<p>`                      |
+| List sub-customers   | `ListConsumeSubCustomers --cli-region=cn-north-1 --project_id=<p>`                |
 | Show account balance | `ShowCustomerAccountBalances --cli-region=cn-north-1 --cli-domain-id=<domain_id>` |
-| List conversions     | `ListConversions --cli-region=cn-north-1 --project_id=<p>`             |
+| List conversions     | `ListConversions --cli-region=cn-north-1 --project_id=<p>`                        |
 
 Discover exact parameters with `--help` before executing any command. All BSS operations are read-only.
 

--- a/plugins/huaweicloud-core/skills/huawei-functiongraph/references/create-function.md
+++ b/plugins/huaweicloud-core/skills/huawei-functiongraph/references/create-function.md
@@ -69,4 +69,6 @@ hcloud IAM AssociateAgencyWithDomainPermission --agency_id=<id> --domain_id=<id>
 hcloud FunctionGraph CreateFunction --func_vpc.vpc_id=<vpc> --func_vpc.subnet_id=<subnet> --app_xrole=<name> ...
 ```
 
+> IAM is a global service in KooCLI. If `CreateAgency` / `AssociateAgencyWithDomainPermission` fail with `缺少必填参数 cli-domain-id`, prefer a concrete `--cli-region` (e.g. `cn-north-4`), or discover the domain-id via `hcloud STS GetCallerIdentity --cli-region=<region>` (see `huaweicloud-cli-and-auth`).
+
 | QuotaExceeded | Max 10 functions per project per region |

--- a/plugins/huaweicloud-core/skills/huawei-iac/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-iac/SKILL.md
@@ -86,7 +86,7 @@ Execution: show the to-be-deleted list for final confirmation → delete in **re
 - `huaweicloud_run_readonly_command` → discovery (flavors, images, zones, prices)
 - `huaweicloud_list_regions` / `huaweicloud_get_regional_availability` → region intent
 - `huaweicloud_hook_check_deploy_plan` → risk-check the plan before approval
-- Balance and pricing: `huawei-billing` skill. Balance operation (BSS is pinned to cn-north-1 in KooCLI): `hcloud BSS ShowCustomerAccountBalances --cli-region=cn-north-1 --cli-domain-id=<domain_id>`. Global services (BSS/IAM) require `--cli-domain-id` per call or in the profile - if unknown, extract it from any resource response's `tenant_id` field (e.g. a VPC create response), or from the profile's domainId once configured
+- Balance and pricing: `huawei-billing` skill. Balance operation (BSS is pinned to cn-north-1 in KooCLI): `hcloud BSS ShowCustomerAccountBalances --cli-region=cn-north-1 --cli-domain-id=<domain_id>`. Global services (BSS/IAM) require `--cli-domain-id` per call or in the profile. If unknown, discover it with `hcloud STS GetCallerIdentity --cli-region=<region>` (`account_id` = domain-id); use `tenant_id` from a resource response only as a fallback
 
 ## Cross-Skill References
 

--- a/plugins/huaweicloud-core/skills/huawei-iac/references/resource-catalog.md
+++ b/plugins/huaweicloud-core/skills/huawei-iac/references/resource-catalog.md
@@ -101,7 +101,7 @@ hcloud BSS ListOnDemandResourceRatings --project_id=<pid> \
 
 - Account balance: `hcloud BSS ShowCustomerAccountBalances --cli-region=cn-north-1 --cli-domain-id=<domain_id>`
   - Global services (BSS/IAM/CDN) demand `--cli-domain-id` per call (or in the profile) under AK/SK auth
-  - If the domain_id is unknown: extract it from ANY resource response's `tenant_id` field (e.g. a VPC create response) or from the console (My Credentials page)
+  - If the domain_id is unknown: discover it via `hcloud STS GetCallerIdentity --cli-region=<region>` (`account_id` = domain-id); fall back to `tenant_id` from a resource response or the console
   - Response shape: `account_balances[].amount` (cash account type=1, voucher account type=5), `debt_amount`, `currency`
 - Cost gate rule: no deployment without a per-resource cost estimate AND a balance check. Verified failure mode when skipped: ECS creation dies with `Ecs.7000 Insufficient account balance` at order submission
 - **Quota pre-check (EIP and friends)**: quota errors surface only at RUN stage (`EIP.7905 Quota exceeded` AFTER plan+approval), wasting an approval cycle. Before provisioning, pre-check counts with `hcloud EIP ListPublicips` (⚠️ beware pagination truncation: `--limit=50` on a 59-EIP account showed "50" - the first "50/50 full" verdict was wrong; count precisely, e.g. loop pages or use the console quota page). If quota is exhausted, surface it at the cost gate instead of after approval. Note: after releasing an EIP, quota counting may lag several minutes - `EIP.7905` can persist briefly even under the limit
@@ -111,4 +111,4 @@ hcloud BSS ListOnDemandResourceRatings --project_id=<pid> \
 - Symptom of a broken profile: every hcloud API returns `APIGW.0301 Incorrect IAM authentication information` while OBS/obsutil keeps working - caused by a stale `securityToken` in the profile
 - Fix: `hcloud configure delete --cli-profile=default`, then re-run `npx huaweicloud-devkit auth init` with permanent AK/SK only (no token). `configure set` refuses empty values, so the token cannot be cleared in place
 - project_id is auto-discovered once signing works - no need to configure it manually
-- VPC/OBS create responses expose `tenant_id` (= domain_id) - the reliable fallback source when BSS/IAM discovery is blocked
+- VPC/OBS create responses expose `tenant_id` (= domain_id) - a fallback when `STS GetCallerIdentity` discovery is unavailable

--- a/plugins/huaweicloud-core/skills/huawei-iam/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-iam/SKILL.md
@@ -23,6 +23,7 @@ Domain expertise for Huawei Cloud Identity and Access Management (IAM). Covers u
 | Wildcard policies dangerous       | Effect:Allow + Resource:* = full access. Always scope resources |
 | Agency trust is powerful          | Agencies let services assume roles. Always add conditions       |
 | Root account must have MFA        | Root AK/SK is all-powerful. Enable MFA immediately              |
+| IAM is a global service in KooCLI | `--cli-region=cn-north-1` routes to the global endpoint and then AK/SK mode needs `--cli-domain-id`. Prefer a concrete region (e.g. `cn-north-4`); if you hit `缺少必填参数 cli-domain-id`, discover it via `hcloud STS GetCallerIdentity --cli-region=<region>` |
 
 ## Policy Structure
 

--- a/plugins/huaweicloud-core/skills/huawei-iam/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-iam/SKILL.md
@@ -16,13 +16,13 @@ Domain expertise for Huawei Cloud Identity and Access Management (IAM). Covers u
 
 ## Critical Warnings
 
-| Trap                              | Why                                                             |
-| --------------------------------- | --------------------------------------------------------------- |
-| NEVER create IAM users for humans | Use OneAccess (IAM Identity Center) or federated SSO            |
-| NEVER create long-term AK/SK      | Use temporary STS tokens via agencies                           |
-| Wildcard policies dangerous       | Effect:Allow + Resource:* = full access. Always scope resources |
-| Agency trust is powerful          | Agencies let services assume roles. Always add conditions       |
-| Root account must have MFA        | Root AK/SK is all-powerful. Enable MFA immediately              |
+| Trap                              | Why                                                                                                                                                                                                                                                              |
+| --------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| NEVER create IAM users for humans | Use OneAccess (IAM Identity Center) or federated SSO                                                                                                                                                                                                             |
+| NEVER create long-term AK/SK      | Use temporary STS tokens via agencies                                                                                                                                                                                                                            |
+| Wildcard policies dangerous       | Effect:Allow + Resource:* = full access. Always scope resources                                                                                                                                                                                                  |
+| Agency trust is powerful          | Agencies let services assume roles. Always add conditions                                                                                                                                                                                                        |
+| Root account must have MFA        | Root AK/SK is all-powerful. Enable MFA immediately                                                                                                                                                                                                               |
 | IAM is a global service in KooCLI | `--cli-region=cn-north-1` routes to the global endpoint and then AK/SK mode needs `--cli-domain-id`. Prefer a concrete region (e.g. `cn-north-4`); if you hit `缺少必填参数 cli-domain-id`, discover it via `hcloud STS GetCallerIdentity --cli-region=<region>` |
 
 ## Policy Structure

--- a/plugins/huaweicloud-core/skills/huawei-voucher/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-voucher/SKILL.md
@@ -49,7 +49,7 @@ version: 1
 ## 环境注意
 
 - 生产环境：`voucher_status` / `voucher_claim` 无需传 `domain_id`，后端从 IAM 自动解析账号。
-- 测试环境：需传 `domain_id`（华为云账号 ID）；未传时返回 `测试环境需提供 domain_id`。此时用 `hcloud STS GetCallerIdentity --cli-region=<region>` 取 `account_id`（= domain_id）后补传；不要用 `hcloud IAM KeystoneListAuthDomains`（临时凭据下会失败）。
+- 测试环境：需传 `domain_id`（华为云账号 ID）；未传时返回 `测试环境需提供 domain_id`。
 
 ## 注意事项
 

--- a/plugins/huaweicloud-core/skills/huawei-voucher/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huawei-voucher/SKILL.md
@@ -49,7 +49,7 @@ version: 1
 ## 环境注意
 
 - 生产环境：`voucher_status` / `voucher_claim` 无需传 `domain_id`，后端从 IAM 自动解析账号。
-- 测试环境：需传 `domain_id`（华为云账号 ID）；未传时返回 `测试环境需提供 domain_id`，此时可用 `hcloud IAM KeystoneListAuthDomains` 查询账号 ID 后补传。
+- 测试环境：需传 `domain_id`（华为云账号 ID）；未传时返回 `测试环境需提供 domain_id`。此时用 `hcloud STS GetCallerIdentity --cli-region=<region>` 取 `account_id`（= domain_id）后补传；不要用 `hcloud IAM KeystoneListAuthDomains`（临时凭据下会失败）。
 
 ## 注意事项
 

--- a/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-cli-and-auth/SKILL.md
@@ -137,6 +137,22 @@ Credentials are resolved in this order (highest priority first):
 
 When switching accounts within the same Agent session, use `huaweicloud_auth_init` to set runtime credentials (overrides all sources for the current MCP process), or `huaweicloud_auth_switch action=persist`, which writes S1 with `configuredBySession: true` so the session-configured account outranks `HW_ACCESS_KEY` / `HW_SECRET_KEY`. Note: running `auth init` clears the configuredBySession flag.
 
+## Global Services & domain-id
+
+Global services (BSS, and IAM routed via the `cn-north-1` global endpoint) require `--cli-domain-id` under AK/SK auth. When it is missing, KooCLI fails with `[USE_ERROR]...缺少必填参数cli-domain-id`.
+
+Do **not** ask the user to run `hcloud configure set --cli-domain-id=...`. Discover the domain-id yourself:
+
+```bash
+hcloud STS GetCallerIdentity --cli-region=<region>
+# → account_id IS the domain-id; retry the original call with --cli-domain-id=<account_id>
+```
+
+- `<region>` is the profile's current region. **STS is not deployed in `cn-north-1`** — if the profile region is `cn-north-1`, use another region (e.g. `cn-north-4`).
+- Temporary credentials (AK/SK + security token) work too: add `--cli-security-token=<token>`.
+- Prefer `STS GetCallerIdentity` over `IAM KeystoneListAuthDomains` — the latter only works with permanent credentials and outside `cn-north-1`; it fails under temporary credentials.
+- `cli-domain-id` is a KooCLI CLI requirement, not a Huawei Cloud API requirement: the raw `GET /v3/auth/domains` can be signed with just AK/SK.
+
 ## Preferred Toolkit Tools
 
 - `huaweicloud_auth_init`

--- a/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
@@ -57,6 +57,7 @@ Use evidence before fixes. Do not guess service behavior when request IDs, regio
 | NoSuchKey / 404          | Resource not found                 | Verify resource ID, region, and project_id                   |
 | QuotaExceeded            | Account limit reached              | Request quota increase in console                            |
 | [USE_ERROR] 不正确的参数 | Wrong param name                   | Run `--help`, check `--param=value` format and nested prefix |
+| `[USE_ERROR]缺少必填参数 cli-domain-id` | Global service (BSS / IAM global endpoint) under AK/SK | Run `hcloud STS GetCallerIdentity --cli-region=<region>` → `account_id`, retry with `--cli-domain-id=<account_id>` (see `huaweicloud-cli-and-auth`) |
 | Ecs.0005                 | Flavor-image mismatch              | Check image `__support_*` against flavor virtualization type |
 | FSS.0400                 | FunctionGraph latest version error | Strip `:latest` from function URN                            |
 | FSS.1417                 | DEDICATEDGATEWAY missing params    | Add instance_id, group_id, protocol, env_name, env_id        |

--- a/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
+++ b/plugins/huaweicloud-core/skills/huaweicloud-troubleshooting/SKILL.md
@@ -50,19 +50,19 @@ Use evidence before fixes. Do not guess service behavior when request IDs, regio
 
 ## Common Error Codes
 
-| Error                    | Likely Cause                       | Fix                                                          |
-| ------------------------ | ---------------------------------- | ------------------------------------------------------------ |
-| AuthFailure / 401        | AK/SK invalid or expired           | Regenerate AK/SK, re-run `npx huaweicloud-devkit auth init`  |
-| AccessDenied / 403       | IAM permission missing             | Check `huawei-iam` skill, add required policy action         |
-| NoSuchKey / 404          | Resource not found                 | Verify resource ID, region, and project_id                   |
-| QuotaExceeded            | Account limit reached              | Request quota increase in console                            |
-| [USE_ERROR] 不正确的参数 | Wrong param name                   | Run `--help`, check `--param=value` format and nested prefix |
+| Error                                   | Likely Cause                                           | Fix                                                                                                                                                 |
+| --------------------------------------- | ------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------- |
+| AuthFailure / 401                       | AK/SK invalid or expired                               | Regenerate AK/SK, re-run `npx huaweicloud-devkit auth init`                                                                                         |
+| AccessDenied / 403                      | IAM permission missing                                 | Check `huawei-iam` skill, add required policy action                                                                                                |
+| NoSuchKey / 404                         | Resource not found                                     | Verify resource ID, region, and project_id                                                                                                          |
+| QuotaExceeded                           | Account limit reached                                  | Request quota increase in console                                                                                                                   |
+| [USE_ERROR] 不正确的参数                | Wrong param name                                       | Run `--help`, check `--param=value` format and nested prefix                                                                                        |
 | `[USE_ERROR]缺少必填参数 cli-domain-id` | Global service (BSS / IAM global endpoint) under AK/SK | Run `hcloud STS GetCallerIdentity --cli-region=<region>` → `account_id`, retry with `--cli-domain-id=<account_id>` (see `huaweicloud-cli-and-auth`) |
-| Ecs.0005                 | Flavor-image mismatch              | Check image `__support_*` against flavor virtualization type |
-| FSS.0400                 | FunctionGraph latest version error | Strip `:latest` from function URN                            |
-| FSS.1417                 | DEDICATEDGATEWAY missing params    | Add instance_id, group_id, protocol, env_name, env_id        |
-| APIC.7201                | Missing security_group_id          | Add `--security_group_id` param for APIG CreateInstanceV2    |
-| [NETWORK_ERROR]          | Transient network failure          | Retry with `maxRetries` param or wait and retry              |
+| Ecs.0005                                | Flavor-image mismatch                                  | Check image `__support_*` against flavor virtualization type                                                                                        |
+| FSS.0400                                | FunctionGraph latest version error                     | Strip `:latest` from function URN                                                                                                                   |
+| FSS.1417                                | DEDICATEDGATEWAY missing params                        | Add instance_id, group_id, protocol, env_name, env_id                                                                                               |
+| APIC.7201                               | Missing security_group_id                              | Add `--security_group_id` param for APIG CreateInstanceV2                                                                                           |
+| [NETWORK_ERROR]                         | Transient network failure                              | Retry with `maxRetries` param or wait and retry                                                                                                     |
 
 ## KooCLI Error Types
 


### PR DESCRIPTION
## 目的

关闭 #574。Agent 遇到全局服务「缺少必填参数 cli-domain-id」时不再把负担推给用户，而是用 `STS GetCallerIdentity` 自行获取 domain-id。

## 背景（已全链路实测）

| 取 domain-id 方法 | 永久 AK/SK | 临时 AK/SK+token |
|---|---|---|
| `STS GetCallerIdentity --cli-region=<region>` | ✅ | ✅（带 `--cli-security-token`） |
| `IAM KeystoneListAuthDomains --cli-region=<region>` | ✅（仅非 cn-north-1） | ❌（「获取账号ID失败」+「缺少 cli-domain-id」） |

- `cli-domain-id` 是 KooCLI 对全局端点（BSS 必然、IAM 走 cn-north-1 时）的 AK/SK 模式强制要求。
- `STS GetCallerIdentity` 是通用取法；`KeystoneListAuthDomains` 仅永久凭据+非 cn-north-1 可用。

## 改动（分层，8 文件）

**权威根治（meta-skill）**
- `huaweicloud-cli-and-auth`：新增「Global Services & domain-id」小节——`STS GetCallerIdentity --cli-region=<region>` 自取 `account_id`；区域用 `<region>`（不写死），仅提示 STS 未部署 cn-north-1；临时凭据带 `--cli-security-token`；点明 `cli-domain-id` 是 KooCLI 限制非 API 限制。
- `huaweicloud-troubleshooting`：错误码表加「缺少必填参数 cli-domain-id」的修复引导。

**修错引用**
- `huawei-billing`：`ShowCustomerAccountBalances` 参数 `--project_id` → `--cli-domain-id=<domain_id>`；加 BSS 全局 domain-id 提醒。
- `huawei-voucher`：`:52` 的 `KeystoneListAuthDomains` → `STS GetCallerIdentity`；补「生产环境后端自解析」。
- `huawei-iac`(+references)：domain_id 首选来源改为 `STS GetCallerIdentity`，`tenant_id`/控制台降为兜底。
- `huawei-iam`：Critical Warnings 加「IAM 是 KooCLI 全局服务」指针。
- `huawei-functiongraph`：`CreateAgency`/`AssociateAgencyWithDomainPermission` 加同款指针。

## 验证

- `npm run lint:md` 通过（0 issues）
- `npm run validate` 通过（29 skills + KooCLI 7.2.12 配对）
- `node --test test/structure.test.mjs` 36/36 通过