### PR TITLE
ci: trigger CI on push to dev (#501)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,8 @@ name: CI
 on:
   pull_request:
     branches: [main, dev, next]
+  push:
+    branches: [dev]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
## 目的

修 #501 的 A：`ci.yml` 之前仅有 `pull_request` 触发，`dev` 分支的推送/合并提交不会跑 CI。

## 改动

`.github/workflows/ci.yml` `on:` 增加 `push: branches: [dev]`。

## 说明

纯 workflow 触发条件变更，无功能影响。