### PR TITLE
fix(codex): detect install status via plugin list JSON, not path substring

### DIFF
--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -702,9 +702,22 @@ function uninstallCodex() {
 }
 
 function codexStatus() {
-  const r = spawnSync('codex plugin list', [], { shell: true, windowsHide: true, stdio: 'pipe' });
+  // Parse the structured output instead of substring-matching the table: the
+  // plugin's SOURCE path (…/plugins/huaweicloud-devkit) also contains the name,
+  // so a naive includes() reports "installed" even when the status column says
+  // "not installed".
+  const r = spawnSync('codex plugin list --json', [], { shell: true, windowsHide: true, stdio: 'pipe' });
   const out = r.stdout ? r.stdout.toString() : '';
-  return out.includes(getCodexPluginName());
+  const name = getCodexPluginName();
+  try {
+    const data = JSON.parse(out);
+    const installed = Array.isArray(data?.installed) ? data.installed : [];
+    return installed.some(
+      (p) => p && (p.name === name || (typeof p.pluginId === 'string' && p.pluginId.startsWith(`${name}@`))),
+    );
+  } catch {
+    return false;
+  }
 }
 
 async function installOpenCode() {

--- a/plugins/huaweicloud-core/src/setup-cli.mjs
+++ b/plugins/huaweicloud-core/src/setup-cli.mjs
@@ -704,7 +704,7 @@ function uninstallCodex() {
 function codexStatus() {
   const r = spawnSync('codex plugin list', [], { shell: true, windowsHide: true, stdio: 'pipe' });
   const out = r.stdout ? r.stdout.toString() : '';
-  return out.includes(getCodexPluginName()) || out.includes('huaweicloud-core');
+  return out.includes(getCodexPluginName());
 }
 
 async function installOpenCode() {

--- a/test/agent-install.test.mjs
+++ b/test/agent-install.test.mjs
@@ -69,7 +69,11 @@ if (args[0] === '--version') {
   process.exit(0);
 }
 if (args[0] === 'plugin' && args[1] === 'list') {
-  console.log(process.env.FAKE_CODEX_LIST_OUTPUT || '');
+  if (args.includes('--json')) {
+    console.log(process.env.FAKE_CODEX_LIST_JSON || '{"installed":[]}');
+  } else {
+    console.log(process.env.FAKE_CODEX_LIST_OUTPUT || '');
+  }
   process.exit(0);
 }
 if (process.env.FAKE_CODEX_FAIL_PLUGIN_ADD === '1' && args[0] === 'plugin' && args[1] === 'add') {
@@ -92,6 +96,7 @@ process.exit(0);
     FAKE_CODEX_LOG: logPath,
     ...(options.failPluginAdd ? { FAKE_CODEX_FAIL_PLUGIN_ADD: '1' } : {}),
     ...(options.listOutput ? { FAKE_CODEX_LIST_OUTPUT: options.listOutput } : {}),
+    ...(options.listJson ? { FAKE_CODEX_LIST_JSON: options.listJson } : {}),
     logPath,
   };
 }
@@ -505,15 +510,40 @@ test('codex install fails fast when plugin add fails', () => {
   }
 });
 
-test('codex status recognizes current and legacy plugin names', () => {
-  for (const listOutput of ['huaweicloud-devkit@huaweicloud-devkit', 'huaweicloud-core@huaweicloud-devkit']) {
+test('codex status parses plugin list JSON (name match, not path substring)', () => {
+  // Installed plugin by name → Installed
+  {
     const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
     const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
     try {
-      const env = fakeCodexEnv(cwd, { listOutput });
+      const env = fakeCodexEnv(cwd, {
+        listJson: JSON.stringify({
+          installed: [{ name: 'huaweicloud-devkit', pluginId: 'huaweicloud-devkit@personal' }],
+        }),
+      });
       const res = run('codex', home, cwd, 'status', env);
       assert.equal(res.status, 0, res.stderr);
       assert.match(res.stdout, /Plugin:.*Installed/);
+    } finally {
+      rmSync(home, { recursive: true, force: true });
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  }
+  // Legacy name huaweicloud-core in a PATH is no longer treated as installed (#501).
+  {
+    const home = mkdtempSync(join(tmpdir(), 'ai-home-'));
+    const cwd = mkdtempSync(join(tmpdir(), 'ai-proj-'));
+    try {
+      const env = fakeCodexEnv(cwd, {
+        listJson: JSON.stringify({
+          installed: [
+            { name: 'documents', pluginId: 'documents@x', source: { path: 'C:/pkg/plugins/huaweicloud-core' } },
+          ],
+        }),
+      });
+      const res = run('codex', home, cwd, 'status', env);
+      assert.equal(res.status, 0, res.stderr);
+      assert.match(res.stdout, /Plugin:.*Not installed/);
     } finally {
       rmSync(home, { recursive: true, force: true });
       rmSync(cwd, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Fixes the Codex plugin install-status false positive.

### Root cause
`codexStatus()` substring-matched the whole `codex plugin list` output. Because the plugin's **SOURCE path** (`…/plugins/huaweicloud-devkit`, and previously `…/plugins/huaweicloud-core`) contains the plugin name, the check returned `true` even when the plugin's STATUS column said `not installed`. The legacy `|| out.includes('huaweicloud-core')` fallback had the same problem and was also dead on current output.

### Change
- `codexStatus()` now runs `codex plugin list --json` and parses the structured `installed[]` array, matching on the `name` field or the `pluginId` prefix (`<name>@…`) — never touching the path column. Malformed/empty output (e.g. Codex CLI absent) returns `false`.
- Removed the `huaweicloud-core` fallback (dead + false-positive source).
- Updated `agent-install.test.mjs`: the fake codex shim now honors `--json`, and the assertion now verifies name-based detection (installed → `Installed`; a foreign plugin whose path merely contains `huaweicloud-core` → `Not installed`).

### Verification (real Codex CLI 0.153.4)
- Before: plugin `not installed` but `status` reported `Installed`.
- End-to-end: `install --target codex` → `status` → **`Installed`** (JSON `installed=true enabled=true`); `uninstall --target codex` → `status` → **`Not installed`**.
- Unit/parser matrix: real not-installed → false, simulated installed → true, path-only match → false, empty/`codex`-absent output → false.