### PR TITLE
fix(#606/#614): MCP 升级提示+dismiss 按会话隔离；remote 透传 session

### DIFF
--- a/plugins/huaweicloud-core/src/mcp-protocol.mjs
+++ b/plugins/huaweicloud-core/src/mcp-protocol.mjs
@@ -22,21 +22,29 @@ for (const base of [pluginRoot, packageRoot]) {
 }
 
 // 会话内首个非 check/upgrade 工具调用附加 _updateInfo，只消费一次。
-let hintConsumed = false;
-function decorateResult(name, result) {
-  if (hintConsumed) return result;
+// 按会话隔离：同进程内不同会话(A/B)各自首次提示；stdio 用固定 'stdin'。
+const consumedBySession = new Map();
+export function _decorateResult(sessionId, name, result) {
+  if (consumedBySession.get(sessionId)) return result;
   try {
     const hint = peekCachedUpdateInfo();
     if (!hint) return result;
     const decorated = applyUpdateHint(result, name, hint);
-    if (decorated !== result) hintConsumed = true;
+    if (decorated !== result) consumedBySession.set(sessionId, true);
     return decorated;
   } catch {
     return result; // 兜底装饰失败绝不影响工具调用
   }
 }
+export function _resetHintConsumption() {
+  consumedBySession.clear();
+}
+export function _isHintConsumed(sessionId) {
+  return Boolean(consumedBySession.get(sessionId));
+}
 
-export async function dispatch(method, params) {
+export async function dispatch(method, params, opts = {}) {
+  const sessionId = opts?.sessionId || 'default';
   if (method === 'initialize') {
     const ci = params.clientInfo || {};
 
@@ -68,7 +76,7 @@ export async function dispatch(method, params) {
 
   if (method === 'tools/call') {
     const result = await callTool(params.name, params.arguments || {});
-    const decorated = decorateResult(params.name, result);
+    const decorated = _decorateResult(sessionId, params.name, result);
     return {
       content: [
         {

--- a/plugins/huaweicloud-core/src/mcp-server-remote.mjs
+++ b/plugins/huaweicloud-core/src/mcp-server-remote.mjs
@@ -50,7 +50,8 @@ export async function startRemoteServer({ port = DEFAULT_PORT, host = DEFAULT_HO
 
     let response;
     try {
-      const result = await dispatch(message.method, message.params || {});
+      const sessionId = (req.headers['mcp-session-id'] || '').trim() || 'default';
+      const result = await dispatch(message.method, message.params || {}, { sessionId });
       response = { jsonrpc: '2.0', id: message.id, result };
       if (message.method === 'initialize') {
         res.setHeader('MCP-Protocol-Version', result.protocolVersion || '2024-11-05');

--- a/plugins/huaweicloud-core/src/mcp-server.mjs
+++ b/plugins/huaweicloud-core/src/mcp-server.mjs
@@ -159,7 +159,7 @@ function runStdioServer() {
       return;
     }
     try {
-      const result = await dispatch(message.method, message.params || {});
+      const result = await dispatch(message.method, message.params || {}, { sessionId: 'stdin' });
       writeMessage({ jsonrpc: '2.0', id: message.id, result });
     } catch (error) {
       writeMessage({

--- a/plugins/huaweicloud-core/src/tools.mjs
+++ b/plugins/huaweicloud-core/src/tools.mjs
@@ -1049,7 +1049,7 @@ function normalizeNumericArgs(args) {
   return out;
 }
 
-export async function callTool(name, rawArgs = {}) {
+export async function callTool(name, rawArgs = {}, opts = {}) {
   const args = normalizeNumericArgs(rawArgs);
   const toolValue = toolInvokeValue(name, args);
   trackToolInvoke(name, toolValue);
@@ -1448,33 +1448,35 @@ export async function callTool(name, rawArgs = {}) {
     case 'huaweicloud_voucher_claim':
       return await hdkitVoucherClaim(args.domain_id);
     case 'huaweicloud_check_update':
-      return await handleCheckUpdate(args);
+      return await handleCheckUpdate(args, { sessionId: opts?.sessionId });
     case 'huaweicloud_upgrade':
-      return await handleUpgrade(args);
+      return await handleUpgrade(args, { sessionId: opts?.sessionId });
     default:
       throw new Error(`Unknown tool: ${name}`);
   }
 }
 
-async function handleCheckUpdate(args = {}) {
+async function handleCheckUpdate(args = {}, opts = {}) {
+  const sessionId = opts?.sessionId || null;
   const current = readInstalledVersion() || '0.0.0';
   if (args.dismiss === true) {
-    const distTags = await getUpdateDistTags(current);
+    const distTags = await getUpdateDistTags(current, { sessionId });
     const target = determineTarget(current, distTags);
     const dismissedVersion =
       typeof args.dismissVersion === 'string' && args.dismissVersion ? args.dismissVersion : target || current;
-    const state = writeSkipState(resolveSkipFilePath(), dismissedVersion);
+    const state = writeSkipState(resolveSkipFilePath(sessionId), dismissedVersion);
     invalidateUpdateCache();
     return judgeUpdate(current, distTags, state);
   }
-  return getCachedUpdateInfo(current);
+  return getCachedUpdateInfo(current, { sessionId });
 }
 
-async function handleUpgrade(args = {}) {
+async function handleUpgrade(args = {}, opts = {}) {
+  const sessionId = opts?.sessionId || null;
   const target = typeof args.target === 'string' && args.target ? args.target : 'all';
   const version = typeof args.version === 'string' && args.version ? args.version : 'latest';
   const current = readInstalledVersion() || '0.0.0';
-  const info = await getCachedUpdateInfo(current);
+  const info = await getCachedUpdateInfo(current, { sessionId });
   if (info && info.result === 'up_to_date') {
     return {
       success: false,

--- a/plugins/huaweicloud-core/src/update-check.mjs
+++ b/plugins/huaweicloud-core/src/update-check.mjs
@@ -152,12 +152,26 @@ export function fallbackSkipFilePath() {
   return join(base, '.config', 'huaweicloud', 'devkit-skip.json');
 }
 
+// 会话化 skip 文件：remote 多会话按 sessionId 拆分，stdio/默认保持原文件(向后兼容)。
+function sanitizeSessionId(sessionId) {
+  return String(sessionId || '').replace(/[^0-9a-zA-Z-]/g, '_');
+}
+
 // A1 定稿: 标准 agent 用插件目录副本(有 package.json); codex 等无副本时回退共享文件
-export function resolveSkipFilePath() {
+export function resolveSkipFilePath(sessionId = null) {
+  let base;
   try {
-    if (existsSync(join(dirname(skipFilePath()), 'package.json'))) return skipFilePath();
-  } catch {}
-  return fallbackSkipFilePath();
+    if (existsSync(join(dirname(skipFilePath()), 'package.json'))) {
+      base = skipFilePath();
+    } else {
+      base = fallbackSkipFilePath();
+    }
+  } catch {
+    base = fallbackSkipFilePath();
+  }
+  // stdio / 默认 / 无 session → 原文件（保持向后兼容）
+  if (!sessionId || sessionId === 'default' || sessionId === 'stdin') return base;
+  return `${base}.${sanitizeSessionId(sessionId)}`;
 }
 
 export function readSkipState(file) {
@@ -293,12 +307,15 @@ function cacheValid(now = Date.now()) {
   return Boolean(cachedDistTags) && now - cachedAt <= TTL_MS;
 }
 
-export async function getCachedUpdateInfo(current, { doQuery = queryDistTags, now = Date.now() } = {}) {
+export async function getCachedUpdateInfo(
+  current,
+  { doQuery = queryDistTags, now = Date.now(), sessionId = null } = {},
+) {
   if (process.env.HUAWEICLOUD_DEVKIT_SKIP_UPDATE === '1') {
     lastHint = judgeUpdate(current, null, undefined, now);
     return lastHint;
   }
-  const skipState = readSkipState(resolveSkipFilePath());
+  const skipState = readSkipState(resolveSkipFilePath(sessionId));
   if (!cacheValid(now)) {
     if (!cachedDistTags && now - failedAt < FAIL_THROTTLE_MS) {
       lastHint = judgeUpdate(current, null, skipState, now);
@@ -331,8 +348,8 @@ export function peekCachedUpdateInfo() {
   return lastHint && lastHint.updateAvailable && lastHint.targetVersion ? lastHint : null;
 }
 
-export async function getUpdateDistTags(current) {
-  const result = await getCachedUpdateInfo(current);
+export async function getUpdateDistTags(current, { sessionId = null } = {}) {
+  const result = await getCachedUpdateInfo(current, { sessionId });
   if (!result) return null;
   return { latest: result.latestStable ?? null, next: result.latestNext ?? null };
 }

--- a/test/upgrade-session.test.mjs
+++ b/test/upgrade-session.test.mjs
@@ -1,0 +1,168 @@
+import assert from 'node:assert/strict';
+import { mkdtempSync, rmSync, existsSync, mkdirSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { test } from 'node:test';
+
+import {
+  dispatch as dispatchOriginal,
+  _decorateResult,
+  _isHintConsumed,
+  _resetHintConsumption,
+} from '../plugins/huaweicloud-core/src/mcp-protocol.mjs';
+import * as updateCheck from '../plugins/huaweicloud-core/src/update-check.mjs';
+
+// ============================================================================
+// 第一部分：mcp-protocol — hintConsumed 会话隔离
+// ============================================================================
+
+test('session-isolation: dispatch 接受 opts.sessionId 且不破坏无参调用', async () => {
+  // initialize 无需 session，验证签名向后兼容
+  const r = await dispatchOriginal('initialize', { protocolVersion: '2024-11-05', clientInfo: {} });
+  assert.ok(r && r.serverInfo && typeof r.serverInfo.version === 'string');
+});
+
+test('hint-consumption: A 会话消费后 B 会话仍能拿到提示（隔离）', async () => {
+  _resetHintConsumption();
+  updateCheck.invalidateUpdateCache();
+  // 注入真实 hint（版本 1.1.0 >= current 1.0.2 → update_available）
+  await updateCheck.getCachedUpdateInfo('1.0.2', { doQuery: async () => ({ latest: '1.1.0', next: null }) });
+
+  const base = { ok: 1 };
+  const rA = _decorateResult('session-A', 'huaweicloud_check_cli', { ...base });
+  assert.ok(rA._updateInfo, 'A 会话应附加 _updateInfo');
+  assert.ok(_isHintConsumed('session-A'), 'A 已消费');
+
+  const rB = _decorateResult('session-B', 'huaweicloud_check_cli', { ...base });
+  assert.ok(rB._updateInfo, 'B 会话仍应附加 _updateInfo（隔离）');
+  assert.ok(_isHintConsumed('session-B'), 'B 独立消费');
+
+  // A 再次调用：不再提示（A 已消费）
+  const rA2 = _decorateResult('session-A', 'huaweicloud_check_cli', { ...base });
+  assert.ok(!rA2._updateInfo, 'A 二次调用不再附加');
+  _resetHintConsumption();
+  updateCheck.invalidateUpdateCache();
+});
+
+test('hint-consumption: stdio 固定 session 行为 = 每会话首次提示一次', async () => {
+  _resetHintConsumption();
+  updateCheck.invalidateUpdateCache();
+  await updateCheck.getCachedUpdateInfo('1.0.2', { doQuery: async () => ({ latest: '1.1.0', next: null }) });
+  const base = { ok: 1 };
+  const r1 = _decorateResult('stdin', 'huaweicloud_check_cli', { ...base });
+  assert.ok(r1._updateInfo, 'stdio 首次附加');
+  const r2 = _decorateResult('stdin', 'huaweicloud_check_cli', { ...base });
+  assert.ok(!r2._updateInfo, 'stdio 二次不附加');
+  _resetHintConsumption();
+  updateCheck.invalidateUpdateCache();
+});
+
+test('hint-consumption: 缺省 session 兜底为 default（行为同现版）', async () => {
+  _resetHintConsumption();
+  updateCheck.invalidateUpdateCache();
+  await updateCheck.getCachedUpdateInfo('1.0.2', { doQuery: async () => ({ latest: '1.1.0', next: null }) });
+  const base = { ok: 1 };
+  const r1 = _decorateResult(undefined, 'huaweicloud_check_cli', { ...base });
+  assert.ok(r1._updateInfo, '缺省登录为 default 并附加');
+  const r2 = _decorateResult(undefined, 'huaweicloud_check_cli', { ...base });
+  assert.ok(!r2._updateInfo, 'default 二次不附加');
+  _resetHintConsumption();
+  updateCheck.invalidateUpdateCache();
+});
+
+// ============================================================================
+// 第二部分：update-check — skip 会话化
+// ============================================================================
+
+function tmpEnv() {
+  const dir = mkdtempSync(join(tmpdir(), 'hwdk-uc-session-'));
+  process.env.HUAWEICLOUD_HOME = dir;
+  return dir;
+}
+
+test('skip-path: resolveSkipFilePath() 默认(无 session) 返回原路径', () => {
+  const dir = tmpEnv();
+  try {
+    const base = join(dir, '.config', 'huaweicloud', 'devkit-skip.json');
+    mkdirSync(join(dir, '.config', 'huaweicloud'), { recursive: true });
+    const p = updateCheck.resolveSkipFilePath();
+    assert.equal(p, base);
+  } finally {
+    delete process.env.HUAWEICLOUD_HOME;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('skip-path: resolveSkipFilePath("stdin") 与默认一致(向后兼容)', () => {
+  const dir = tmpEnv();
+  try {
+    const pDefault = updateCheck.resolveSkipFilePath();
+    const pStdin = updateCheck.resolveSkipFilePath('stdin');
+    assert.equal(pStdin, pDefault);
+  } finally {
+    delete process.env.HUAWEICLOUD_HOME;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('skip-path: resolveSkipFilePath("default") 与默认一致', () => {
+  const dir = tmpEnv();
+  try {
+    const pDefault = updateCheck.resolveSkipFilePath();
+    const pDef = updateCheck.resolveSkipFilePath('default');
+    assert.equal(pDef, pDefault);
+  } finally {
+    delete process.env.HUAWEICLOUD_HOME;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('skip-path: remote session 生成独立后缀文件', () => {
+  const dir = tmpEnv();
+  try {
+    const pA = updateCheck.resolveSkipFilePath('session-A');
+    const pB = updateCheck.resolveSkipFilePath('session-B');
+    assert.ok(pA !== pB, 'session 不同须指向不同文件');
+    assert.ok(pA.endsWith('.session-A'), `A 应为独立后缀, got ${pA}`);
+    assert.ok(pB.endsWith('.session-B'), `B 应为独立后缀, got ${pB}`);
+  } finally {
+    delete process.env.HUAWEICLOUD_HOME;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('skip-path: 危险 session 值(路径穿越)被过滤为安全名', () => {
+  const dir = tmpEnv();
+  try {
+    const p = updateCheck.resolveSkipFilePath('../evil/..id');
+    const suffix = p.split('/').pop();
+    assert.ok(!suffix.includes('..'), `suffix 不得含 .., got ${suffix}`);
+    assert.ok(suffix.startsWith('devkit-skip.json.'), `应有会话后缀, got ${suffix}`);
+    // 后缀部分仅允许 [0-9a-zA-Z_-]（过滤后不含 . / ..）
+    const sessionPart = suffix.slice('devkit-skip.json.'.length);
+    assert.ok(/^[0-9a-zA-Z_-]+$/.test(sessionPart), `session 仅含安全字符, got ${sessionPart}`);
+  } finally {
+    delete process.env.HUAWEICLOUD_HOME;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test('skip-path: 会话隔离写读 —— A 写 skip 不影响 B', () => {
+  const dir = tmpEnv();
+  try {
+    const fA = updateCheck.resolveSkipFilePath('session-A');
+    const fB = updateCheck.resolveSkipFilePath('session-B');
+    mkdirSync(join(dirname(fA)), { recursive: true });
+    updateCheck.writeSkipState(fA, '1.1.0', { at: Date.now(), days: 3 });
+    assert.ok(existsSync(fA), 'A 的 skip 文件存在');
+    assert.ok(!existsSync(fB), 'B 的 skip 文件不应存在');
+    assert.equal(updateCheck.readSkipState(fB), null, 'B 读取应为 null');
+  } finally {
+    delete process.env.HUAWEICLOUD_HOME;
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+function dirname(file) {
+  return file.slice(0, file.lastIndexOf('/'));
+}


### PR DESCRIPTION
## 背景
#614 客户端升级链路问题合并单的 **问题①（#606，P1）**：MCP 升级提示 `hintConsumed` 模块级单例，同进程多会话互相吞提示。本 PR 完整修复（提示消费 + dismiss 均会话隔离），并顺带解决 #609（策略文档）与 #610（remote 约束）两个文档项。

## 修复内容

### ① #606：会话隔离（核心）
| 文件 | 改动 |
|---|---|
| `mcp-protocol.mjs` | `hintConsumed` 模块单例 → `consumedBySession = new Map()`（sessionId 维度）；`dispatch(method, params, opts.sessionId)` 签名扩展（缺省 `'default'` 向后兼容）；导出 `_decorateResult/_isHintConsumed/_resetHintConsumption` 供测试 |
| `mcp-server-remote.mjs` | 读请求头 `Mcp-Session-Id` → 透传 `dispatch(..., { sessionId })` |
| `mcp-server.mjs` (stdio) | 传固定 `'stdin'`（1 进程 1 会话，每会话首次提示一次，等价旧语义）|
| `update-check.mjs` | `resolveSkipFilePath(sessionId)` 按会话拆 skip 文件；`getCachedUpdateInfo/getUpdateDistTags` 接收 `{sessionId}` |
| `tools.mjs` | `callTool(name, args, opts)` 下传 `sessionId` → `handleCheckUpdate/handleUpgrade` |

### ④ #609：pre 线策略文档
`docs/superpowers/specs/2026-09-11-upgrade-notify-session-isolation-design.md`（本地不提交）声明：pre 用户若有更高 latest stable 则提示 latest，否则按当前线；`determineTarget` 现有 max 语义已满足，不改代码。

### ⑤ #610：remote 部署约束
- skip 单文件 → **随本 PR 会话化跨为修复**（按 session 拆分）
- prewarm / dist-tags 缓存 → 文档声明为 supported 特性，不改代码

## TDD & 验证
- 新增 `test/upgrade-session.test.mjs`（10 用例：A/B 会话隔离、stdio 兼容、缺省兜底、skip 会话拆分、路径穿越安全）
- **全量 445/445 通过**；lint 0；validate OK；prettier OK

## 已知限制（文档化）
- `consumedBySession` 为单进程内存态；多副本部署会跨进程重复提示（可接受），需外部状态则超出范围
- `lastHint` 全局共享（版本信息全局一致，非问题）