### PR TITLE
fix(auth): validate region before persist and keep import file for replay (#502)

### DIFF
--- a/plugins/huaweicloud-core/src/auth/service.mjs
+++ b/plugins/huaweicloud-core/src/auth/service.mjs
@@ -57,10 +57,13 @@ export function syncAuth(target = 'all') {
   try {
     obs = writeObsConfig(credentials);
   } catch (error) {
+    const missingRegion = !String(credentials?.region || '').trim();
     return {
       ok: false,
       error: error.message,
-      nextStep: 'Run "npx huaweicloud-devkit auth init" to refresh credentials and region.',
+      nextStep: missingRegion
+        ? 'Credential region is missing — run huaweicloud_auth_switch action=persist with --region, or add "region" to creds-import.json and re-import.'
+        : 'Run "npx huaweicloud-devkit auth init" to refresh credentials and region.',
     };
   }
 

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -1194,6 +1194,7 @@ export async function callTool(name, rawArgs = {}) {
           newRegion: region,
           oldFingerprint: fingerprint(prev.ak, prev.sk),
           newFingerprint: fingerprint(ak, sk),
+          fromImport: importedFromFile,
         });
         return {
           status: 'needs_confirmation',
@@ -1206,7 +1207,10 @@ export async function callTool(name, rawArgs = {}) {
       }
 
       const persisted = persistCredentials(ak, sk, securityToken, region);
-      if (importedFromFile && persisted.status === 'ok') clearImportFile();
+      // Clear the import file for non-replayable outcomes (success, or an
+      // unfixable rejection such as STS R3). Keep it only for a retryable
+      // 'partial' (S1 written but a mirror failed).
+      if (importedFromFile && persisted.status !== 'partial') clearImportFile();
       refreshUserHashAfterAuthChange();
       return persisted;
     }
@@ -1218,6 +1222,7 @@ export async function callTool(name, rawArgs = {}) {
         return { status: 'ok', outcome: 'aborted', message: '保持 S1 现有账号，未覆盖。' };
       }
       const confirmed = persistCredentials(pending.newAk, pending.newSk, pending.newSecurityToken, pending.newRegion);
+      if (pending.fromImport && confirmed.status !== 'partial') clearImportFile();
       refreshUserHashAfterAuthChange();
       return confirmed;
     }

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -961,9 +961,23 @@ function readImportFile() {
       region: String(data.region || ''),
     };
   } catch {
+    // Malformed/undecodable import file is un-replayable — wipe it. A VALID
+    // file is kept so a rejected persist can be replayed (see #502).
+    try {
+      rmSync(path, { force: true });
+    } catch {
+      // ignore
+    }
     return null;
-  } finally {
+  }
+}
+
+function clearImportFile() {
+  const path = join(dirname(globalCredentialsPath()), 'creds-import.json');
+  try {
     rmSync(path, { force: true });
+  } catch {
+    // best-effort: an absent or locked file is not an error
   }
 }
 
@@ -996,7 +1010,7 @@ function persistCredentials(ak, sk, securityToken, region) {
     writeLastSync({ kooCliProfile: profile, s1Fingerprint: fingerprint(ak, sk) });
   }
   return {
-    status: 'ok',
+    status: obs.ok && hcloud.ok ? 'ok' : 'partial',
     scope: 'persist',
     backedUp: Boolean(before),
     obs: obs.ok ? { configured: true } : { configured: false, error: obs.error },
@@ -1124,10 +1138,14 @@ export async function callTool(name, rawArgs = {}) {
       let securityToken = args.securityToken || '';
       let region = args.region || '';
       const sourceChannel = args.mode || 'memory';
+      let importedFromFile = false;
 
       if (sourceChannel === 'import' && (!ak || !sk)) {
         const imported = readImportFile();
-        if (imported) ({ ak, sk, securityToken, region } = imported);
+        if (imported) {
+          ({ ak, sk, securityToken, region } = imported);
+          importedFromFile = true;
+        }
       }
       if (sourceChannel === 'mcp-config' && (!ak || !sk)) {
         const cc = readCodeArtsCredentials();
@@ -1143,9 +1161,19 @@ export async function callTool(name, rawArgs = {}) {
         throw new Error('ak and sk are required (or provide creds-import.json for mode=import).');
       }
 
+      if (action === 'persist' && !String(region || '').trim()) {
+        return {
+          status: 'error',
+          scope: 'invalid_region',
+          error:
+            'region is required to persist credentials. Pass --region, or include "region" in creds-import.json (mode=import).',
+        };
+      }
+
       if (action === 'temporary') {
         setRuntimeCredentials(ak, sk, securityToken || undefined, region);
         refreshUserHashAfterAuthChange();
+        if (importedFromFile) clearImportFile();
         return {
           status: 'ok',
           scope: 'temporary',
@@ -1178,6 +1206,7 @@ export async function callTool(name, rawArgs = {}) {
       }
 
       const persisted = persistCredentials(ak, sk, securityToken, region);
+      if (importedFromFile && persisted.status === 'ok') clearImportFile();
       refreshUserHashAfterAuthChange();
       return persisted;
     }

--- a/test/cred-reconcile-e2e.test.mjs
+++ b/test/cred-reconcile-e2e.test.mjs
@@ -289,6 +289,30 @@ test('10 auth_confirm decision=s1 aborts and leaves S1 unchanged', async () => {
   });
 });
 
+test('10b auth_confirm(newImported) from import clears the import file on success', async () => {
+  await withTempHome(async (dir) => {
+    setFakeHcloud(join(dir, 'hcloud.log'));
+    const newAk = 'E2E10B_B_AK';
+    const newSk = 'E2E10B_B_SK';
+    const region = 'cn-north-4';
+    writeFakeKooCli('deploy', [{ name: 'deploy', accessKeyId: newAk, secretAccessKey: newSk, region }]);
+    writeGlobalCredentials({ ak: 'E2E10B_A_AK', sk: 'E2E10B_A_SK', region });
+
+    const importFile = join(dir, '.config', 'huaweicloud', 'creds-import.json');
+    mkdirSync(dirname(importFile), { recursive: true });
+    writeFileSync(importFile, JSON.stringify({ ak: newAk, sk: newSk, region }), 'utf8');
+
+    const switched = await callTool('huaweicloud_auth_switch', { mode: 'import', action: 'persist' });
+    assert.equal(switched.status, 'needs_confirmation');
+    assert.equal(existsSync(importFile), true, 'import file kept while awaiting confirmation');
+
+    const out = await callTool('huaweicloud_auth_confirm', { token: switched.confirmToken, decision: 'newImported' });
+    assert.equal(out.status, 'ok');
+    assert.equal(readGlobalCredentials().ak, newAk);
+    assert.equal(existsSync(importFile), false, 'import file cleared after successful confirm');
+  });
+});
+
 test('11 auth_switch clear empties runtime and lets syncAuth run again', async () => {
   await withTempHome(async (dir) => {
     const log = join(dir, 'hcloud.log');

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict';
-import { mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
+import { existsSync, mkdtempSync, mkdirSync, writeFileSync, symlinkSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import test from 'node:test';
@@ -294,5 +294,55 @@ test('auth_switch clear resets runtime', async () => {
     if (prevHome === undefined) delete process.env.HUAWEICLOUD_HOME;
     else process.env.HUAWEICLOUD_HOME = prevHome;
     rmSync(isolatedHome, { recursive: true, force: true });
+  }
+});
+
+test('auth_switch persist(mode=import) rejects missing region and keeps import file (#502)', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'auth-import-region-'));
+  const prevHome = process.env.HUAWEICLOUD_HOME;
+  process.env.HUAWEICLOUD_HOME = home;
+  try {
+    const cfgDir = join(home, '.config', 'huaweicloud');
+    mkdirSync(cfgDir, { recursive: true });
+    const importFile = join(cfgDir, 'creds-import.json');
+    writeFileSync(importFile, JSON.stringify({ ak: 'IMPORT_AK', sk: 'IMPORT_SK' }), 'utf8');
+
+    const out = await callTool('huaweicloud_auth_switch', { mode: 'import', action: 'persist' });
+
+    assert.equal(out.status, 'error');
+    assert.equal(out.scope, 'invalid_region');
+    assert.match(out.error, /region/);
+    // S1 must not be written on a rejected persist.
+    assert.equal(existsSync(join(cfgDir, 'credentials.json')), false);
+    // Import file must survive for replay.
+    assert.equal(existsSync(importFile), true);
+  } finally {
+    if (prevHome === undefined) delete process.env.HUAWEICLOUD_HOME;
+    else process.env.HUAWEICLOUD_HOME = prevHome;
+    clearRuntimeCredentials();
+    rmSync(home, { recursive: true, force: true });
+  }
+});
+
+test('auth_switch temporary(mode=import) clears import file on success', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'auth-import-temp-'));
+  const prevHome = process.env.HUAWEICLOUD_HOME;
+  process.env.HUAWEICLOUD_HOME = home;
+  try {
+    const cfgDir = join(home, '.config', 'huaweicloud');
+    mkdirSync(cfgDir, { recursive: true });
+    const importFile = join(cfgDir, 'creds-import.json');
+    writeFileSync(importFile, JSON.stringify({ ak: 'TMP_AK', sk: 'TMP_SK' }), 'utf8');
+
+    const out = await callTool('huaweicloud_auth_switch', { mode: 'import', action: 'temporary' });
+
+    assert.equal(out.scope, 'temporary');
+    assert.equal(existsSync(importFile), false, 'import file should be cleared after successful temporary set');
+    assert.equal(resolveCredentialsWithRuntime({}).ak, 'TMP_AK');
+  } finally {
+    if (prevHome === undefined) delete process.env.HUAWEICLOUD_HOME;
+    else process.env.HUAWEICLOUD_HOME = prevHome;
+    clearRuntimeCredentials();
+    rmSync(home, { recursive: true, force: true });
   }
 });

--- a/test/tools.test.mjs
+++ b/test/tools.test.mjs
@@ -346,3 +346,34 @@ test('auth_switch temporary(mode=import) clears import file on success', async (
     rmSync(home, { recursive: true, force: true });
   }
 });
+
+test('auth_switch persist(mode=import) with STS token is rejected and clears import file', async () => {
+  const home = mkdtempSync(join(tmpdir(), 'auth-import-sts-'));
+  const prevHome = process.env.HUAWEICLOUD_HOME;
+  process.env.HUAWEICLOUD_HOME = home;
+  try {
+    const cfgDir = join(home, '.config', 'huaweicloud');
+    mkdirSync(cfgDir, { recursive: true });
+    const importFile = join(cfgDir, 'creds-import.json');
+    writeFileSync(
+      importFile,
+      JSON.stringify({ ak: 'STS_AK', sk: 'STS_SK', securityToken: 'STS_TOK', region: 'cn-north-4' }),
+      'utf8',
+    );
+
+    const out = await callTool('huaweicloud_auth_switch', { mode: 'import', action: 'persist' });
+
+    assert.equal(out.status, 'error');
+    assert.equal(out.scope, 'rejected');
+    assert.equal(
+      existsSync(importFile),
+      false,
+      'unfixable STS import must be cleared — no replay value, and no plaintext token residual',
+    );
+  } finally {
+    if (prevHome === undefined) delete process.env.HUAWEICLOUD_HOME;
+    else process.env.HUAWEICLOUD_HOME = prevHome;
+    clearRuntimeCredentials();
+    rmSync(home, { recursive: true, force: true });
+  }
+});


### PR DESCRIPTION
## 目的

修 #502：`auth_switch mode=import` 缺省 region 导致 S3/OBS 同步失败，且失败后无重放路径。

## 根因

- `readImportFile()` 缺 region 时静默 `''`，且在 `finally` 无条件删除 `creds-import.json`（persist 未完成即删，无重放）。
- `auth_switch persist` 只校验 ak/sk、不校验 region，空 region 被放行。
- `persistCredentials()` 写 S1（空 region）后 OBS 写失败被 catch，顶层仍 `status:'ok'`，半完成被掩盖。
- `syncAuth()` 失败 `nextStep` 仅泛化提示 auth init，不指到 region。

## 改动

1. **persist 前校验 region**：`action=persist` 且 region 为空 → 直接拒绝，返回 `{status:'error', scope:'invalid_region'}`，不写 S1、不同步，字段级报错。
2. **导入文件延迟删除**：`readImportFile` 不再读后即删，**合法文件保留**（供重放）、仅在 persist 返回 `ok` 或 temporary 成功后 `clearImportFile()`；**格式非法**的文件仍清掉（无重放价值）。
3. **如实上报部分失败**：`persistCredentials` 在 OBS 或 hcloud 失败时返回 `status:'partial'`（不再 `'ok'`）。
4. **诊断精准**：`syncAuth` 缺 region 时 `nextStep` 指向 region 缺失的具体处置。

## 测试

- `auth_switch persist(mode=import)` 缺 region → 拒绝、S1 未写、导入文件保留。
- `auth_switch temporary(mode=import)` 缺 region → 成功并清掉导入文件。
- 兼容既有用例（malformed 文件仍被清）：全量 `node --test` **417/417**、`lint:js`/`validate` 通过。